### PR TITLE
feat: Support smdx or json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber = "0.3.16"
 tracing-log = "0.1.3"
 serde-xml-rs = "0.6.0"
 serde = { version = "1.0.185", features=["derive"]}
+serde_json = { version = "1.0.117" }
 clap = { version = "4.3.24", features = ["derive","env"] }
 anyhow = "1.0.75"
 lazy_static = "1.4.0"

--- a/models/generac/smdx_64205.xml
+++ b/models/generac/smdx_64205.xml
@@ -41,6 +41,8 @@
         <symbol id="IEEE_1547_2003_ReConnV_10">29</symbol>
         <symbol id="MWEC_2023">30</symbol>
         <symbol id="LADWP_2023">31</symbol>
+        <symbol id="BED_2022">32</symbol>
+        <symbol id="PREPA_LUMA_2024">33</symbol>
       </point>
       <point id="Def" offset="1" type="enum16" mandatory="true">
         <symbol id="NOT_DEFAULTED">0</symbol>
@@ -216,6 +218,16 @@
       </symbol>
       <symbol id="LADWP_2023">
         <label>LADWP 2023</label>
+        <description></description>
+        <notes></notes>
+      </symbol>
+      <symbol id="BED_2022">
+        <label>BED 2022</label>
+        <description></description>
+        <notes></notes>
+      </symbol>
+      <symbol id="PREPA_LUMA_2024">
+        <label>PREPA-LUMA 2024</label>
         <description></description>
         <notes></notes>
       </symbol>

--- a/models/generac/smdx_64206.xml
+++ b/models/generac/smdx_64206.xml
@@ -40,6 +40,8 @@
         <symbol id="IEEE_1547_2003_ReConnV_10">29</symbol>
         <symbol id="MWEC_2023">30</symbol>
         <symbol id="LADWP_2023">31</symbol>
+        <symbol id="BED_2022">32</symbol>
+        <symbol id="PREPA_LUMA_2024">33</symbol>
       </point>
       <point id="Def" offset="6" type="enum16" mandatory="true">
         <symbol id="NOT_DEFAULTED">0</symbol>
@@ -343,6 +345,16 @@
       </symbol>
       <symbol id="LADWP_2023">
         <label>LADWP 2023</label>
+        <description></description>
+        <notes></notes>
+      </symbol>
+      <symbol id="BED_2022">
+        <label>BED 2022</label>
+        <description></description>
+        <notes></notes>
+      </symbol>
+      <symbol id="PREPA_LUMA_2024">
+        <label>PREPA-LUMA 2024</label>
         <description></description>
         <notes></notes>
       </symbol>

--- a/models/generac/smdx_64259.xml
+++ b/models/generac/smdx_64259.xml
@@ -1,7 +1,7 @@
 <sunSpecModels v="1">
   <!-- 64259: Site Energy Metrics -->
-  <model id="64259" len="64" name="site_energy">
-    <block len="64">
+  <model id="64259" len="96" name="site_energy">
+    <block len="96">
       <point id="time" offset="0" type="uint32" mandatory="true" units="Unix seconds"/>
       <point id="sysmode" offset="2" type="enum16" mandatory="true">
         <symbol id="SAFETY_SHUTDOWN">0</symbol>
@@ -61,8 +61,15 @@
       <point id="bat_power"   offset="59" type="int16" units="W" mandatory="true"/>
       <point id="max_sink_power"   offset="60" type="int16" units="W" mandatory="true"/>
       <point id="max_source_power" offset="61" type="int16" units="W" mandatory="true"/>
-      <point id="Pad5"        offset="62"  type="pad" mandatory="true"/>
-      <point id="Pad6"        offset="63"  type="pad" mandatory="true"/>
+      <point id="previous_time" offset="62" type="uint32" mandatory="true" units="Unix seconds"/>
+      <point id="generation_delta"  offset="64"  type="uint64" mandatory="true" units="Ws"/>
+      <point id="consumption_delta" offset="68" type="int64" mandatory="true" units="Ws"/>
+      <point id="bat_out_delta"     offset="72" type="uint64" mandatory="true" units="Ws"/>
+      <point id="bat_in_delta"      offset="76" type="uint64" mandatory="true" units="Ws"/>
+      <point id="net_out_delta"     offset="80" type="uint64" mandatory="true" units="Ws"/>
+      <point id="net_in_delta"      offset="84" type="uint64" mandatory="true" units="Ws"/>
+      <point id="inv_out_delta"     offset="88" type="uint64" mandatory="true" units="Ws"/>
+      <point id="inv_in_delta"      offset="92" type="uint64" mandatory="true" units="Ws"/>
     </block>
   </model>
   <strings id="64259">
@@ -284,6 +291,46 @@
     <point id="max_source_power">
       <label>Max Source Power</label>
       <description>Estimated maximum amount of power the site is capable of sourcing at present</description>
+      <notes></notes>
+    </point>
+    <point id="generation_delta">
+      <label>Delta Generation Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="consumption_delta">
+      <label>Delta Consumption Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="bat_out_delta">
+      <label>Delta Battery Discharge Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="bat_in_delta">
+      <label>Delta Battery Charge Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="net_out_delta">
+      <label>Delta Net Exported Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="net_in_delta">
+      <label>Delta Net Imported Energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="inv_out_delta">
+      <label>Delta Inverter Exported energy</label>
+      <description></description>
+      <notes></notes>
+    </point>
+    <point id="inv_in_delta">
+      <label>Delta Inverter Imported Energy</label>
+      <description></description>
       <notes></notes>
     </point>
   </strings>

--- a/models/generac/smdx_64268.xml
+++ b/models/generac/smdx_64268.xml
@@ -1,71 +1,64 @@
 <sunSpecModels v="1">
-    <model id="64268" len="60" name="Power_Prioritization_Basic_Diagnostics">
-        <block len="60">
-            <point id="AvgGridVoltage" type="uint16" units="V" offset="0" />
-            <point id="GridFrequency" type="uint32" units="Hz" sf="Hz_SF" offset="1" /> <!-- Hz_SF = x1000 -->
-            <point id="RealPower" type="uint16" units="W" offset="3" />
-            <point id="ReactivePower" type="uint16" units="VAR" offset="4" />
-            <point id="VoltWattExportLimit" type="uint16" units="W" offset="5" />
-            <point id="FreqWattRealPowerTarget" type="uint16" units="W" offset="6" />
+    <model id="64268" len="53" name="Power_Prioritization_Basic_Diagnostics">
+        <block len="53">
+            <point id="AvgGridVoltage" type="int16" units="V" sf="V_SF" offset="0" /> <!-- V_SF = x10 -->
+            <point id="GridFrequency" type="int32" units="Hz" sf="Hz_SF" offset="1" /> <!-- Hz_SF = x1000 -->
+            <point id="RealPower" type="int16" units="W" offset="3" />
+            <point id="ReactivePower" type="int16" units="VAR" offset="4" />
+            <point id="VoltWattExportLimit" type="int16" units="W" offset="5" />
+            <point id="FreqWattRealPowerTarget" type="int16" units="W" offset="6" />
             <point id="FreqWattActiveStatus" type="enum16" offset="7">
                 <symbol id="INACTIVE">0</symbol>
                 <symbol id="ACTIVE">1</symbol>
             </point>
-            <point id="WattVarReactivePowerTarget" type="uint16" units="VAR" offset="8" />
-            <point id="VoltVarReactivePowerTarget" type="uint16" units="VAR" offset="9" />
-            <point id="VoltVarReferenceVoltage" type="uint16" units="V_Percent" sf="V_Percent_SF" offset="10" /> <!-- V_Percent_SF = x10 -->
-            <point id="ConstantPowerFactorReactivePowerTarget" type="uint16" units="VAR" offset="11" />
-            <point id="ConstantReactivePowerCommandReactivePowerTarget" type="uint16" units="VAR" offset="12" />
-            <point id="RealPowerLimit" type="uint16" units="W" offset="13" />
-            <point id="RealPowerSettingTarget" type="uint16" units="W" offset="14" />
-            <point id="GSLRealPowerCommand" type="uint16" units="W/unit" offset="15" />
-            <point id="GSLRealPowerLowLimit" type="uint16" units="W/unit" offset="16" />
-            <point id="GSLRealPowerHighLimit" type="uint16" units="W/unit" offset="17" />
+            <point id="WattVarReactivePowerTarget" type="int16" units="VAR" offset="8" />
+            <point id="VoltVarReactivePowerTarget" type="int16" units="VAR" offset="9" />
+            <point id="VoltVarReferenceVoltage" type="int16" units="V_Percent" sf="V_Percent_SF" offset="10" /> <!-- V_Percent_SF = x10 -->
+            <point id="ConstantPowerFactorReactivePowerTarget" type="int16" units="VAR" offset="11" />
+            <point id="ConstantReactivePowerCommandReactivePowerTarget" type="int16" units="VAR" offset="12" />
+            <point id="RealPowerLimit" type="int16" units="W" offset="13" />
+            <point id="RealPowerSettingTarget" type="int16" units="W" offset="14" />
+            <point id="GSLRealPowerCommand" type="int16" units="W_Percent" sf="W_Percent_SF" offset="15" /> <!-- W_Percent_SF = x10 -->
+            <point id="GSLRealPowerLowLimit" type="int16" units="W_Percent" sf="W_Percent_SF" offset="16" />
+            <point id="GSLRealPowerHighLimit" type="int16" units="W_Percent" sf="W_Percent_SF" offset="17" />
             <point id="GSLRealPowerCommandActiveStatus" type="enum16" offset="18">
                 <symbol id="INACTIVE">0</symbol>
                 <symbol id="ACTIVE">1</symbol>
             </point>
-            <point id="GSLReactivePowerCommand" type="uint16" units="VAR/unit" offset="19" />
-            <point id="MaxReactiveAmpsReference" type="uint16" units="A" offset="20" /> <!-- Raw sampled -->
-            <point id="ReactiveAmpsFromCapacitor" type="uint16" units="A" sf="A_SF" offset="21" /> <!-- A_SF = x100 -->
-            <point id="ReactiveAmpsTarget" type="uint16" units="A" sf="A_SF" offset="22" />
-            <point id="ReactiveAmpsTargetFromGSL" type="uint16" units="A" sf="A_SF" offset="23" />
-            <point id="RealPowerAmpsReferenceTotal" type="uint16" units="A" offset="24" />
-            <point id="RealPowerAmpsReference1" type="uint16" units="A" offset="25" />
-            <point id="RealPowerAmpsReference2" type="uint16" units="A" offset="26" />
-            <point id="ReactiveAmpsReference" type="uint16" units="A" offset="27" />
-            <point id="RealPowerAmpsReferenceTargetTotal" type="uint16" units="A" offset="28" />
-            <point id="RealPowerAmpsReferenceTarget1" type="uint16" units="A" offset="29" />
-            <point id="RealPowerAmpsReferenceTarget2" type="uint16" units="A" offset="30" />
-            <point id="ApparentPowerVectorAmpLimit" type="uint16" units="A" offset="31" /> <!-- NOT raw sampled -->
-            <point id="PowerAsWattsNegativeLimit1" type="uint16" units="A" sf="A_SF" offset="32" />
-            <point id="PowerAsWattsNegativeLimit2" type="uint16" units="A" sf="A_SF" offset="33" />
-            <point id="PowerAsWattsPositiveLimit1" type="uint16" units="A" sf="A_SF" offset="34" />
-            <point id="PowerAsWattsPositiveLimit2" type="uint16" units="A" sf="A_SF" offset="35" />
-            <point id="PowerTargetAsPerUnit1" type="uint16" units="W/unit" offset="36" />
-            <point id="PowerTargetAsPerUnit2" type="uint16" units="W/unit" offset="37" />
-            <point id="PowerTargetAsAmps1" type="uint16" units="A" sf="A_SF" offset="38" />
-            <point id="PowerTargetAsAmps2" type="uint16" units="A" sf="A_SF" offset="39" />
-            <point id="CTTargetSelfSupply1" type="uint16" units="W/unit" offset="40" />
-            <point id="CTTargetSelfSupply2" type="uint16" units="W/unit" offset="41" />
-            <point id="CTTargetZeroExport1" type="uint16" units="W/unit" offset="42" />
-            <point id="CTTargetZeroExport2" type="uint16" units="W/unit" offset="43" />
-            <point id="CTTargetZeroImport1" type="uint16" units="W/unit" offset="44" />
-            <point id="CTTargetZeroImport2" type="uint16" units="W/unit" offset="45" />
-            <point id="CTTargetGenConnected1" type="uint16" units="W/unit" offset="46" />
-            <point id="CTTargetGenConnected2" type="uint16" units="W/unit" offset="47" />
-            <point id="Hz_SF" access="r" type="sunssf" offset="48" />
-            <point id="V_Percent_SF" access="r" type="sunssf" offset="49" />
-            <point id="A_SF" access="r" type="sunssf" offset="50" />
-            <point id="Pad0" type="pad" offset="51" />
-            <point id="Pad1" type="pad" offset="52" />
-            <point id="Pad2" type="pad" offset="53" />
-            <point id="Pad3" type="pad" offset="54" />
-            <point id="Pad4" type="pad" offset="55" />
-            <point id="Pad5" type="pad" offset="56" />
-            <point id="Pad6" type="pad" offset="57" />
-            <point id="Pad7" type="pad" offset="58" />
-            <point id="Pad8" type="pad" offset="59" />
+            <point id="GSLReactivePowerCommand" type="int16" units="VAR_Percent" sf="VAR_Percent_SF" offset="19" /> <!-- VAR_Percent_SF = x10 -->
+            <point id="MaxReactiveAmpsReference" type="int16" units="A" offset="20" /> <!-- Raw sampled -->
+            <point id="ReactiveAmpsFromCapacitor" type="int16" units="A" sf="A_SF" offset="21" /> <!-- A_SF = x100 -->
+            <point id="ReactiveAmpsTarget" type="int16" units="A" sf="A_SF" offset="22" />
+            <point id="ReactiveAmpsTargetFromGSL" type="int16" units="A" sf="A_SF" offset="23" />
+            <point id="RealPowerAmpsReferenceTotal" type="int16" units="A" offset="24" />
+            <point id="RealPowerAmpsReference1" type="int16" units="A" offset="25" />
+            <point id="RealPowerAmpsReference2" type="int16" units="A" offset="26" />
+            <point id="ReactiveAmpsReference" type="int16" units="A" offset="27" />
+            <point id="RealPowerAmpsReferenceTarget" type="int16" units="A" offset="28" />
+            <point id="ApparentPowerVectorAmpLimit" type="int16" units="A" offset="29" /> <!-- NOT raw sampled -->
+            <point id="PowerAsWattsNegativeLimit" type="int16" units="W" offset="30" />
+            <point id="PowerAsWattsPositiveLimit" type="int16" units="W" offset="31" />
+            <point id="PowerTargetAsPercent" type="int16" units="W_Percent" sf="W_Percent_SF" offset="32" />
+            <point id="PowerTargetAsAmps" type="int16" units="A" sf="A_SF" offset="33" />
+            <point id="CTTargetSelfSupply" type="int16" units="W_Percent" sf="W_Percent_SF" offset="34" />
+            <point id="CTTargetZeroExport" type="int16" units="W_Percent" sf="W_Percent_SF" offset="35" />
+            <point id="CTTargetZeroImport" type="int16" units="W_Percent" sf="W_Percent_SF" offset="36" />
+            <point id="CTTargetGenConnected" type="int16" units="W_Percent" sf="W_Percent_SF" offset="37" />
+            <point id="V_SF" access="r" type="sunssf" offset="38" />
+            <point id="Hz_SF" access="r" type="sunssf" offset="39" />
+            <point id="V_Percent_SF" access="r" type="sunssf" offset="40" />
+            <point id="W_Percent_SF" access="r" type="sunssf" offset="41" />
+            <point id="VAR_Percent_SF" access="r" type="sunssf" offset="42" />
+            <point id="A_SF" access="r" type="sunssf" offset="43" />
+            <point id="Pad0" type="pad" offset="44" />
+            <point id="Pad1" type="pad" offset="45" />
+            <point id="Pad2" type="pad" offset="46" />
+            <point id="Pad3" type="pad" offset="47" />
+            <point id="Pad4" type="pad" offset="48" />
+            <point id="Pad5" type="pad" offset="49" />
+            <point id="Pad6" type="pad" offset="50" />
+            <point id="Pad7" type="pad" offset="51" />
+            <point id="Pad8" type="pad" offset="52" />
         </block>
     </model>
     <strings id="64268" locale="en">
@@ -76,12 +69,12 @@
         </model>
         <point id="AvgGridVoltage">
             <label>Average Grid Voltage from GSL Measurements</label>
-            <description>The average grid voltage as reported by the GSL</description>
+            <description>The average grid voltage as reported by the GSL - when the ATS is grid connected, these measurements are taken from the AC input of the inverter, while when the ATS is not grid connected, the measurements are taken from the interconnect via the CTs and ATS connection to the inverter</description>
             <notes></notes>
         </point>
         <point id="GridFrequency">
             <label>Grid Frequency from GSL Measurements</label>
-            <description>The grid frequency as reported by the GSL</description>
+            <description>The grid frequency as reported by the GSL - this is calculated using the voltage measurements' period</description>
             <notes></notes>
         </point>
         <point id="RealPower">
@@ -106,7 +99,7 @@
         </point>
         <point id="FreqWattActiveStatus">
             <label>Frequency Watt Active Status</label>
-            <description>The frequency watt control algorithm's active status</description>
+            <description>Active status of the frequency watt control algorithm</description>
             <notes></notes>
         </point>
         <point id="WattVarReactivePowerTarget">
@@ -130,7 +123,7 @@
             <notes></notes>
         </point>
         <point id="ConstantReactivePowerCommandReactivePowerTarget">
-            <label>Constant Power Factor Reactive Power Target</label>
+            <label>Constant Reactive Power Command Reactive Power Target</label>
             <description>The target for reactive power based on the constant reactive power command</description>
             <notes></notes>
         </point>
@@ -171,7 +164,7 @@
         </point>
         <point id="MaxReactiveAmpsReference">
             <label>Maximum Reactive Amps Reference</label>
-            <description>Positive and negative threshold for reactive amps target</description>
+            <description>The absolute threshold for the reactive amps target</description>
             <notes></notes>
         </point>
         <point id="ReactiveAmpsFromCapacitor">
@@ -186,7 +179,7 @@
         </point>
         <point id="ReactiveAmpsTargetFromGSL">
             <label>Reactive Amps Target From GSL</label>
-            <description>Reactive amps target from GSL</description>
+            <description>Target for reactive amps from GSL</description>
             <notes></notes>
         </point>
         <point id="RealPowerAmpsReferenceTotal">
@@ -209,19 +202,9 @@
             <description>Integral form of the reactive amps target</description>
             <notes></notes>
         </point>
-        <point id="RealPowerAmpsReferenceTargetTotal">
-            <label>Real Power Amps Reference Target Total</label>
+        <point id="RealPowerAmpsReferenceTarget">
+            <label>Real Power Amps Reference Target</label>
             <description>Target from divy - total</description>
-            <notes></notes>
-        </point>
-        <point id="RealPowerAmpsReferenceTarget1">
-            <label>Real Power Amps Reference Target for Phase 1</label>
-            <description>Target from divy - phase 1 component</description>
-            <notes></notes>
-        </point>
-        <point id="RealPowerAmpsReferenceTarget2">
-            <label>Real Power Amps Reference Target for Phase 2</label>
-            <description>Target from divy - phase 2 component </description>
             <notes></notes>
         </point>
         <point id="ApparentPowerVectorAmpLimit">
@@ -229,84 +212,44 @@
             <description>Restricts all combined real and reactive amps from exceeding this limit</description>
             <notes></notes>
         </point>
-        <point id="PowerAsWattsNegativeLimit1">
-            <label>Power as Watts Negative Limit for Phase 1</label>
-            <description>Negative real power limit for phase 1</description>
+        <point id="PowerAsWattsNegativeLimit">
+            <label>Power as Watts Negative Limit</label>
+            <description>Negative real power limit</description>
             <notes></notes>
         </point>
-        <point id="PowerAsWattsNegativeLimit2">
-            <label>Power as Watts Negative Limit for Phase 2</label>
-            <description>Negative real power limit for phase 2</description>
+        <point id="PowerAsWattsPositiveLimit">
+            <label>Power as Watts Positive Limit</label>
+            <description>Positive real power limit</description>
             <notes></notes>
         </point>
-        <point id="PowerAsWattsPositiveLimit1">
-            <label>Power as Watts Positive Limit for Phase 1</label>
-            <description>Positive real power limit for phase 1</description>
+        <point id="PowerTargetAsPercent">
+            <label>Power Target as Percent</label>
+            <description>Target for real power dependent on mode</description>
             <notes></notes>
         </point>
-        <point id="PowerAsWattsPositiveLimit2">
-            <label>Power as Watts Positive Limit for Phase 2</label>
-            <description>Positive real power limit for phase 2</description>
+        <point id="PowerTargetAsAmps">
+            <label>Power Target as Amps</label>
+            <description>Amps required to reach the target for real power</description>
             <notes></notes>
         </point>
-        <point id="PowerTargetAsPerUnit1">
-            <label>Power Target as Per Unit for Phase 1</label>
-            <description>Real power target dependent on mode - phase 1 component</description>
+        <point id="CTTargetSelfSupply">
+            <label>CT Target for Self Supply</label>
+            <description>CT target for self supply</description>
             <notes></notes>
         </point>
-        <point id="PowerTargetAsPerUnit2">
-            <label>Power Target as Per Unit for Phase 2</label>
-            <description>Real power target dependent on mode - phase 2 component</description>
+        <point id="CTTargetZeroExport">
+            <label>CT Target for Zero Export</label>
+            <description>CT target for zero export</description>
             <notes></notes>
         </point>
-        <point id="PowerTargetAsAmps1">
-            <label>Power Target as Amps for Phase 1</label>
-            <description>Amps required to reach the real power target - phase 1 component</description>
+        <point id="CTTargetZeroImport">
+            <label>CT Target for Zero Import</label>
+            <description>CT target for zero import</description>
             <notes></notes>
         </point>
-        <point id="PowerTargetAsAmps2">
-            <label>Power Target as Amps for Phase 2</label>
-            <description>Amps required to reach the real power target - phase 2 component</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetSelfSupply1">
-            <label>CT Target for Self Supply for Phase 1</label>
-            <description>CT target for self supply for phase 1</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetSelfSupply2">
-            <label>CT Target for Self Supply for Phase 2</label>
-            <description>CT target for self supply for phase 2</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetZeroExport1">
-            <label>CT Target for Zero Export for Phase 1</label>
-            <description>CT target for zero export for phase 1</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetZeroExport2">
-            <label>CT Target for Zero Export for Phase 2</label>
-            <description>CT target for zero export for phase 2</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetZeroImport1">
-            <label>CT Target for Zero Import for Phase 1</label>
-            <description>CT target for zero import for phase 1</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetZeroImport2">
-            <label>CT Target for Zero Import for Phase 2</label>
-            <description>CT target for zero import for phase 2</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetGenConnected1">
-            <label>CT Target when Gen Connected for Phase 1</label>
-            <description>CT target when generator connected for phase 1</description>
-            <notes></notes>
-        </point>
-        <point id="CTTargetGenConnected2">
-            <label>CT Target when Gen Connected for Phase 2</label>
-            <description>CT target when generator connected for phase 2</description>
+        <point id="CTTargetGenConnected">
+            <label>CT Target when Gen Connected</label>
+            <description>CT target when generator connected</description>
             <notes></notes>
         </point>
     </strings>

--- a/models/manifest.xml
+++ b/models/manifest.xml
@@ -29,7 +29,7 @@
   <file md5="68a438fb7ba23a140220a00100f353ec" name="smdx_00120.xml" />
   <file md5="0d6a55de305f8b3f9920d9c8ad7435a7" name="smdx_00121.xml" />
   <file md5="80120291ee9093e94badb00f94b57fc6" name="smdx_00122.xml" />
-  <file md5="71c4de0088f2fccc0a18f69623ea2a22" name="smdx_00123.xml" />
+  <file md5="ad51ff5ecfac76699c03dd382cc89c5a" name="smdx_00123.xml" />
   <file md5="fc48e60e899dfdc7a952504c401c95b3" name="smdx_00124.xml" />
   <file md5="a0f37bebfc392e2679445bd47c28c2d7" name="smdx_00125.xml" />
   <file md5="be6df47ed6fcaef4bd30b1929eca5200" name="smdx_00126.xml" />
@@ -86,7 +86,8 @@
   <file md5="18749956780dc33c1d2050d6c0064456" name="smdx_00808.xml" />
   <file md5="20d3cc8ee07c2f2178de3d40a521356f" name="smdx_00809.xml" />
   <file md5="b0a8ce8f8b0d206c179665783ac30670" name="smdx_10000.xml" />
-  <file md5="7dd213d34166f814c18aead44b0d04f5" name="smdx_10020.xml" />
+  <file md5="c34c5d9c50c5e25132252ca0e7bb79d2" name="smdx_10020.xml" />
+  <file md5="ee5bd20f9b8f586a3bbf30658ddc2128" name="smdx_10040.xml" />
   <file md5="92f777bd774d731b8c6f9fbfef884f1c" name="smdx_63001.xml" />
   <file md5="6b27bd7343daa816f5b234ec2210bc3c" name="smdx_63002.xml" />
   <file md5="584d6889c51d84163cd8a621e146590a" name="smdx_64001.xml" />
@@ -100,8 +101,8 @@
   <file md5="a678b0a24456de7baf4f5c128e31f400" name="smdx_64202.xml" />
   <file md5="fe6ea046c8a2cb3b92afabfaf167aa41" name="smdx_64203.xml" />
   <file md5="133bfb8d09e407624cd09d015bd77bd3" name="smdx_64204.xml" />
-  <file md5="348a8b5f81acf9cd466cdce19425109c" name="smdx_64205.xml" />
-  <file md5="614c0f414986ed8b2157f18c19a63e6c" name="smdx_64206.xml" />
+  <file md5="cc2fd463c06b79606a8d1169cda4c638" name="smdx_64205.xml" />
+  <file md5="bf6f73fa5109210a3411c9db3ff3561c" name="smdx_64206.xml" />
   <file md5="fb60c4504c6d348227015672af52566d" name="smdx_64207.xml" />
   <file md5="b72abba84f405525d1144df776bf2baa" name="smdx_64208.xml" />
   <file md5="34438111cf08ac20426d04828775059c" name="smdx_64209.xml" />
@@ -118,14 +119,16 @@
   <file md5="4fa175625dd46f3b1b6894b7d653a354" name="smdx_64252.xml" />
   <file md5="144bf526a8735f24cc98be453ad3b662" name="smdx_64253.xml" />
   <file md5="aeda4bb693ab5b544b21a79284b461c0" name="smdx_64254.xml" />
-  <file md5="174d3b4171bebf68b744488f6f9ac981" name="smdx_64255.xml" />
+  <file md5="f8360e29006d982a1006c8633b5606d8" name="smdx_64255.xml" />
   <file md5="761ab622af555884bee05b4a70fe22aa" name="smdx_64256.xml" />
   <file md5="54e6e9818f9045df25b59d6b8d99158d" name="smdx_64257.xml" />
   <file md5="b858e02d3288d02f00bdcefd820a6a69" name="smdx_64258.xml" />
-  <file md5="f719c2ce8534dbde33fc5790a9c8b68e" name="smdx_64259.xml" />
-  <file md5="f243346b0cdb5c66751eaf076d7c66f7" name="smdx_64260.xml" />
+  <file md5="d27cdfcfde597a6a154a0a1570cc61b4" name="smdx_64259.xml" />
+  <file md5="497f1acd2d00c549b3cbc0381a1ad3d4" name="smdx_64260.xml" />
   <file md5="652feb9695de66dddc1b3b838412b752" name="smdx_64261.xml" />
-  <file md5="52fe2169f005d64126371aff4e934b92" name="smdx_64262.xml" />
+  <file md5="29c19a181f9719d59d8f109165f61f51" name="smdx_64262.xml" />
   <file md5="48a568f2135d8f7b7af9280f13edc6c9" name="smdx_64263.xml" />
   <file md5="75ee5cc31d188dd6ddcd7f1029def527" name="smdx_64264.xml" />
+  <file md5="65857b18802cd2e00243b0cb1b8ad269" name="smdx_64265.xml" />
+  <file md5="230cdd997a9918156234523ac4e9042a" name="smdx_64268.xml" />
 </manifest>

--- a/models/model_1.json
+++ b/models/model_1.json
@@ -1,0 +1,82 @@
+{
+  "group": {
+    "name": "common",
+    "type": "group",
+    "label": "Common",
+    "desc": "Make, model and serial number information for this device",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 1
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Mn",
+        "type": "string",
+        "size": 16,
+        "mandatory": "M",
+        "label": "Manufacturer",
+        "desc": "Well known value registered with SunSpec for compliance"
+      },
+      {
+        "name": "Md",
+        "type": "string",
+        "size": 16,
+        "mandatory": "M",
+        "label": "Model",
+        "desc": "Manufacturer specific value (32 chars)"
+      },
+      {
+        "name": "Opt",
+        "type": "string",
+        "size": 8,
+        "label": "Options",
+        "desc": "Manufacturer specific value (16 chars)"
+      },
+      {
+        "name": "Vr",
+        "type": "string",
+        "size": 8,
+        "label": "Version",
+        "desc": "Manufacturer specific value (16 chars)"
+      },
+      {
+        "name": "SN",
+        "type": "string",
+        "size": 16,
+        "mandatory": "M",
+        "label": "Serial Number",
+        "desc": "Manufacturer specific value (32 chars)"
+      },
+      {
+        "name": "DA",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "label": "Device Address",
+        "desc": "Modbus device address"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "desc": "Force even alignment"
+      }
+    ]
+  },
+  "id": 1
+}

--- a/models/model_10.json
+++ b/models/model_10.json
@@ -1,0 +1,108 @@
+{
+  "group": {
+    "name": "model_10",
+    "type": "group",
+    "label": "Communication Interface Header",
+    "desc": "To be included first for a complete interface description",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 10
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Interface Status",
+        "desc": "Overall interface status",
+        "symbols": [
+          {
+            "name": "DOWN",
+            "value": 0,
+            "label": "down",
+            "desc": "Interface is down"
+          },
+          {
+            "name": "UP",
+            "value": 1,
+            "label": "up",
+            "desc": "Interface is up"
+          },
+          {
+            "name": "FAULT",
+            "value": 2,
+            "label": "fault",
+            "desc": "Interface is in a fault state"
+          }
+        ]
+      },
+      {
+        "name": "Ctl",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "label": "Interface Control",
+        "desc": "Overall interface control (TBD)"
+      },
+      {
+        "name": "Typ",
+        "type": "enum16",
+        "size": 1,
+        "label": "Physical Access Type",
+        "desc": "Enumerated value.  Type of physical media",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "unknown",
+            "desc": "Unknown media"
+          },
+          {
+            "name": "INTERNAL",
+            "value": 1,
+            "label": "internal",
+            "desc": "Internal e.g. embedded switch"
+          },
+          {
+            "name": "TWISTED_PAIR",
+            "value": 2,
+            "label": "twisted pair",
+            "desc": "Twisted Pair"
+          },
+          {
+            "name": "FIBER",
+            "value": 3,
+            "label": "fiber",
+            "desc": "Fiber"
+          },
+          {
+            "name": "WIRELESS",
+            "value": 4
+          }
+        ]
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 10
+}

--- a/models/model_10000.json
+++ b/models/model_10000.json
@@ -1,0 +1,205 @@
+{
+  "group": {
+    "name": "batt_status",
+    "type": "group",
+    "label": "Battery Status",
+    "desc": "Contains the status of a battery.",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 10000
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DeviceID",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "BatteryType",
+        "type": "uint16",
+        "size": 1,
+        "desc": "Harbor, etc."
+      },
+      {
+        "name": "BatterySubtype",
+        "type": "uint16",
+        "size": 1,
+        "desc": "Number of modules,"
+      },
+      {
+        "name": "State",
+        "type": "enum16",
+        "size": 1,
+        "desc": "disabled, ready, standby, etc."
+      },
+      {
+        "name": "BattP",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "desc": "Signed watts at present"
+      },
+      {
+        "name": "SoC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Tenth_SF",
+        "units": "1/10 %"
+      },
+      {
+        "name": "Tenth_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "BattV",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tenth_SF",
+        "units": "V"
+      },
+      {
+        "name": "Priority",
+        "type": "uint16",
+        "size": 1,
+        "desc": "From REB.h: the B-Link's active priority pair"
+      },
+      {
+        "name": "MaxChargePower",
+        "type": "uint16",
+        "size": 1,
+        "units": "W",
+        "desc": "Watts, always >= 0"
+      },
+      {
+        "name": "MaxDischargePower",
+        "type": "uint16",
+        "size": 1,
+        "units": "W",
+        "desc": "Watts, always >= 0"
+      },
+      {
+        "name": "WhyChargeLimit",
+        "type": "bitfield16",
+        "size": 1,
+        "symbols": [
+          {
+            "name": "CellV",
+            "value": 0
+          },
+          {
+            "name": "ModuleV",
+            "value": 1
+          },
+          {
+            "name": "StackV",
+            "value": 2
+          },
+          {
+            "name": "CellTemp",
+            "value": 3
+          },
+          {
+            "name": "SoC",
+            "value": 4
+          },
+          {
+            "name": "Disabled",
+            "value": 5
+          },
+          {
+            "name": "min_factor_bit0",
+            "value": 6
+          },
+          {
+            "name": "min_factor_bit1",
+            "value": 7
+          },
+          {
+            "name": "min_factor_bit2",
+            "value": 8
+          },
+          {
+            "name": "min_factor_bit3",
+            "value": 9
+          }
+        ]
+      },
+      {
+        "name": "WhyDischargeLimit",
+        "type": "bitfield16",
+        "size": 1,
+        "symbols": [
+          {
+            "name": "CellV",
+            "value": 0
+          },
+          {
+            "name": "ModuleV",
+            "value": 1
+          },
+          {
+            "name": "StackV",
+            "value": 2
+          },
+          {
+            "name": "CellTemp",
+            "value": 3
+          },
+          {
+            "name": "SoC",
+            "value": 4
+          },
+          {
+            "name": "Disabled",
+            "value": 5
+          },
+          {
+            "name": "min_factor_bit0",
+            "value": 6
+          },
+          {
+            "name": "min_factor_bit1",
+            "value": 7
+          },
+          {
+            "name": "min_factor_bit2",
+            "value": 8
+          },
+          {
+            "name": "min_factor_bit3",
+            "value": 9
+          }
+        ]
+      },
+      {
+        "name": "AmpHourCap",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AmpHourCap_SF",
+        "units": "x100 Ah"
+      },
+      {
+        "name": "AmpHourCap_SF",
+        "type": "sunssf",
+        "size": 1
+      }
+    ]
+  },
+  "id": 10000
+}

--- a/models/model_10020.json
+++ b/models/model_10020.json
@@ -1,0 +1,163 @@
+{
+  "group": {
+    "name": "dc_generator_status",
+    "type": "group",
+    "label": "DC-Coupled Generator Status",
+    "desc": "Communicates details about the current behavior of a DC-coupled generator connected to an ESS",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 10020
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Health",
+        "type": "enum16",
+        "size": 1,
+        "label": "Generator Health",
+        "desc": "Indicates presence of any faults (alarms or warnings) that impact the generator's ability to run",
+        "symbols": [
+          {
+            "name": "HEALTH_UNKNOWN",
+            "value": 0,
+            "label": "Generator unknown/unset health state",
+            "desc": "This constant is defined to reserve the numeric default value as meaningless."
+          },
+          {
+            "name": "ALARM",
+            "value": 1,
+            "label": "Generator ALARM health state",
+            "desc": "The generator has an alarm-level fault and cannot run (red)"
+          },
+          {
+            "name": "WARNING",
+            "value": 2,
+            "label": "Generator WARNING health state",
+            "desc": "The generator has a warning-level fault but can still run (yellow)"
+          },
+          {
+            "name": "READY",
+            "value": 3,
+            "label": "Generator READY health state",
+            "desc": "The generator has no active alarms or warnings and can run (green)"
+          }
+        ]
+      },
+      {
+        "name": "RunHours",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Tenth_SF",
+        "units": "h",
+        "label": "Generator Lifetime Run Hours",
+        "desc": "A running total of the number of hours for which the generator has run"
+      },
+      {
+        "name": "Tenth_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "ActiveECode",
+        "type": "uint16",
+        "size": 1,
+        "label": "Active E-Code",
+        "desc": "Contains the E-Code value for any currently-active fault (alarm or warning) on generator.  If multiple faults are active, the E-Code for the highest-priority fault is reported."
+      },
+      {
+        "name": "EnergyIn",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Energy In",
+        "desc": "Contains the lifetime total amount of energy consumed by the generator, in watt-hours."
+      },
+      {
+        "name": "EnergyOut",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Energy Out",
+        "desc": "Contains the lifetime total amount of energy produced by the generator, in watt-hours."
+      },
+      {
+        "name": "AutoStartState",
+        "type": "enum16",
+        "size": 1,
+        "label": "Generator Start/Stop Mode",
+        "desc": "The generator is designed to start automatically most of the time.  This field reports if the generator is in auto mode or not.",
+        "symbols": [
+          {
+            "name": "AUTO_STATE_UNKNOWN",
+            "value": 0,
+            "label": "Generator unknown/unset start/stop mode",
+            "desc": "This constant is defined to reserve the numeric default value as meaningless."
+          },
+          {
+            "name": "IN_AUTO",
+            "value": 1,
+            "label": "Generator IN_AUTO start/stop mode",
+            "desc": "The generator is ready to start if necessary to charge the ESS battery"
+          },
+          {
+            "name": "NOT_IN_AUTO",
+            "value": 2,
+            "label": "Generator NOT_IN_AUTO start/stop mode",
+            "desc": "The generator will not start on its own when the ESS battery is in need of charging"
+          }
+        ]
+      },
+      {
+        "name": "ProducingPower",
+        "type": "enum16",
+        "size": 1,
+        "symbols": [
+          {
+            "name": "NO",
+            "value": 0
+          },
+          {
+            "name": "YES",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "DC_Generator_Inhibit_State",
+        "type": "enum16",
+        "size": 1,
+        "label": "DC Generator Inhibit State",
+        "desc": "Reports the current DC Gen inhibit state",
+        "symbols": [
+          {
+            "name": "NOT_INHIBITED",
+            "value": 0,
+            "label": "DC Generator Not Inhibited",
+            "desc": "The DC generator is permitted to run and produce power on REbus"
+          },
+          {
+            "name": "INHIBITED",
+            "value": 1,
+            "label": "DC Generator Inhibited",
+            "desc": "The DC generator is NOT permitted to run and produce power on REbus"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 10020
+}

--- a/models/model_10040.json
+++ b/models/model_10040.json
@@ -1,0 +1,51 @@
+{
+  "group": {
+    "name": "inverter_status",
+    "type": "group",
+    "label": "Inverter Status",
+    "desc": "Communicates details about the current behavior of a PWRcell inverter as part of an ESS",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 10040
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DC_Generator_Inhibit",
+        "type": "enum16",
+        "size": 1,
+        "label": "DC Generator Inhibit",
+        "desc": "Allows a DC generator to be inhibited from producing power",
+        "symbols": [
+          {
+            "name": "NOT_INHIBIT",
+            "value": 0,
+            "label": "DC Generator Not Inhibit",
+            "desc": "The DC generator is permitted to run and produce power on REbus"
+          },
+          {
+            "name": "INHIBIT",
+            "value": 1,
+            "label": "DC Generator Inhibit",
+            "desc": "The DC generator is NOT permitted to run and produce power on REbus"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 10040
+}

--- a/models/model_101.json
+++ b/models/model_101.json
@@ -1,0 +1,501 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Single Phase)",
+    "desc": "Include this model for single phase inverter monitoring",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 101
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Hz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "VAr",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAr_SF",
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "VAr_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "WH",
+        "type": "acc32",
+        "size": 2,
+        "sf": "WH_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "WH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "DCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCW",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCW_SF",
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "TmpCab",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "Tmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Device is not operating"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "Sleeping",
+            "desc": "Device is sleeping / auto-shutdown"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "Starting",
+            "desc": "Device is staring up"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "Throttled",
+            "desc": "Device is operating at reduced power output"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "Shutting down",
+            "desc": "Device is shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "Fault",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "Standby",
+            "desc": "Device is in standby mode"
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid disconnect"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 101
+}

--- a/models/model_102.json
+++ b/models/model_102.json
@@ -1,0 +1,503 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Split-Phase)",
+    "desc": "Include this model for split phase inverter monitoring",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 102
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Hz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "VAr",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAr_SF",
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "VAr_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "WH",
+        "type": "acc32",
+        "size": 2,
+        "sf": "WH_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "WH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "DCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCW",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCW_SF",
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "TmpCab",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "Tmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Device is not operating"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "Sleeping",
+            "desc": "Device is sleeping / auto-shutdown"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "Starting",
+            "desc": "Device is staring up"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "Throttled",
+            "desc": "Device is operating at reduced power output"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "Shutting down",
+            "desc": "Device is shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "Fault",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "Standby",
+            "desc": "Device is in standby mode"
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid shutdown"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 102
+}

--- a/models/model_103.json
+++ b/models/model_103.json
@@ -1,0 +1,505 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Three Phase)",
+    "desc": "Include this model for three phase inverter monitoring",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 103
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Hz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "VAr",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAr_SF",
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "VAr_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "WH",
+        "type": "acc32",
+        "size": 2,
+        "sf": "WH_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "WH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "DCA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "DCW",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCW_SF",
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "TmpCab",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "Tmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Device is not operating"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "Sleeping",
+            "desc": "Device is sleeping / auto-shutdown"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "Starting",
+            "desc": "Device is staring up"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "Throttled",
+            "desc": "Device is operating at reduced power output"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "Shutting down",
+            "desc": "Device is shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "Fault",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "Standby",
+            "desc": "Device is in standby mode"
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid shutdown"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 103
+}

--- a/models/model_11.json
+++ b/models/model_11.json
@@ -1,0 +1,171 @@
+{
+  "group": {
+    "name": "model_11",
+    "type": "group",
+    "label": "Ethernet Link Layer",
+    "desc": "Include to support a wired ethernet port",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 11
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Spd",
+        "type": "uint16",
+        "size": 1,
+        "units": "Mbps",
+        "mandatory": "M",
+        "label": "Ethernet Link Speed",
+        "desc": "Interface speed in Mb/s"
+      },
+      {
+        "name": "CfgSt",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Interface Status Flags",
+        "desc": "Bitmask values Interface flags.",
+        "symbols": [
+          {
+            "name": "LINK",
+            "value": 0,
+            "label": "link status",
+            "desc": "link is up"
+          },
+          {
+            "name": "FULL_DUPLEX",
+            "value": 1,
+            "label": "full duplex",
+            "desc": "link is in full duplex mode"
+          },
+          {
+            "name": "AUTO_NEG1",
+            "value": 2,
+            "label": "auto negotiation 1",
+            "desc": "Auto-negotiation bits are encoded as: 000 - in progress.  001 - speed detection has failed.  010 - negotiation has failed.  011 - negotiated speed and duplex.  100 - negotiation not attempted."
+          },
+          {
+            "name": "AUTO_NEG2",
+            "value": 3,
+            "label": "auto negotiation 2",
+            "desc": "See AUTO_NEG1"
+          },
+          {
+            "name": "AUTO_NEG3",
+            "value": 4,
+            "label": "auto negotiation 3",
+            "desc": "See AUTO_NEG1"
+          },
+          {
+            "name": "RESET_REQUIRED",
+            "value": 5,
+            "label": "reset required",
+            "desc": "Setting requires reset"
+          },
+          {
+            "name": "HW_FAULT",
+            "value": 6,
+            "label": "hw fault",
+            "desc": "Hardware fault"
+          }
+        ]
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Link State",
+        "desc": "Enumerated value. State information for this interface",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "unknown",
+            "desc": "Unknown state"
+          },
+          {
+            "name": "ENABLED",
+            "value": 1,
+            "label": "enabled",
+            "desc": "Link is enabled and read"
+          },
+          {
+            "name": "DISABLED",
+            "value": 2,
+            "label": "disabled",
+            "desc": "Link is disabled"
+          },
+          {
+            "name": "TESTING",
+            "value": 3,
+            "label": "testing",
+            "desc": "Link is in test"
+          }
+        ]
+      },
+      {
+        "name": "MAC",
+        "type": "eui48",
+        "size": 4,
+        "label": "MAC",
+        "desc": "IEEE MAC address of this interface"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name (8 chars)"
+      },
+      {
+        "name": "Ctl",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "label": "Control",
+        "desc": "Control flags",
+        "symbols": [
+          {
+            "name": "AUTO",
+            "value": 0,
+            "label": "auto",
+            "desc": "Enable auto-negotiation"
+          },
+          {
+            "name": "FULL_DUPLEX",
+            "value": 1,
+            "label": "duplex",
+            "desc": "Force full duplex"
+          }
+        ]
+      },
+      {
+        "name": "FrcSpd",
+        "type": "uint16",
+        "size": 1,
+        "units": "Mbps",
+        "access": "RW",
+        "label": "Forced Speed",
+        "desc": "Forced interface speed in Mb/s when AUTO is disabled"
+      }
+    ]
+  },
+  "id": 11
+}

--- a/models/model_111.json
+++ b/models/model_111.json
@@ -1,0 +1,398 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Single Phase) FLOAT",
+    "desc": "Include this model for single phase inverter monitoring using float values",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 111
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAr",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "WH",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "DCA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCW",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "TmpCab",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "ggOFF",
+            "value": 1
+          },
+          {
+            "name": "ggSLEEPING",
+            "value": 2
+          },
+          {
+            "name": "ggSTARTING",
+            "value": 3
+          },
+          {
+            "name": "ggMPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "ggTHROTTLED",
+            "value": 5
+          },
+          {
+            "name": "ggSHUTTING_DOWN",
+            "value": 6
+          },
+          {
+            "name": "ggFAULT",
+            "value": 7
+          },
+          {
+            "name": "ggSTANDBY",
+            "value": 8
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid shutdown"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 111
+}

--- a/models/model_112.json
+++ b/models/model_112.json
@@ -1,0 +1,414 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Split Phase) FLOAT",
+    "desc": "Include this model for split phase inverter monitoring using float values",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 112
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAr",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "WH",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "DCA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCW",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "TmpCab",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Device is not operating"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "Sleeping",
+            "desc": "Device is sleeping / auto-shutdown"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "Starting",
+            "desc": "Device is staring up"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "Throttled",
+            "desc": "Device is operating at reduced power output"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "Shutting down",
+            "desc": "Device is shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "Fault",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "Standby",
+            "desc": "Device is in standby mode"
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid shutdown"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 112
+}

--- a/models/model_113.json
+++ b/models/model_113.json
@@ -1,0 +1,416 @@
+{
+  "group": {
+    "name": "inverter",
+    "type": "group",
+    "label": "Inverter (Three Phase) FLOAT",
+    "desc": "Include this model for three phase inverter monitoring using float values",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 113
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "AC Power"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Line Frequency"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAr",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAr",
+        "desc": "AC Reactive Power"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "Pct",
+        "label": "PF",
+        "desc": "AC Power Factor"
+      },
+      {
+        "name": "WH",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WattHours",
+        "desc": "AC Energy"
+      },
+      {
+        "name": "DCA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "DC Amps",
+        "desc": "DC Current"
+      },
+      {
+        "name": "DCV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "DC Voltage",
+        "desc": "DC Voltage"
+      },
+      {
+        "name": "DCW",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "DC Watts",
+        "desc": "DC Power"
+      },
+      {
+        "name": "TmpCab",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "mandatory": "M",
+        "label": "Cabinet Temperature",
+        "desc": "Cabinet Temperature"
+      },
+      {
+        "name": "TmpSnk",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Heat Sink Temperature",
+        "desc": "Heat Sink Temperature"
+      },
+      {
+        "name": "TmpTrns",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Transformer Temperature",
+        "desc": "Transformer Temperature"
+      },
+      {
+        "name": "TmpOt",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Other Temperature",
+        "desc": "Other Temperature"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "desc": "Enumerated value.  Operating state",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Device is not operating"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "Sleeping",
+            "desc": "Device is sleeping / auto-shutdown"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "Starting",
+            "desc": "Device is staring up"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Device is auto tracking maximum power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "Throttled",
+            "desc": "Device is operating at reduced power output"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "Shutting down",
+            "desc": "Device is shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "Fault",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "Standby",
+            "desc": "Device is in standby mode"
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Operating State",
+        "desc": "Vendor specific operating state code"
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event1",
+        "desc": "Bitmask value. Event fields",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground fault"
+          },
+          {
+            "name": "DC_OVER_VOLT",
+            "value": 1,
+            "label": "DC over voltage"
+          },
+          {
+            "name": "AC_DISCONNECT",
+            "value": 2,
+            "label": "AC disconnect open"
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC disconnect open"
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 4,
+            "label": "Grid shutdown"
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over temperature"
+          },
+          {
+            "name": "OVER_FREQUENCY",
+            "value": 8,
+            "label": "Frequency above limit"
+          },
+          {
+            "name": "UNDER_FREQUENCY",
+            "value": 9,
+            "label": "Frequency under limit"
+          },
+          {
+            "name": "AC_OVER_VOLT",
+            "value": 10,
+            "label": "AC Voltage above limit"
+          },
+          {
+            "name": "AC_UNDER_VOLT",
+            "value": 11,
+            "label": "AC Voltage under limit"
+          },
+          {
+            "name": "BLOWN_STRING_FUSE",
+            "value": 12,
+            "label": "Blown String fuse on input"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Generic Memory or Communication error (internal)"
+          },
+          {
+            "name": "HW_TEST_FAILURE",
+            "value": 15,
+            "label": "Hardware test failure"
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Bitfield 2",
+        "desc": "Reserved for future use"
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd3",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 3",
+        "desc": "Vendor defined events"
+      },
+      {
+        "name": "EvtVnd4",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 4",
+        "desc": "Vendor defined events"
+      }
+    ]
+  },
+  "id": 113
+}

--- a/models/model_12.json
+++ b/models/model_12.json
@@ -1,0 +1,277 @@
+{
+  "group": {
+    "name": "model_12",
+    "type": "group",
+    "label": "IPv4",
+    "desc": "Include to support an IPv4 protocol stack on this interface",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 12
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name"
+      },
+      {
+        "name": "CfgSt",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Config Status",
+        "desc": "Enumerated value.  Configuration status",
+        "symbols": [
+          {
+            "name": "NOT_CONFIGURED",
+            "value": 0,
+            "label": "not configured",
+            "desc": "the stack is not configured"
+          },
+          {
+            "name": "VALID_SETTING",
+            "value": 1,
+            "label": "valid setting",
+            "desc": "a valid configuration from BOOTP, DHCP, or NV mem"
+          },
+          {
+            "name": "VALID_HW",
+            "value": 2,
+            "label": "valid hardware",
+            "desc": "a valid configuration from hardware settings"
+          }
+        ]
+      },
+      {
+        "name": "ChgSt",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Change Status",
+        "desc": "Bitmask value.  A configuration change is pending",
+        "symbols": [
+          {
+            "name": "PENDING",
+            "value": 0,
+            "label": "pending",
+            "desc": "a configuration change is pending"
+          }
+        ]
+      },
+      {
+        "name": "Cap",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Config Capability",
+        "desc": "Bitmask value. Identify capable sources of configuration",
+        "symbols": [
+          {
+            "name": "DHCP",
+            "value": 0,
+            "label": "DHCP",
+            "desc": "DHCP Client capable"
+          },
+          {
+            "name": "BOOTP",
+            "value": 1,
+            "label": "BOOTP",
+            "desc": "BOOTP client capable"
+          },
+          {
+            "name": "ZEROCONF",
+            "value": 2,
+            "label": "zeroconf",
+            "desc": "Zeroconf capable"
+          },
+          {
+            "name": "DNS",
+            "value": 3,
+            "label": "DNS",
+            "desc": "DNS Client capable"
+          },
+          {
+            "name": "CFG_SETTABLE",
+            "value": 4,
+            "label": "configurable",
+            "desc": "Settable configuration capable"
+          },
+          {
+            "name": "HW_CONFIG",
+            "value": 5,
+            "label": "hw",
+            "desc": "Hardware configuration capable"
+          },
+          {
+            "name": "NTP_CLIENT",
+            "value": 6,
+            "label": "ntp",
+            "desc": "NTP Client capable"
+          },
+          {
+            "name": "RESET_REQUIRED",
+            "value": 7,
+            "label": "reset required",
+            "desc": "configuration change requires reset"
+          }
+        ]
+      },
+      {
+        "name": "Cfg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "IPv4 Config",
+        "desc": "Enumerated value.  Configuration method used.",
+        "symbols": [
+          {
+            "name": "STATIC",
+            "value": 0,
+            "label": "static",
+            "desc": "Use static IP"
+          },
+          {
+            "name": "DHCP",
+            "value": 1,
+            "label": "DHCP",
+            "desc": "Use DHCP"
+          },
+          {
+            "name": "BOOTP",
+            "value": 2,
+            "label": "BOOTP",
+            "desc": "Use BOOTP"
+          },
+          {
+            "name": "ZEROCONF",
+            "value": 3,
+            "label": "zeroconf",
+            "desc": "Use Zeroconf"
+          }
+        ]
+      },
+      {
+        "name": "Ctl",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Control",
+        "desc": "Configure use of services",
+        "symbols": [
+          {
+            "name": "ENABLE_DNS",
+            "value": 0,
+            "label": "DNS",
+            "desc": "Enable DNS"
+          },
+          {
+            "name": "ENABLE_NTP",
+            "value": 1,
+            "label": "NTP",
+            "desc": "Enable NTP"
+          }
+        ]
+      },
+      {
+        "name": "Addr",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "IP",
+        "desc": "IPv4 numeric address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "Msk",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Netmask",
+        "desc": "IPv4 numeric netmask as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "Gw",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Gateway",
+        "desc": "IPv4 numeric gateway address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "DNS1",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "DNS1",
+        "desc": "IPv4 numeric DNS address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "DNS2",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "DNS2",
+        "desc": "IPv4 numeric DNS address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "NTP1",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "NTP1",
+        "desc": "IPv4 numeric NTP address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "NTP2",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "NTP2",
+        "desc": "IPv4 numeric NTP address as a dotted string xxx.xxx.xxx.xxx"
+      },
+      {
+        "name": "DomNam",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Domain",
+        "desc": "Domain name (24 chars max)"
+      },
+      {
+        "name": "HostNam",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Host Name",
+        "desc": "Host name (24 chars max)"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 12
+}

--- a/models/model_120.json
+++ b/models/model_120.json
@@ -1,0 +1,269 @@
+{
+  "group": {
+    "name": "nameplate",
+    "type": "group",
+    "label": "Nameplate",
+    "desc": "Inverter Controls Nameplate Ratings ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 120
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DERTyp",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "DERTyp",
+        "desc": "Type of DER device. Default value is 4 to indicate PV device.",
+        "symbols": [
+          {
+            "name": "PV",
+            "value": 4
+          },
+          {
+            "name": "PV_STOR",
+            "value": 82
+          }
+        ]
+      },
+      {
+        "name": "WRtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WRtg_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "WRtg",
+        "desc": "Continuous power output capability of the inverter."
+      },
+      {
+        "name": "WRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "WRtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "VARtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VARtg_SF",
+        "units": "VA",
+        "mandatory": "M",
+        "label": "VARtg",
+        "desc": "Continuous Volt-Ampere capability of the inverter."
+      },
+      {
+        "name": "VARtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VARtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "VArRtgQ1",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArRtg_SF",
+        "units": "var",
+        "mandatory": "M",
+        "label": "VArRtgQ1",
+        "desc": "Continuous VAR capability of the inverter in quadrant 1."
+      },
+      {
+        "name": "VArRtgQ2",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArRtg_SF",
+        "units": "var",
+        "mandatory": "M",
+        "label": "VArRtgQ2",
+        "desc": "Continuous VAR capability of the inverter in quadrant 2."
+      },
+      {
+        "name": "VArRtgQ3",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArRtg_SF",
+        "units": "var",
+        "mandatory": "M",
+        "label": "VArRtgQ3",
+        "desc": "Continuous VAR capability of the inverter in quadrant 3."
+      },
+      {
+        "name": "VArRtgQ4",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArRtg_SF",
+        "units": "var",
+        "mandatory": "M",
+        "label": "VArRtgQ4",
+        "desc": "Continuous VAR capability of the inverter in quadrant 4."
+      },
+      {
+        "name": "VArRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VArRtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "ARtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ARtg_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "ARtg",
+        "desc": "Maximum RMS AC current level capability of the inverter."
+      },
+      {
+        "name": "ARtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "ARtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "PFRtgQ1",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFRtg_SF",
+        "units": "cos()",
+        "mandatory": "M",
+        "label": "PFRtgQ1",
+        "desc": "Minimum power factor capability of the inverter in quadrant 1."
+      },
+      {
+        "name": "PFRtgQ2",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFRtg_SF",
+        "units": "cos()",
+        "mandatory": "M",
+        "label": "PFRtgQ2",
+        "desc": "Minimum power factor capability of the inverter in quadrant 2."
+      },
+      {
+        "name": "PFRtgQ3",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFRtg_SF",
+        "units": "cos()",
+        "mandatory": "M",
+        "label": "PFRtgQ3",
+        "desc": "Minimum power factor capability of the inverter in quadrant 3."
+      },
+      {
+        "name": "PFRtgQ4",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFRtg_SF",
+        "units": "cos()",
+        "mandatory": "M",
+        "label": "PFRtgQ4",
+        "desc": "Minimum power factor capability of the inverter in quadrant 4."
+      },
+      {
+        "name": "PFRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PFRtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "WHRtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WHRtg_SF",
+        "units": "Wh",
+        "label": "WHRtg",
+        "desc": "Nominal energy rating of storage device."
+      },
+      {
+        "name": "WHRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "WHRtg_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "AhrRtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AhrRtg_SF",
+        "units": "AH",
+        "label": "AhrRtg",
+        "desc": "The usable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating)."
+      },
+      {
+        "name": "AhrRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "AhrRtg_SF",
+        "desc": "Scale factor for amp-hour rating."
+      },
+      {
+        "name": "MaxChaRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "MaxChaRte_SF",
+        "units": "W",
+        "label": "MaxChaRte",
+        "desc": "Maximum rate of energy transfer into the storage device."
+      },
+      {
+        "name": "MaxChaRte_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "MaxChaRte_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "MaxDisChaRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "MaxDisChaRte_SF",
+        "units": "W",
+        "label": "MaxDisChaRte",
+        "desc": "Maximum rate of energy transfer out of the storage device."
+      },
+      {
+        "name": "MaxDisChaRte_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "MaxDisChaRte_SF",
+        "desc": "Scale factor"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "label": "Pad",
+        "desc": "Pad register."
+      }
+    ]
+  },
+  "id": 120
+}

--- a/models/model_121.json
+++ b/models/model_121.json
@@ -1,0 +1,334 @@
+{
+  "group": {
+    "name": "settings",
+    "type": "group",
+    "label": "Basic Settings",
+    "desc": "Inverter Controls Basic Settings ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 121
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "WMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WMax_SF",
+        "units": "W",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WMax",
+        "desc": "Setting for maximum power output. Default to WRtg."
+      },
+      {
+        "name": "VRef",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VRef_SF",
+        "units": "V",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "VRef",
+        "desc": "Voltage at the PCC."
+      },
+      {
+        "name": "VRefOfs",
+        "type": "int16",
+        "size": 1,
+        "sf": "VRefOfs_SF",
+        "units": "V",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "VRefOfs",
+        "desc": "Offset  from PCC to inverter."
+      },
+      {
+        "name": "VMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VMinMax_SF",
+        "units": "V",
+        "access": "RW",
+        "label": "VMax",
+        "desc": "Setpoint for maximum voltage."
+      },
+      {
+        "name": "VMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VMinMax_SF",
+        "units": "V",
+        "access": "RW",
+        "label": "VMin",
+        "desc": "Setpoint for minimum voltage."
+      },
+      {
+        "name": "VAMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VAMax_SF",
+        "units": "VA",
+        "access": "RW",
+        "label": "VAMax",
+        "desc": "Setpoint for maximum apparent power. Default to VARtg."
+      },
+      {
+        "name": "VArMaxQ1",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArMax_SF",
+        "units": "var",
+        "access": "RW",
+        "label": "VArMaxQ1",
+        "desc": "Setting for maximum reactive power in quadrant 1. Default to VArRtgQ1."
+      },
+      {
+        "name": "VArMaxQ2",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArMax_SF",
+        "units": "var",
+        "access": "RW",
+        "label": "VArMaxQ2",
+        "desc": "Setting for maximum reactive power in quadrant 2. Default to VArRtgQ2."
+      },
+      {
+        "name": "VArMaxQ3",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArMax_SF",
+        "units": "var",
+        "access": "RW",
+        "label": "VArMaxQ3",
+        "desc": "Setting for maximum reactive power in quadrant 3. Default to VArRtgQ3."
+      },
+      {
+        "name": "VArMaxQ4",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArMax_SF",
+        "units": "var",
+        "access": "RW",
+        "label": "VArMaxQ4",
+        "desc": "Setting for maximum reactive power in quadrant 4. Default to VArRtgQ4."
+      },
+      {
+        "name": "WGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WGra_SF",
+        "units": "%WMax/sec",
+        "access": "RW",
+        "label": "WGra",
+        "desc": "Default ramp rate of change of active power due to command or internal action."
+      },
+      {
+        "name": "PFMinQ1",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFMin_SF",
+        "units": "cos()",
+        "access": "RW",
+        "label": "PFMinQ1",
+        "desc": "Setpoint for minimum power factor value in quadrant 1. Default to PFRtgQ1."
+      },
+      {
+        "name": "PFMinQ2",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFMin_SF",
+        "units": "cos()",
+        "access": "RW",
+        "label": "PFMinQ2",
+        "desc": "Setpoint for minimum power factor value in quadrant 2. Default to PFRtgQ2."
+      },
+      {
+        "name": "PFMinQ3",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFMin_SF",
+        "units": "cos()",
+        "access": "RW",
+        "label": "PFMinQ3",
+        "desc": "Setpoint for minimum power factor value in quadrant 3. Default to PFRtgQ3."
+      },
+      {
+        "name": "PFMinQ4",
+        "type": "int16",
+        "size": 1,
+        "sf": "PFMin_SF",
+        "units": "cos()",
+        "access": "RW",
+        "label": "PFMinQ4",
+        "desc": "Setpoint for minimum power factor value in quadrant 4. Default to PFRtgQ4."
+      },
+      {
+        "name": "VArAct",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "VArAct",
+        "desc": "VAR action on change between charging and discharging: 1=switch 2=maintain VAR characterization.",
+        "symbols": [
+          {
+            "name": "SWITCH",
+            "value": 1
+          },
+          {
+            "name": "MAINTAIN",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "ClcTotVA",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "ClcTotVA",
+        "desc": "Calculation method for total apparent power. 1=vector 2=arithmetic.",
+        "symbols": [
+          {
+            "name": "VECTOR",
+            "value": 1
+          },
+          {
+            "name": "ARITHMETIC",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "MaxRmpRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "MaxRmpRte_SF",
+        "units": "%WGra",
+        "access": "RW",
+        "label": "MaxRmpRte",
+        "desc": "Setpoint for maximum ramp rate as percentage of nominal maximum ramp rate. This setting will limit the rate that watts delivery to the grid can increase or decrease in response to intermittent PV generation."
+      },
+      {
+        "name": "ECPNomHz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ECPNomHz_SF",
+        "units": "Hz",
+        "access": "RW",
+        "label": "ECPNomHz",
+        "desc": "Setpoint for nominal frequency at the ECP."
+      },
+      {
+        "name": "ConnPh",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "ConnPh",
+        "desc": "Identity of connected phase for single phase inverters. A=1 B=2 C=3.",
+        "symbols": [
+          {
+            "name": "A",
+            "value": 1
+          },
+          {
+            "name": "B",
+            "value": 2
+          },
+          {
+            "name": "C",
+            "value": 3
+          }
+        ]
+      },
+      {
+        "name": "WMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "WMax_SF",
+        "desc": "Scale factor for real power."
+      },
+      {
+        "name": "VRef_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VRef_SF",
+        "desc": "Scale factor for voltage at the PCC."
+      },
+      {
+        "name": "VRefOfs_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VRefOfs_SF",
+        "desc": "Scale factor for offset voltage."
+      },
+      {
+        "name": "VMinMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VMinMax_SF",
+        "desc": "Scale factor for min/max voltages."
+      },
+      {
+        "name": "VAMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VAMax_SF",
+        "desc": "Scale factor for apparent power."
+      },
+      {
+        "name": "VArMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VArMax_SF",
+        "desc": "Scale factor for reactive power."
+      },
+      {
+        "name": "WGra_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "WGra_SF",
+        "desc": "Scale factor for default ramp rate."
+      },
+      {
+        "name": "PFMin_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "PFMin_SF",
+        "desc": "Scale factor for minimum power factor."
+      },
+      {
+        "name": "MaxRmpRte_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "MaxRmpRte_SF",
+        "desc": "Scale factor for maximum ramp percentage."
+      },
+      {
+        "name": "ECPNomHz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "ECPNomHz_SF",
+        "desc": "Scale factor for nominal frequency."
+      }
+    ]
+  },
+  "id": 121
+}

--- a/models/model_122.json
+++ b/models/model_122.json
@@ -1,0 +1,350 @@
+{
+  "group": {
+    "name": "status",
+    "type": "group",
+    "label": "Measurements_Status",
+    "desc": "Inverter Controls Extended Measurements and Status ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 122
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "PVConn",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PVConn",
+        "desc": "PV inverter present/available status. Enumerated value.",
+        "symbols": [
+          {
+            "name": "CONNECTED",
+            "value": 0
+          },
+          {
+            "name": "AVAILABLE",
+            "value": 1
+          },
+          {
+            "name": "OPERATING",
+            "value": 2
+          },
+          {
+            "name": "TEST",
+            "value": 3
+          }
+        ]
+      },
+      {
+        "name": "StorConn",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "StorConn",
+        "desc": "Storage inverter present/available status. Enumerated value.",
+        "symbols": [
+          {
+            "name": "CONNECTED",
+            "value": 0
+          },
+          {
+            "name": "AVAILABLE",
+            "value": 1
+          },
+          {
+            "name": "OPERATING",
+            "value": 2
+          },
+          {
+            "name": "TEST",
+            "value": 3
+          }
+        ]
+      },
+      {
+        "name": "ECPConn",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "ECPConn",
+        "desc": "ECP connection status: disconnected=0  connected=1.",
+        "symbols": [
+          {
+            "name": "CONNECTED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "ActWh",
+        "type": "acc64",
+        "size": 4,
+        "units": "Wh",
+        "label": "ActWh",
+        "desc": "AC lifetime active (real) energy output."
+      },
+      {
+        "name": "ActVAh",
+        "type": "acc64",
+        "size": 4,
+        "units": "VAh",
+        "label": "ActVAh",
+        "desc": "AC lifetime apparent energy output."
+      },
+      {
+        "name": "ActVArhQ1",
+        "type": "acc64",
+        "size": 4,
+        "units": "varh",
+        "label": "ActVArhQ1",
+        "desc": "AC lifetime reactive energy output in quadrant 1."
+      },
+      {
+        "name": "ActVArhQ2",
+        "type": "acc64",
+        "size": 4,
+        "units": "varh",
+        "label": "ActVArhQ2",
+        "desc": "AC lifetime reactive energy output in quadrant 2."
+      },
+      {
+        "name": "ActVArhQ3",
+        "type": "acc64",
+        "size": 4,
+        "units": "varh",
+        "label": "ActVArhQ3",
+        "desc": "AC lifetime negative energy output  in quadrant 3."
+      },
+      {
+        "name": "ActVArhQ4",
+        "type": "acc64",
+        "size": 4,
+        "units": "varh",
+        "label": "ActVArhQ4",
+        "desc": "AC lifetime reactive energy output  in quadrant 4."
+      },
+      {
+        "name": "VArAval",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArAval_SF",
+        "units": "var",
+        "label": "VArAval",
+        "desc": "Amount of VARs available without impacting watts output."
+      },
+      {
+        "name": "VArAval_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VArAval_SF",
+        "desc": "Scale factor for available VARs."
+      },
+      {
+        "name": "WAval",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WAval_SF",
+        "units": "var",
+        "label": "WAval",
+        "desc": "Amount of Watts available."
+      },
+      {
+        "name": "WAval_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "WAval_SF",
+        "desc": "Scale factor for available Watts."
+      },
+      {
+        "name": "StSetLimMsk",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "StSetLimMsk",
+        "desc": "Bit Mask indicating setpoint limit(s) reached.",
+        "symbols": [
+          {
+            "name": "WMax",
+            "value": 0
+          },
+          {
+            "name": "VAMax",
+            "value": 1
+          },
+          {
+            "name": "VArAval",
+            "value": 2
+          },
+          {
+            "name": "VArMaxQ1",
+            "value": 3
+          },
+          {
+            "name": "VArMaxQ2",
+            "value": 4
+          },
+          {
+            "name": "VArMaxQ3",
+            "value": 5
+          },
+          {
+            "name": "VArMaxQ4",
+            "value": 6
+          },
+          {
+            "name": "PFMinQ1",
+            "value": 7
+          },
+          {
+            "name": "PFMinQ2",
+            "value": 8
+          },
+          {
+            "name": "PFMinQ3",
+            "value": 9
+          },
+          {
+            "name": "PFMinQ4",
+            "value": 10
+          }
+        ]
+      },
+      {
+        "name": "StActCtl",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "StActCtl",
+        "desc": "Bit Mask indicating which inverter controls are currently active.",
+        "symbols": [
+          {
+            "name": "FixedW",
+            "value": 0
+          },
+          {
+            "name": "FixedVAR",
+            "value": 1
+          },
+          {
+            "name": "FixedPF",
+            "value": 2
+          },
+          {
+            "name": "Volt-VAr",
+            "value": 3
+          },
+          {
+            "name": "Freq-Watt-Param",
+            "value": 4
+          },
+          {
+            "name": "Freq-Watt-Curve",
+            "value": 5
+          },
+          {
+            "name": "Dyn-Reactive-Current",
+            "value": 6
+          },
+          {
+            "name": "LVRT",
+            "value": 7
+          },
+          {
+            "name": "HVRT",
+            "value": 8
+          },
+          {
+            "name": "Watt-PF",
+            "value": 9
+          },
+          {
+            "name": "Volt-Watt",
+            "value": 10
+          },
+          {
+            "name": "Scheduled",
+            "value": 12
+          },
+          {
+            "name": "LFRT",
+            "value": 13
+          },
+          {
+            "name": "HFRT",
+            "value": 14
+          }
+        ]
+      },
+      {
+        "name": "TmSrc",
+        "type": "string",
+        "size": 4,
+        "label": "TmSrc",
+        "desc": "Source of time synchronization."
+      },
+      {
+        "name": "Tms",
+        "type": "uint32",
+        "size": 2,
+        "units": "Secs",
+        "label": "Tms",
+        "desc": "Seconds since 01-01-2000 00:00 UTC"
+      },
+      {
+        "name": "RtSt",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "RtSt",
+        "desc": "Bit Mask indicating active ride-through status.",
+        "symbols": [
+          {
+            "name": "LVRT_ACTIVE",
+            "value": 0
+          },
+          {
+            "name": "HVRT_ACTIVE",
+            "value": 1
+          },
+          {
+            "name": "LFRT_ACTIVE",
+            "value": 2
+          },
+          {
+            "name": "HFRT_ACTIVE",
+            "value": 3
+          }
+        ]
+      },
+      {
+        "name": "Ris",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Ris_SF",
+        "units": "ohms",
+        "label": "Ris",
+        "desc": "Isolation resistance."
+      },
+      {
+        "name": "Ris_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Ris_SF",
+        "desc": "Scale factor for isolation resistance."
+      }
+    ]
+  },
+  "id": 122
+}

--- a/models/model_123.json
+++ b/models/model_123.json
@@ -1,0 +1,314 @@
+{
+  "group": {
+    "name": "controls",
+    "type": "group",
+    "label": "Immediate Controls",
+    "desc": "Immediate Inverter Controls ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 123
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Conn_WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "Conn_WinTms",
+        "desc": "Time window for connect/disconnect."
+      },
+      {
+        "name": "Conn_RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "Conn_RvrtTms",
+        "desc": "Timeout period for connect/disconnect."
+      },
+      {
+        "name": "Conn",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Conn",
+        "desc": "Enumerated valued.  Connection control.",
+        "symbols": [
+          {
+            "name": "DISCONNECT",
+            "value": 0
+          },
+          {
+            "name": "CONNECT",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "WMaxLimPct",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WMaxLimPct_SF",
+        "units": "%WMax",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WMaxLimPct",
+        "desc": "Set power output to specified level."
+      },
+      {
+        "name": "WMaxLimPct_WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WMaxLimPct_WinTms",
+        "desc": "Time window for power limit change."
+      },
+      {
+        "name": "WMaxLimPct_RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WMaxLimPct_RvrtTms",
+        "desc": "Timeout period for power limit."
+      },
+      {
+        "name": "WMaxLimPct_RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WMaxLimPct_RmpTms",
+        "desc": "Ramp time for moving from current setpoint to new setpoint."
+      },
+      {
+        "name": "WMaxLim_Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WMaxLim_Ena",
+        "desc": "Enumerated valued.  Throttle enable/disable control.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "OutPFSet",
+        "type": "int16",
+        "size": 1,
+        "sf": "OutPFSet_SF",
+        "units": "cos()",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "OutPFSet",
+        "desc": "Set power factor to specific value - cosine of angle."
+      },
+      {
+        "name": "OutPFSet_WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "OutPFSet_WinTms",
+        "desc": "Time window for power factor change."
+      },
+      {
+        "name": "OutPFSet_RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "OutPFSet_RvrtTms",
+        "desc": "Timeout period for power factor."
+      },
+      {
+        "name": "OutPFSet_RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "OutPFSet_RmpTms",
+        "desc": "Ramp time for moving from current setpoint to new setpoint."
+      },
+      {
+        "name": "OutPFSet_Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "OutPFSet_Ena",
+        "desc": "Enumerated value. Fixed power factor enable/disable control.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED_REAL_POWER_PRIORITY",
+            "value": 1
+          },
+          {
+            "name": "ENABLED_REACTIVE_POWER_PRIORITY",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "VArWMaxPct",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArPct_SF",
+        "units": "%WMax",
+        "access": "RW",
+        "label": "VArWMaxPct",
+        "desc": "Reactive power in percent of WMax."
+      },
+      {
+        "name": "VArMaxPct",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArPct_SF",
+        "units": "%VArMax",
+        "access": "RW",
+        "label": "VArMaxPct",
+        "desc": "Reactive power in percent of VArMax."
+      },
+      {
+        "name": "VArAvalPct",
+        "type": "int16",
+        "size": 1,
+        "sf": "VArPct_SF",
+        "units": "%VArAval",
+        "access": "RW",
+        "label": "VArAvalPct",
+        "desc": "Reactive power in percent of VArAval."
+      },
+      {
+        "name": "VArPct_WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "VArPct_WinTms",
+        "desc": "Time window for VAR limit change."
+      },
+      {
+        "name": "VArPct_RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "VArPct_RvrtTms",
+        "desc": "Timeout period for VAR limit."
+      },
+      {
+        "name": "VArPct_RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "VArPct_RmpTms",
+        "desc": "Ramp time for moving from current setpoint to new setpoint."
+      },
+      {
+        "name": "VArPct_Mod",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "VArPct_Mod",
+        "desc": "Enumerated value. VAR percent limit mode.",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "desc": "No VAR limit"
+          },
+          {
+            "name": "WMax",
+            "value": 1,
+            "desc": "VAR limit as a % of Wmax"
+          },
+          {
+            "name": "VArMax",
+            "value": 2,
+            "desc": "VAR limit as a % of VArMax"
+          },
+          {
+            "name": "VArAval",
+            "value": 3,
+            "desc": "VAR limit as a % of VArAval"
+          }
+        ]
+      },
+      {
+        "name": "VArPct_Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "VArPct_Ena",
+        "desc": "Enumerated valued.  Percent limit VAr enable/disable control.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "WMaxLimPct_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "WMaxLimPct_SF",
+        "desc": "Scale factor for power output percent."
+      },
+      {
+        "name": "OutPFSet_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "OutPFSet_SF",
+        "desc": "Scale factor for power factor."
+      },
+      {
+        "name": "VArPct_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VArPct_SF",
+        "desc": "Scale factor for reactive power percent."
+      }
+    ]
+  },
+  "id": 123
+}

--- a/models/model_124.json
+++ b/models/model_124.json
@@ -1,0 +1,287 @@
+{
+  "group": {
+    "name": "storage",
+    "type": "group",
+    "label": "Storage",
+    "desc": "Basic Storage Controls ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 124
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "WChaMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WChaMax_SF",
+        "units": "W",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WChaMax",
+        "desc": "Setpoint for maximum charge."
+      },
+      {
+        "name": "WChaGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WChaDisChaGra_SF",
+        "units": "%WChaMax/sec",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WChaGra",
+        "desc": "Setpoint for maximum charging rate. Default is MaxChaRte."
+      },
+      {
+        "name": "WDisChaGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WChaDisChaGra_SF",
+        "units": "%WChaMax/sec",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WDisChaGra",
+        "desc": "Setpoint for maximum discharge rate. Default is MaxDisChaRte."
+      },
+      {
+        "name": "StorCtl_Mod",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "StorCtl_Mod",
+        "desc": "Activate hold/discharge/charge storage control mode. Bitfield value.",
+        "symbols": [
+          {
+            "name": "CHARGE",
+            "value": 0
+          },
+          {
+            "name": "DiSCHARGE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "VAChaMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VAChaMax_SF",
+        "units": "VA",
+        "access": "RW",
+        "label": "VAChaMax",
+        "desc": "Setpoint for maximum charging VA."
+      },
+      {
+        "name": "MinRsvPct",
+        "type": "uint16",
+        "size": 1,
+        "sf": "MinRsvPct_SF",
+        "units": "%WChaMax",
+        "access": "RW",
+        "label": "MinRsvPct",
+        "desc": "Setpoint for minimum reserve for storage as a percentage of the nominal maximum storage."
+      },
+      {
+        "name": "ChaState",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ChaState_SF",
+        "units": "%AhrRtg",
+        "label": "ChaState",
+        "desc": "Currently available energy as a percent of the capacity rating."
+      },
+      {
+        "name": "StorAval",
+        "type": "uint16",
+        "size": 1,
+        "sf": "StorAval_SF",
+        "units": "AH",
+        "label": "StorAval",
+        "desc": "State of charge (ChaState) minus storage reserve (MinRsvPct) times capacity rating (AhrRtg)."
+      },
+      {
+        "name": "InBatV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "InBatV_SF",
+        "units": "V",
+        "label": "InBatV",
+        "desc": "Internal battery voltage."
+      },
+      {
+        "name": "ChaSt",
+        "type": "enum16",
+        "size": 1,
+        "label": "ChaSt",
+        "desc": "Charge status of storage device. Enumerated value.",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1
+          },
+          {
+            "name": "EMPTY",
+            "value": 2
+          },
+          {
+            "name": "DISCHARGING",
+            "value": 3
+          },
+          {
+            "name": "CHARGING",
+            "value": 4
+          },
+          {
+            "name": "FULL",
+            "value": 5
+          },
+          {
+            "name": "HOLDING",
+            "value": 6
+          },
+          {
+            "name": "TESTING",
+            "value": 7
+          }
+        ]
+      },
+      {
+        "name": "OutWRte",
+        "type": "int16",
+        "size": 1,
+        "sf": "InOutWRte_SF",
+        "units": "%WDisChaMax",
+        "access": "RW",
+        "label": "OutWRte",
+        "desc": "Percent of max discharge rate."
+      },
+      {
+        "name": "InWRte",
+        "type": "int16",
+        "size": 1,
+        "sf": "InOutWRte_SF",
+        "units": " % WChaMax",
+        "access": "RW",
+        "label": "InWRte",
+        "desc": "Percent of max charging rate."
+      },
+      {
+        "name": "InOutWRte_WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "InOutWRte_WinTms",
+        "desc": "Time window for charge/discharge rate change."
+      },
+      {
+        "name": "InOutWRte_RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "InOutWRte_RvrtTms",
+        "desc": "Timeout period for charge/discharge rate."
+      },
+      {
+        "name": "InOutWRte_RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "InOutWRte_RmpTms",
+        "desc": "Ramp time for moving from current setpoint to new setpoint."
+      },
+      {
+        "name": "ChaGriSet",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "symbols": [
+          {
+            "name": "PV",
+            "value": 0
+          },
+          {
+            "name": "GRID",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "WChaMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "WChaMax_SF",
+        "desc": "Scale factor for maximum charge."
+      },
+      {
+        "name": "WChaDisChaGra_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "WChaDisChaGra_SF",
+        "desc": "Scale factor for maximum charge and discharge rate."
+      },
+      {
+        "name": "VAChaMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VAChaMax_SF",
+        "desc": "Scale factor for maximum charging VA."
+      },
+      {
+        "name": "MinRsvPct_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "MinRsvPct_SF",
+        "desc": "Scale factor for minimum reserve percentage."
+      },
+      {
+        "name": "ChaState_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "ChaState_SF",
+        "desc": "Scale factor for available energy percent."
+      },
+      {
+        "name": "StorAval_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "StorAval_SF",
+        "desc": "Scale factor for state of charge."
+      },
+      {
+        "name": "InBatV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "InBatV_SF",
+        "desc": "Scale factor for battery voltage."
+      },
+      {
+        "name": "InOutWRte_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "InOutWRte_SF",
+        "desc": "Scale factor for percent charge/discharge rate."
+      }
+    ]
+  },
+  "id": 124
+}

--- a/models/model_125.json
+++ b/models/model_125.json
@@ -1,0 +1,130 @@
+{
+  "group": {
+    "name": "pricing",
+    "type": "group",
+    "label": "Pricing",
+    "desc": "Pricing Signal  ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 125
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is price-based charge/discharge mode active?",
+        "symbols": [
+          {
+            "name": "ENABLE",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "SigType",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "SigType",
+        "desc": "Meaning of the pricing signal. When a Price schedule is used, type must match the schedule range variable description.",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "desc": "Signal type is unknown or other type of  value"
+          },
+          {
+            "name": "ABSOLUTE",
+            "value": 1,
+            "desc": "Signal is an absolute price value in local rate. E.g. 23 (cents/kWh)"
+          },
+          {
+            "name": "RELATIVE",
+            "value": 2,
+            "desc": "Signal is a relative price in local rate. E.g. -5 (cents/kWh)"
+          },
+          {
+            "name": "MULTIPLIER",
+            "value": 3,
+            "desc": "Signal is a price multiplier (percentage).  E.g. 15 % uplift in the rate"
+          },
+          {
+            "name": "LEVEL",
+            "value": 4,
+            "desc": "Signal is a price level.  E.g. 0=lowest 1=low 2=normal 3=high 4=highest"
+          }
+        ]
+      },
+      {
+        "name": "Sig",
+        "type": "int16",
+        "size": 1,
+        "sf": "Sig_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Sig",
+        "desc": "Utility/ESP specific pricing signal. Content depends on pricing signal type. When H/M/L type is specified. Low=0; Med=1; High=2."
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for charge/discharge pricing change."
+      },
+      {
+        "name": "RvtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvtTms",
+        "desc": "Timeout period for charge/discharge pricing change."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current charge or discharge level to new level."
+      },
+      {
+        "name": "Sig_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sig_SF",
+        "desc": "Pricing signal scale factor."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 125
+}

--- a/models/model_126.json
+++ b/models/model_126.json
@@ -1,0 +1,616 @@
+{
+  "group": {
+    "name": "volt_var",
+    "type": "group",
+    "label": "Static Volt-VAR",
+    "desc": "Static Volt-VAR Arrays ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 126
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is Volt-VAR control active",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for volt-VAR change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for volt-VAR curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "The time of the PT1 in seconds (time to accomplish a change of 95%)"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef"
+      },
+      {
+        "name": "DeptRef_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "DeptRef_SF",
+        "desc": "Scale factor for dependent variable"
+      },
+      {
+        "name": "RmpIncDec_SF",
+        "type": "sunssf",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "DeptRef",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "DeptRef",
+            "desc": "Meaning of dependent variable: 1=%WMax 2=%VArMax 3=%VArAval",
+            "symbols": [
+              {
+                "name": "WMax",
+                "value": 1
+              },
+              {
+                "name": "VArMax",
+                "value": 2
+              },
+              {
+                "name": "VArAval",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 Volts"
+          },
+          {
+            "name": "VAr1",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "VAr1",
+            "desc": "Point 1 VARs"
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 Volts"
+          },
+          {
+            "name": "VAr2",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr2",
+            "desc": "Point 2 VARs"
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 2 Volts"
+          },
+          {
+            "name": "VAr3",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr3",
+            "desc": "Point 3 VARs"
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 Volts"
+          },
+          {
+            "name": "VAr4",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr4",
+            "desc": "Point 4 VARs"
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 Volts"
+          },
+          {
+            "name": "VAr5",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr5",
+            "desc": "Point 5 VARs"
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 Volts"
+          },
+          {
+            "name": "VAr6",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr6",
+            "desc": "Point 6 VARs"
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 Volts"
+          },
+          {
+            "name": "VAr7",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr7",
+            "desc": "Point 7 VARs"
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 Volts"
+          },
+          {
+            "name": "VAr8",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr8",
+            "desc": "Point 8 VARs"
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 Volts"
+          },
+          {
+            "name": "VAr9",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr9",
+            "desc": "Point 9 VARs"
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 Volts"
+          },
+          {
+            "name": "VAr10",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr10",
+            "desc": "Point 10 VARs"
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 Volts"
+          },
+          {
+            "name": "VAr11",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr11",
+            "desc": "Point 11 VARs"
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 Volts"
+          },
+          {
+            "name": "VAr12",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr12",
+            "desc": "Point 12 VARs"
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 Volts"
+          },
+          {
+            "name": "VAr13",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr13",
+            "desc": "Point 13 VARs"
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 Volts"
+          },
+          {
+            "name": "VAr14",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr14",
+            "desc": "Point 14 VARs"
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 Volts"
+          },
+          {
+            "name": "VAr15",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr15",
+            "desc": "Point 15 VARs"
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 Volts"
+          },
+          {
+            "name": "VAr16",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr16",
+            "desc": "Point 16 VARs"
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 Volts"
+          },
+          {
+            "name": "VAr17",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr17",
+            "desc": "Point 17 VARs"
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 Volts"
+          },
+          {
+            "name": "VAr18",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr18",
+            "desc": "Point 18 VARs"
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 Volts"
+          },
+          {
+            "name": "VAr19",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr19",
+            "desc": "Point 19 VARs"
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 Volts"
+          },
+          {
+            "name": "VAr20",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "VAr20",
+            "desc": "Point 20 VARs"
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve. (Max 16 chars)"
+          },
+          {
+            "name": "RmpTms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "RmpTms",
+            "desc": "The time of the PT1 in seconds (time to accomplish a change of 95%)"
+          },
+          {
+            "name": "RmpDecTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%ref_value/min",
+            "access": "RW",
+            "label": "RmpDecTmm",
+            "desc": "The maximum rate at which the VAR value may be reduced in response to changes in the voltage value. %ref_value is %WMax %VArMax or %VArAval depending on value of DeptRef"
+          },
+          {
+            "name": "RmpIncTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%ref_value/min",
+            "access": "RW",
+            "label": "RmpIncTmm",
+            "desc": "The maximum rate at which the VAR value may be increased in response to changes in the voltage value. %ref_value is %WMax %VArMax or %VArAval depending on value of DeptRef"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Boolean flag indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 126
+}

--- a/models/model_127.json
+++ b/models/model_127.json
@@ -1,0 +1,129 @@
+{
+  "group": {
+    "name": "freq_watt_param",
+    "type": "group",
+    "label": "Freq-Watt Param",
+    "desc": "Parameterized Frequency-Watt ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 127
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "WGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WGra_SF",
+        "units": "%PM/Hz",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "WGra",
+        "desc": "The slope of the reduction in the maximum allowed watts output as a function of frequency."
+      },
+      {
+        "name": "HzStr",
+        "type": "int16",
+        "size": 1,
+        "sf": "HzStrStop_SF",
+        "units": "Hz",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "HzStr",
+        "desc": "The frequency deviation from nominal frequency (ECPNomHz) at which a snapshot of the instantaneous power output is taken to act as the CAPPED power level (PM) and above which reduction in power output occurs."
+      },
+      {
+        "name": "HzStop",
+        "type": "int16",
+        "size": 1,
+        "sf": "HzStrStop_SF",
+        "units": "Hz",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "HzStop",
+        "desc": "The frequency deviation from nominal frequency (ECPNomHz) at which curtailed power output may return to normal and the cap on the power level value is removed."
+      },
+      {
+        "name": "HysEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "HysEna",
+        "desc": "Enable hysteresis",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is Parameterized Frequency-Watt control active.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "HzStopWGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "RmpIncDec_SF",
+        "units": "%WMax/min",
+        "access": "RW",
+        "label": "HzStopWGra",
+        "desc": "The maximum time-based rate of change at which power output returns to normal after having been capped by an over frequency event."
+      },
+      {
+        "name": "WGra_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "WGra_SF",
+        "desc": "Scale factor for output gradient."
+      },
+      {
+        "name": "HzStrStop_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "HzStrStop_SF",
+        "desc": "Scale factor for frequency deviations."
+      },
+      {
+        "name": "RmpIncDec_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "RmpIncDec_SF",
+        "desc": "Scale factor for increment and decrement ramps."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 127
+}

--- a/models/model_128.json
+++ b/models/model_128.json
@@ -1,0 +1,173 @@
+{
+  "group": {
+    "name": "reactive_current",
+    "type": "group",
+    "label": "Dynamic Reactive Current",
+    "desc": "Dynamic Reactive Current ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 128
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ArGraMod",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ArGraMod",
+        "desc": "Indicates if gradients trend toward zero at the edges of the deadband or trend toward zero at the center of the deadband.",
+        "symbols": [
+          {
+            "name": "EDGE",
+            "value": 0
+          },
+          {
+            "name": "CENTER",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "ArGraSag",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ArGra_SF",
+        "units": "%ARtg/%dV",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ArGraSag",
+        "desc": "The gradient used to increase capacitive dynamic current. A value of 0 indicates no additional reactive current support."
+      },
+      {
+        "name": "ArGraSwell",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ArGra_SF",
+        "units": "%ARtg/%dV",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ArGraSwell",
+        "desc": "The gradient used to increase inductive dynamic current.  A value of 0 indicates no additional reactive current support."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Activate dynamic reactive current model",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "FilTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "FilTms",
+        "desc": "The time window used to calculate the moving average voltage."
+      },
+      {
+        "name": "DbVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VRefPct_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "label": "DbVMin",
+        "desc": "The lower delta voltage limit for which negative voltage deviations less than this value no dynamic vars are produced."
+      },
+      {
+        "name": "DbVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VRefPct_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "label": "DbVMax",
+        "desc": "The upper delta voltage limit for which positive voltage deviations less than this value no dynamic current produced."
+      },
+      {
+        "name": "BlkZnV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VRefPct_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "label": "BlkZnV",
+        "desc": "Block zone voltage which defines a lower voltage boundary below which no dynamic current is produced."
+      },
+      {
+        "name": "HysBlkZnV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VRefPct_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "label": "HysBlkZnV",
+        "desc": "Hysteresis voltage used with BlkZnV."
+      },
+      {
+        "name": "BlkZnTmms",
+        "type": "uint16",
+        "size": 1,
+        "units": "mSecs",
+        "access": "RW",
+        "label": "BlkZnTmms",
+        "desc": "Block zone time the time before which reactive current support remains active regardless of how low the voltage drops."
+      },
+      {
+        "name": "HoldTmms",
+        "type": "uint16",
+        "size": 1,
+        "units": "mSecs",
+        "access": "RW",
+        "label": "HoldTmms",
+        "desc": "Hold time during which reactive current support continues after the average voltage has entered the dead zone."
+      },
+      {
+        "name": "ArGra_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "ArGra_SF",
+        "desc": "Scale factor for the gradients."
+      },
+      {
+        "name": "VRefPct_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "VRefPct_SF",
+        "desc": "Scale factor for the voltage zone and limit settings."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 128
+}

--- a/models/model_129.json
+++ b/models/model_129.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "lvrt",
+    "type": "group",
+    "label": "LVRTD",
+    "desc": "LVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 129
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 129
+}

--- a/models/model_13.json
+++ b/models/model_13.json
@@ -1,0 +1,276 @@
+{
+  "group": {
+    "name": "model_13",
+    "type": "group",
+    "label": "IPv6",
+    "desc": "Include to support an IPv6 protocol stack on this interface",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 13
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name"
+      },
+      {
+        "name": "CfgSt",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Config Status",
+        "desc": "Enumerated value.  Configuration status",
+        "symbols": [
+          {
+            "name": "NOT_CONFIGURED",
+            "value": 0,
+            "label": "not configured",
+            "desc": "the stack is not configured"
+          },
+          {
+            "name": "VALID_SETTING",
+            "value": 1,
+            "label": "valid setting",
+            "desc": "a valid configuration from BOOTP, DHCP, or NV mem"
+          },
+          {
+            "name": "VALID_HW",
+            "value": 2,
+            "label": "valid hardware",
+            "desc": "a valid configuration from hardware settings"
+          }
+        ]
+      },
+      {
+        "name": "ChgSt",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Change Status",
+        "desc": "Bitmask value.  A configuration change is pending",
+        "symbols": [
+          {
+            "name": "PENDING",
+            "value": 0,
+            "label": "pending",
+            "desc": "a configuration change is pending"
+          }
+        ]
+      },
+      {
+        "name": "Cap",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Config Capability",
+        "desc": "Bitmask value. Identify capable sources of configuration",
+        "symbols": [
+          {
+            "name": "DHCP",
+            "value": 0,
+            "label": "DHCP",
+            "desc": "DHCP Client capable"
+          },
+          {
+            "name": "BOOTP",
+            "value": 1,
+            "label": "BOOTP",
+            "desc": "BOOTP client capable"
+          },
+          {
+            "name": "ZEROCONF",
+            "value": 2,
+            "label": "zeroconf",
+            "desc": "Zeroconf capable"
+          },
+          {
+            "name": "DNS",
+            "value": 3,
+            "label": "DNS",
+            "desc": "DNS Client capable"
+          },
+          {
+            "name": "CFG_SETTABLE",
+            "value": 4,
+            "label": "configurable",
+            "desc": "Settable configuration capable"
+          },
+          {
+            "name": "HW_CONFIG",
+            "value": 5,
+            "label": "hw",
+            "desc": "Hardware configuration capable"
+          },
+          {
+            "name": "NTP_CLIENT",
+            "value": 6,
+            "label": "ntp",
+            "desc": "NTP Client capable"
+          },
+          {
+            "name": "RESET_REQUIRED",
+            "value": 7,
+            "label": "reset required",
+            "desc": "configuration change requires reset"
+          }
+        ]
+      },
+      {
+        "name": "Cfg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "IPv6 Config",
+        "desc": "Enumerated value.  Configuration method used.",
+        "symbols": [
+          {
+            "name": "STATIC",
+            "value": 0,
+            "label": "static",
+            "desc": "Use static IP"
+          },
+          {
+            "name": "DHCP",
+            "value": 1,
+            "label": "DHCP",
+            "desc": "Use DHCP"
+          },
+          {
+            "name": "BOOTP",
+            "value": 2,
+            "label": "BOOTP",
+            "desc": "Use BOOTP"
+          },
+          {
+            "name": "ZEROCONF",
+            "value": 3,
+            "label": "zeroconf",
+            "desc": "Use Zeroconf"
+          }
+        ]
+      },
+      {
+        "name": "Ctl",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Control",
+        "desc": "Bitmask value.  Configure use of services",
+        "symbols": [
+          {
+            "name": "ENABLE_DNS",
+            "value": 0,
+            "label": "DNS",
+            "desc": "Enable DNS"
+          },
+          {
+            "name": "ENABLE_NTP",
+            "value": 1,
+            "label": "NTP",
+            "desc": "Enable NTP"
+          }
+        ]
+      },
+      {
+        "name": "Addr",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "IP",
+        "desc": "IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "CIDR",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "CIDR",
+        "desc": "Classless Inter-Domain Routing Number"
+      },
+      {
+        "name": "Gw",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Gateway",
+        "desc": "IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "DNS1",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "DNS1",
+        "desc": "IPv6 numeric DNS address as a dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "DNS2",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "DNS2",
+        "desc": "IPv6 numeric DNS address as a dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "NTP1",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "NTP1",
+        "desc": "IPv6 numeric NTP address as a name or dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "NTP2",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "NTP2",
+        "desc": "IPv6 numeric NTP address as a name or dotted string xxxx.xxxx.xxxx.xxxx"
+      },
+      {
+        "name": "DomNam",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Domain",
+        "desc": "Domain name (24 chars max)"
+      },
+      {
+        "name": "HostNam",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Host Name",
+        "desc": "Host name (24 chars max)"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 13
+}

--- a/models/model_130.json
+++ b/models/model_130.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "hvrt",
+    "type": "group",
+    "label": "HVRTD",
+    "desc": "HVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 130
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 130
+}

--- a/models/model_131.json
+++ b/models/model_131.json
@@ -1,0 +1,600 @@
+{
+  "group": {
+    "name": "watt_pf",
+    "type": "group",
+    "label": "Watt-PF",
+    "desc": "Watt-Power Factor ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 131
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is watt-PF mode active.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for watt-PF change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for watt-PF curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Max number of points in array."
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "W_SF",
+        "desc": "Scale factor for percent WMax."
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PF_SF",
+        "desc": "Scale factor for PF."
+      },
+      {
+        "name": "RmpIncDec_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "RmpIncDec_SF",
+        "desc": "Scale factor for increment and decrement ramps."
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "W1",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "W1",
+            "desc": "Point 1 Watts."
+          },
+          {
+            "name": "PF1",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "PF1",
+            "desc": "Point 1 PF in EEI notation."
+          },
+          {
+            "name": "W2",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W2",
+            "desc": "Point 2 Watts."
+          },
+          {
+            "name": "PF2",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF2",
+            "desc": "Point 2 PF in EEI notation."
+          },
+          {
+            "name": "W3",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W3",
+            "desc": "Point 3 Watts."
+          },
+          {
+            "name": "PF3",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF3",
+            "desc": "Point 3 PF in EEI notation."
+          },
+          {
+            "name": "W4",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W4",
+            "desc": "Point 4 Watts."
+          },
+          {
+            "name": "PF4",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF4",
+            "desc": "Point 4 PF in EEI notation."
+          },
+          {
+            "name": "W5",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W5",
+            "desc": "Point 5 Watts."
+          },
+          {
+            "name": "PF5",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF5",
+            "desc": "Point 5 PF in EEI notation."
+          },
+          {
+            "name": "W6",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W6",
+            "desc": "Point 6 Watts."
+          },
+          {
+            "name": "PF6",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF6",
+            "desc": "Point 6 PF in EEI notation."
+          },
+          {
+            "name": "W7",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W7",
+            "desc": "Point 7 Watts."
+          },
+          {
+            "name": "PF7",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF7",
+            "desc": "Point 7 PF in EEI notation."
+          },
+          {
+            "name": "W8",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W8",
+            "desc": "Point 8 Watts."
+          },
+          {
+            "name": "PF8",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF8",
+            "desc": "Point 8 PF in EEI notation."
+          },
+          {
+            "name": "W9",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W9",
+            "desc": "Point 9 Watts."
+          },
+          {
+            "name": "PF9",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF9",
+            "desc": "Point 9 PF in EEI notation."
+          },
+          {
+            "name": "W10",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W10",
+            "desc": "Point 10 Watts."
+          },
+          {
+            "name": "PF10",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF10",
+            "desc": "Point 10 PF in EEI notation."
+          },
+          {
+            "name": "W11",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W11",
+            "desc": "Point 11 Watts."
+          },
+          {
+            "name": "PF11",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF11",
+            "desc": "Point 11 PF in EEI notation."
+          },
+          {
+            "name": "W12",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W12",
+            "desc": "Point 12 Watts."
+          },
+          {
+            "name": "PF12",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF12",
+            "desc": "Point 12 PF in EEI notation."
+          },
+          {
+            "name": "W13",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W13",
+            "desc": "Point 13 Watts."
+          },
+          {
+            "name": "PF13",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF13",
+            "desc": "Point 13 PF in EEI notation."
+          },
+          {
+            "name": "W14",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W14",
+            "desc": "Point 14 Watts."
+          },
+          {
+            "name": "PF14",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF14",
+            "desc": "Point 14 PF in EEI notation."
+          },
+          {
+            "name": "W15",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W15",
+            "desc": "Point 15 Watts."
+          },
+          {
+            "name": "PF15",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF15",
+            "desc": "Point 15 PF in EEI notation."
+          },
+          {
+            "name": "W16",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W16",
+            "desc": "Point 16 Watts."
+          },
+          {
+            "name": "PF16",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF16",
+            "desc": "Point 16 PF in EEI notation."
+          },
+          {
+            "name": "W17",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W17",
+            "desc": "Point 17 Watts."
+          },
+          {
+            "name": "PF17",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF17",
+            "desc": "Point 17 PF in EEI notation."
+          },
+          {
+            "name": "W18",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W18",
+            "desc": "Point 18 Watts."
+          },
+          {
+            "name": "PF18",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF18",
+            "desc": "Point 18 PF in EEI notation."
+          },
+          {
+            "name": "W19",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W19",
+            "desc": "Point 19 Watts."
+          },
+          {
+            "name": "PF19",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF19",
+            "desc": "Point 19 PF in EEI notation."
+          },
+          {
+            "name": "W20",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WMax",
+            "access": "RW",
+            "label": "W20",
+            "desc": "Point 20 Watts."
+          },
+          {
+            "name": "PF20",
+            "type": "int16",
+            "size": 1,
+            "sf": "PF_SF",
+            "units": "cos()",
+            "access": "RW",
+            "label": "PF20",
+            "desc": "Point 20 PF in EEI notation."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "RmpPT1Tms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "RmpPT1Tms",
+            "desc": "The time of the PT1 in seconds (time to accomplish a change of 95%)."
+          },
+          {
+            "name": "RmpDecTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%PF/min",
+            "access": "RW",
+            "label": "RmpDecTmm",
+            "desc": "The maximum rate at which the power factor may be reduced in response to changes in the power value."
+          },
+          {
+            "name": "RmpIncTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%PF/min",
+            "access": "RW",
+            "label": "RmpIncTmm",
+            "desc": "The maximum rate at which the power factor may be increased in response to changes in the power value."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Pad",
+            "type": "pad",
+            "size": 1
+          }
+        ]
+      }
+    ]
+  },
+  "id": 131
+}

--- a/models/model_132.json
+++ b/models/model_132.json
@@ -1,0 +1,614 @@
+{
+  "group": {
+    "name": "volt_watt",
+    "type": "group",
+    "label": "Volt-Watt",
+    "desc": "Volt-Watt ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 132
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is Volt-Watt control active",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for volt-watt change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for volt-watt curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend min. 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of points in array (maximum 20)"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef"
+      },
+      {
+        "name": "DeptRef_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "DeptRef_SF",
+        "desc": "Scale Factor for %DeptRef"
+      },
+      {
+        "name": "RmpIncDec_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "RmpIncDec_SF",
+        "desc": "Scale factor for increment and decrement ramps"
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "DeptRef",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "DeptRef",
+            "desc": "Meaning of dependent variable: 1=%WMax 2=%WAvail",
+            "symbols": [
+              {
+                "name": "%WMax",
+                "value": 1
+              },
+              {
+                "name": "%WAval",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 Volts"
+          },
+          {
+            "name": "W1",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "W1",
+            "desc": "Point 1 Watts"
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 Volts"
+          },
+          {
+            "name": "W2",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W2",
+            "desc": "Point 2 Watts"
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 Volts"
+          },
+          {
+            "name": "W3",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W3",
+            "desc": "Point 3 Watts"
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 Volts"
+          },
+          {
+            "name": "W4",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W4",
+            "desc": "Point 4 Watts"
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 Volts"
+          },
+          {
+            "name": "W5",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W5",
+            "desc": "Point 5 Watts"
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 Volts"
+          },
+          {
+            "name": "W6",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W6",
+            "desc": "Point 6 Watts"
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 Volts"
+          },
+          {
+            "name": "W7",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W7",
+            "desc": "Point 7 Watts"
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 Volts"
+          },
+          {
+            "name": "W8",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W8",
+            "desc": "Point 8 Watts"
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 Volts"
+          },
+          {
+            "name": "W9",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W9",
+            "desc": "Point 9 Watts"
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 Volts"
+          },
+          {
+            "name": "W10",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W10",
+            "desc": "Point 10 Watts"
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 Volts"
+          },
+          {
+            "name": "W11",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W11",
+            "desc": "Point 11 Watts"
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 Volts"
+          },
+          {
+            "name": "W12",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W12",
+            "desc": "Point 12 Watts"
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 Volts"
+          },
+          {
+            "name": "W13",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W13",
+            "desc": "Point 13 Watts"
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 Volts"
+          },
+          {
+            "name": "W14",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W14",
+            "desc": "Point 14 Watts"
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 Volts"
+          },
+          {
+            "name": "W15",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W15",
+            "desc": "Point 15 Watts"
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 Volts"
+          },
+          {
+            "name": "W16",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W16",
+            "desc": "Point 16 Watts"
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 Volts"
+          },
+          {
+            "name": "W17",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W17",
+            "desc": "Point 17 Watts"
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 Volts"
+          },
+          {
+            "name": "W18",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W18",
+            "desc": "Point 18 Watts"
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 Volts"
+          },
+          {
+            "name": "W19",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W19",
+            "desc": "Point 19 Watts"
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 Volts"
+          },
+          {
+            "name": "W20",
+            "type": "int16",
+            "size": 1,
+            "sf": "DeptRef_SF",
+            "units": "%DeptRef",
+            "access": "RW",
+            "label": "W20",
+            "desc": "Point 20 Watts"
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "RmpPt1Tms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "RmpPt1Tms",
+            "desc": "The time of the PT1 in seconds (time to accomplish a change of 95%)"
+          },
+          {
+            "name": "RmpDecTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%WMax/min",
+            "access": "RW",
+            "label": "RmpDecTmm",
+            "desc": "The maximum rate at which the watt value may be reduced in response to changes in the voltage value"
+          },
+          {
+            "name": "RmpIncTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%WMax/min",
+            "access": "RW",
+            "label": "RmpIncTmm",
+            "desc": "The maximum rate at which the watt value may be increased in response to changes in the voltage value"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 132
+}

--- a/models/model_133.json
+++ b/models/model_133.json
@@ -1,0 +1,623 @@
+{
+  "group": {
+    "name": "schedule",
+    "type": "group",
+    "label": "Basic Scheduling",
+    "desc": "Basic Scheduling ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 133
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActSchd",
+        "type": "bitfield32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActSchd",
+        "desc": "Bitfield of active schedules",
+        "symbols": [
+          {
+            "name": "SCHED1",
+            "value": 0
+          },
+          {
+            "name": "SCHED2",
+            "value": 1
+          },
+          {
+            "name": "SCHED3",
+            "value": 2
+          },
+          {
+            "name": "SCHED4",
+            "value": 3
+          },
+          {
+            "name": "SCHED5",
+            "value": 4
+          },
+          {
+            "name": "SCHED6",
+            "value": 5
+          },
+          {
+            "name": "SCHED7",
+            "value": 6
+          },
+          {
+            "name": "SCHED8",
+            "value": 7
+          },
+          {
+            "name": "SCHED9",
+            "value": 8
+          },
+          {
+            "name": "SCHED10",
+            "value": 9
+          },
+          {
+            "name": "SCHED11",
+            "value": 10
+          },
+          {
+            "name": "SCHED12",
+            "value": 11
+          },
+          {
+            "name": "SCHED13",
+            "value": 12
+          },
+          {
+            "name": "SCHED14",
+            "value": 13
+          },
+          {
+            "name": "SCHED15",
+            "value": 14
+          },
+          {
+            "name": "SCHED16",
+            "value": 15
+          },
+          {
+            "name": "SCHED17",
+            "value": 16
+          },
+          {
+            "name": "SCHED18",
+            "value": 17
+          },
+          {
+            "name": "SCHED19",
+            "value": 18
+          },
+          {
+            "name": "SCHED20",
+            "value": 19
+          },
+          {
+            "name": "SCHED21",
+            "value": 20
+          },
+          {
+            "name": "SCHED22",
+            "value": 21
+          },
+          {
+            "name": "SCHED23",
+            "value": 22
+          },
+          {
+            "name": "SCHED24",
+            "value": 23
+          },
+          {
+            "name": "SCHED25",
+            "value": 24
+          },
+          {
+            "name": "SCHED26",
+            "value": 25
+          },
+          {
+            "name": "SCHED27",
+            "value": 26
+          },
+          {
+            "name": "SCHED28",
+            "value": 27
+          },
+          {
+            "name": "SCHED29",
+            "value": 28
+          },
+          {
+            "name": "SCHED30",
+            "value": 29
+          },
+          {
+            "name": "SCHED31",
+            "value": 30
+          },
+          {
+            "name": "SCHED32",
+            "value": 31
+          }
+        ]
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is basic scheduling active.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "NSchd",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NSchd",
+        "desc": "Number of schedules supported (recommend min. 4, max 32)"
+      },
+      {
+        "name": "NPts",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPts",
+        "desc": "Number of schedule entries supported (maximum of 10)."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "label": "Pad",
+        "desc": "Pad register."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPts",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPts",
+            "desc": "Number of active entries in schedule."
+          },
+          {
+            "name": "StrTms",
+            "type": "uint32",
+            "size": 2,
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "StrTms",
+            "desc": "Schedule start in seconds since 2000 JAN 01 00:00:00 UTC."
+          },
+          {
+            "name": "RepPer",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "RepPer",
+            "desc": "The repetition count for time-based schedules (0=repeat forever)"
+          },
+          {
+            "name": "IntvTyp",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "SchdTyp",
+            "desc": "The repetition frequency for time-based schedules: no repeat=0",
+            "symbols": [
+              {
+                "name": "ONETIME",
+                "value": 0
+              },
+              {
+                "name": "DAILY",
+                "value": 1
+              },
+              {
+                "name": "WEEKLY",
+                "value": 2
+              },
+              {
+                "name": "MONTHLY",
+                "value": 3
+              },
+              {
+                "name": "WEEKDAY",
+                "value": 4
+              },
+              {
+                "name": "HOLIDAY",
+                "value": 5
+              },
+              {
+                "name": "WEEKEND",
+                "value": 6
+              },
+              {
+                "name": "YEARLY",
+                "value": 7
+              }
+            ]
+          },
+          {
+            "name": "XTyp",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "XTyp",
+            "desc": "The meaning of the X-values in the array. ",
+            "symbols": [
+              {
+                "name": "UNSET",
+                "value": 0
+              },
+              {
+                "name": "TIME",
+                "value": 1
+              },
+              {
+                "name": "TEMP",
+                "value": 2
+              },
+              {
+                "name": "PRICE",
+                "value": 3
+              },
+              {
+                "name": "OTHER",
+                "value": 99
+              },
+              {
+                "name": "MONTH_DAY",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "name": "X_SF",
+            "type": "sunssf",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "X_SF",
+            "desc": "Scale factor for schedule range values."
+          },
+          {
+            "name": "YTyp",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "YTyp",
+            "desc": "The meaning of the Y-values in the array.",
+            "symbols": [
+              {
+                "name": "UNSET",
+                "value": 0
+              },
+              {
+                "name": "WMax",
+                "value": 1
+              },
+              {
+                "name": "RSRVD2",
+                "value": 2
+              },
+              {
+                "name": "PF",
+                "value": 3
+              },
+              {
+                "name": "RSRVD4",
+                "value": 4
+              },
+              {
+                "name": "WATT_PRICE",
+                "value": 5
+              },
+              {
+                "name": "VAR_PRICE",
+                "value": 6
+              },
+              {
+                "name": "RSRVD7",
+                "value": 7
+              },
+              {
+                "name": "VOLT_VAR_ARRAY",
+                "value": 8
+              },
+              {
+                "name": "WChaGra",
+                "value": 9
+              },
+              {
+                "name": "WDisChaGra",
+                "value": 10
+              },
+              {
+                "name": "VArAval",
+                "value": 11
+              },
+              {
+                "name": "Schedule",
+                "value": 12
+              },
+              {
+                "name": "OTHER",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "name": "Y_SF",
+            "type": "sunssf",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Y_SF",
+            "desc": "Scale factor for schedule target values."
+          },
+          {
+            "name": "X1",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "X1",
+            "desc": "Entry 1 range."
+          },
+          {
+            "name": "Y1",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Y1",
+            "desc": "Entry 1 target."
+          },
+          {
+            "name": "X2",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X2",
+            "desc": "Entry 2 range."
+          },
+          {
+            "name": "Y2",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y2",
+            "desc": "Entry 2 target."
+          },
+          {
+            "name": "X3",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X3",
+            "desc": "Entry 3 range."
+          },
+          {
+            "name": "Y3",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y3",
+            "desc": "Entry 3 target."
+          },
+          {
+            "name": "X4",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X4",
+            "desc": "Entry 4 range."
+          },
+          {
+            "name": "Y4",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y4",
+            "desc": "Entry 4 target."
+          },
+          {
+            "name": "X5",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X5",
+            "desc": "Entry 15range."
+          },
+          {
+            "name": "Y5",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y5",
+            "desc": "Entry 5 target."
+          },
+          {
+            "name": "X6",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X6",
+            "desc": "Entry 6 range."
+          },
+          {
+            "name": "Y6",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y6",
+            "desc": "Entry 6 target."
+          },
+          {
+            "name": "X7",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X7",
+            "desc": "Entry 7 range."
+          },
+          {
+            "name": "Y7",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y7",
+            "desc": "Entry 7 target."
+          },
+          {
+            "name": "X8",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X8",
+            "desc": "Entry 8 range."
+          },
+          {
+            "name": "Y8",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y8",
+            "desc": "Entry 8 target."
+          },
+          {
+            "name": "X9",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X9",
+            "desc": "Entry 9 range."
+          },
+          {
+            "name": "Y9",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y9",
+            "desc": "Entry 9 target."
+          },
+          {
+            "name": "X10",
+            "type": "int32",
+            "size": 2,
+            "sf": "X_SF",
+            "access": "RW",
+            "label": "X10",
+            "desc": "Entry 10 range."
+          },
+          {
+            "name": "Y10",
+            "type": "int32",
+            "size": 2,
+            "sf": "Y_SF",
+            "access": "RW",
+            "label": "Y10",
+            "desc": "Entry 10 target."
+          },
+          {
+            "name": "Nam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "Nam",
+            "desc": "Optional description for schedule."
+          },
+          {
+            "name": "WinTms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "WinTms",
+            "desc": "Time window for schedule entry change."
+          },
+          {
+            "name": "RmpTms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "RmpTms",
+            "desc": "Ramp time for moving from current target to new target."
+          },
+          {
+            "name": "ActIndx",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ActIndx",
+            "desc": "Index of active entry in the active schedule."
+          }
+        ]
+      }
+    ]
+  },
+  "id": 133
+}

--- a/models/model_134.json
+++ b/models/model_134.json
@@ -1,0 +1,647 @@
+{
+  "group": {
+    "name": "freq_watt",
+    "type": "group",
+    "label": "Freq-Watt Crv",
+    "desc": "Curve-Based Frequency-Watt ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 134
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Is curve-based Frequency-Watt control active",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for freq-watt change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for freq-watt curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend min. 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 10)"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "units": "SF",
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "units": "SF",
+        "mandatory": "M",
+        "label": "W_SF",
+        "desc": "Scale factor for percent WRef"
+      },
+      {
+        "name": "RmpIncDec_SF",
+        "type": "sunssf",
+        "size": 1,
+        "units": "SF",
+        "label": "RmpIncDec_SF",
+        "desc": "Scale factor for increment and decrement ramps"
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 Hertz"
+          },
+          {
+            "name": "W1",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "W1",
+            "desc": "Point 1 Watts"
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 Hertz"
+          },
+          {
+            "name": "W2",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W2",
+            "desc": "Point 2 Watts"
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 Hertz"
+          },
+          {
+            "name": "W3",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W3",
+            "desc": "Point 3 Watts"
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 Hertz"
+          },
+          {
+            "name": "W4",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W4",
+            "desc": "Point 4 Watts"
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 Hertz"
+          },
+          {
+            "name": "W5",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W5",
+            "desc": "Point 5 Watts"
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 Hertz"
+          },
+          {
+            "name": "W6",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W6",
+            "desc": "Point 6 Watts"
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 Hertz"
+          },
+          {
+            "name": "W7",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W7",
+            "desc": "Point 7 Watts"
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 Hertz"
+          },
+          {
+            "name": "W8",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W8",
+            "desc": "Point 8 Watts"
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 Hertz"
+          },
+          {
+            "name": "W9",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W9",
+            "desc": "Point 9 Watts"
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 Hertz"
+          },
+          {
+            "name": "W10",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W10",
+            "desc": "Point 10 Watts"
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 Hertz"
+          },
+          {
+            "name": "W11",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W11",
+            "desc": "Point 11 Watts"
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 Hertz"
+          },
+          {
+            "name": "W12",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W12",
+            "desc": "Point 12 Watts"
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 Hertz"
+          },
+          {
+            "name": "W13",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W13",
+            "desc": "Point 13 Watts"
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 Hertz"
+          },
+          {
+            "name": "W14",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W14",
+            "desc": "Point 14 Watts"
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 Hertz"
+          },
+          {
+            "name": "W15",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W15",
+            "desc": "Point 15 Watts"
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 Hertz"
+          },
+          {
+            "name": "W16",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W16",
+            "desc": "Point 16 Watts"
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 Hertz"
+          },
+          {
+            "name": "W17",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W17",
+            "desc": "Point 17 Watts"
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 Hertz"
+          },
+          {
+            "name": "W18",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W18",
+            "desc": "Point 18 Watts"
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 Hertz"
+          },
+          {
+            "name": "W19",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W19",
+            "desc": "Point 19 Watts"
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 Hertz"
+          },
+          {
+            "name": "W20",
+            "type": "int16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "%WRef",
+            "access": "RW",
+            "label": "W20",
+            "desc": "Point 20 Watts"
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve. (Max 16 chars)"
+          },
+          {
+            "name": "RmpPT1Tms",
+            "type": "uint16",
+            "size": 1,
+            "units": "Secs",
+            "access": "RW",
+            "label": "RmpPT1Tms",
+            "desc": "The time of the PT1 in seconds (time to accomplish a change of 95%)"
+          },
+          {
+            "name": "RmpDecTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%WMax/min",
+            "access": "RW",
+            "label": "RmpDecTmm",
+            "desc": "The maximum rate at which the power value may be reduced in response to changes in the frequency value"
+          },
+          {
+            "name": "RmpIncTmm",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%WMax/min",
+            "access": "RW",
+            "label": "RmpIncTmm",
+            "desc": "The maximum rate at which the power value may be increased in response to changes in the frequency value"
+          },
+          {
+            "name": "RmpRsUp",
+            "type": "uint16",
+            "size": 1,
+            "sf": "RmpIncDec_SF",
+            "units": "%WMax/min",
+            "access": "RW",
+            "label": "RmpRsUp",
+            "desc": "The maximum rate at which the power may be increased after releasing the frozen value of snap shot function. "
+          },
+          {
+            "name": "SnptW",
+            "type": "bitfield16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "SnptW",
+            "desc": "1=enable snapshot/capture mode"
+          },
+          {
+            "name": "WRef",
+            "type": "uint16",
+            "size": 1,
+            "sf": "W_SF",
+            "units": "W",
+            "access": "RW",
+            "label": "WRef",
+            "desc": "Reference active power (default = WMax)"
+          },
+          {
+            "name": "WRefStrHz",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "WRefStrHz",
+            "desc": "Frequency deviation from nominal frequency at the time of the snapshot to start constraining power output"
+          },
+          {
+            "name": "WRefStopHz",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "WRefStopHz",
+            "desc": "Frequency deviation from nominal frequency at which to release the power output"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 134
+}

--- a/models/model_135.json
+++ b/models/model_135.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "lfrt",
+    "type": "group",
+    "label": "LFRT",
+    "desc": "Low Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 135
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 135
+}

--- a/models/model_136.json
+++ b/models/model_136.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "hfrt",
+    "type": "group",
+    "label": "HFRT",
+    "desc": "High Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 136
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HFRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 136
+}

--- a/models/model_137.json
+++ b/models/model_137.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "lvrtc",
+    "type": "group",
+    "label": "LVRTC",
+    "desc": "LVRT must remain connected",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 137
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must remain connected duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must remain connected voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must remain connected duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must remain connected voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must remain connected duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must remain connected voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must remain connected duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must remain connected voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must remain connected duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must remain connected voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must remain connected duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must remain connected voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must remain connected duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must remain connected voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must remain connected duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must remain connected voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must remain connected duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must remain connected voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must remain connected duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must remain connected voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must remain connected duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must remain connected voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must remain connected duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must remain connected voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must remain connected duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must remain connected voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must remain connected duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must remain connected voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must remain connected duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must remain connected voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must remain connected duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must remain connected voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must remain connected duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must remain connected voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must remain connected duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must remain connected voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must remain connected duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must remain connected voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must remain connected duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must remain connected voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 137
+}

--- a/models/model_138.json
+++ b/models/model_138.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "hvrtc",
+    "type": "group",
+    "label": "HVRTC",
+    "desc": "HVRT must remain connected",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 138
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must remain connected duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must remain connected voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must remain connected duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must remain connected voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must remain connected duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must remain connected voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must remain connected duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must remain connected voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must remain connected duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must remain connected voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must remain connected duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must remain connected voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must remain connected duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must remain connected voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must remain connected duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must remain connected voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must remain connected duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must remain connected voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must remain connected duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must remain connected voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must remain connected duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must remain connected voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must remain connected duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must remain connected voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must remain connected duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must remain connected voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must remain connected duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must remain connected voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must remain connected duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must remain connected voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must remain connected duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must remain connected voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must remain connected duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must remain connected voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must remain connected duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must remain connected voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must remain connected duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must remain connected voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must remain connected duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must remain connected voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 138
+}

--- a/models/model_139.json
+++ b/models/model_139.json
@@ -1,0 +1,571 @@
+{
+  "group": {
+    "name": "lvrtx",
+    "type": "group",
+    "label": "LVRTX",
+    "desc": "LVRT extended curve",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 139
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "CrvType",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "CEASE_TO_ENERGIZE",
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 139
+}

--- a/models/model_14.json
+++ b/models/model_14.json
@@ -1,0 +1,119 @@
+{
+  "group": {
+    "name": "model_14",
+    "type": "group",
+    "label": "Proxy Server",
+    "desc": "Include this block to allow for a proxy server",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 14
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "name",
+        "desc": "Interface name (8 chars)"
+      },
+      {
+        "name": "Cap",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Capabilities",
+        "desc": "Bitmask value.  Proxy configuration capabilities",
+        "symbols": [
+          {
+            "name": "NO_PROXY",
+            "value": 0,
+            "label": "No Proxy",
+            "desc": "Turn off the proxy"
+          },
+          {
+            "name": "IPV4_PROXY",
+            "value": 1,
+            "label": "IPv4 Proxy",
+            "desc": "Can proxy IPv4"
+          },
+          {
+            "name": "IPV6_PROXY",
+            "value": 2,
+            "label": "IPv6 Proxy",
+            "desc": "Can proxy IPv6"
+          }
+        ]
+      },
+      {
+        "name": "Cfg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Config",
+        "desc": "Enumerated value.  Set proxy address type"
+      },
+      {
+        "name": "Typ",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Type",
+        "desc": "Enumerate value.  Proxy server type"
+      },
+      {
+        "name": "Addr",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Address",
+        "desc": "IPv4 or IPv6 proxy hostname or dotted address (40 chars)"
+      },
+      {
+        "name": "Port",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Port",
+        "desc": "Proxy port number"
+      },
+      {
+        "name": "User",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Username",
+        "desc": "Proxy user name"
+      },
+      {
+        "name": "Pw",
+        "type": "string",
+        "size": 12,
+        "access": "RW",
+        "label": "Password",
+        "desc": "Proxy password"
+      }
+    ]
+  },
+  "id": 14
+}

--- a/models/model_140.json
+++ b/models/model_140.json
@@ -1,0 +1,571 @@
+{
+  "group": {
+    "name": "hvrtx",
+    "type": "group",
+    "label": "HVRTX",
+    "desc": "HVRT extended curve",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 140
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "CrvType",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "CEASE_TO_ENERGIZE",
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 voltage."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 voltage."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 voltage."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 voltage."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 voltage."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 voltage."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 voltage."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 voltage."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 voltage."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 voltage."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 voltage."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 voltage."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 voltage."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 voltage."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 voltage."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 voltage."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 voltage."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 voltage."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 voltage."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 voltage."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 140
+}

--- a/models/model_141.json
+++ b/models/model_141.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "lfrtc",
+    "type": "group",
+    "label": "LFRTC",
+    "desc": "LFRT must remain connected",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 141
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must remain connected duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must remain connected frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must remain connected duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must remain connected frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must remain connected duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must remain connected frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must remain connected duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must remain connected frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must remain connected duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must remain connected frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must remain connected duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must remain connected frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must remain connected duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must remain connected frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must remain connected duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must remain connected frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must remain connected duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must remain connected frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must remain connected duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must remain connected frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must remain connected duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must remain connected frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must remain connected duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must remain connected frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must remain connected duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must remain connected frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must remain connected duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must remain connected frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must remain connected duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must remain connected frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must remain connected duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must remain connected frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must remain connected duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must remain connected frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must remain connected duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must remain connected frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must remain connected duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must remain connected frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must remain connected duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must remain connected frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 141
+}

--- a/models/model_142.json
+++ b/models/model_142.json
@@ -1,0 +1,564 @@
+{
+  "group": {
+    "name": "hfrtc",
+    "type": "group",
+    "label": "HFRTC",
+    "desc": "HFRT must remain connected",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 142
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must remain connected duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must remain connected frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must remain connected duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must remain connected frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must remain connected duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must remain connected frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must remain connected duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must remain connected frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must remain connected duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must remain connected frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must remain connected duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must remain connected frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must remain connected duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must remain connected frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must remain connected duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must remain connected frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must remain connected duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must remain connected frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must remain connected duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must remain connected frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must remain connected duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must remain connected frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must remain connected duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must remain connected frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must remain connected duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must remain connected frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must remain connected duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must remain connected frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must remain connected duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must remain connected frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must remain connected duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must remain connected frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must remain connected duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must remain connected frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must remain connected duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must remain connected frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must remain connected duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must remain connected frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must remain connected duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must remain connected frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 142
+}

--- a/models/model_143.json
+++ b/models/model_143.json
@@ -1,0 +1,571 @@
+{
+  "group": {
+    "name": "lfrtx",
+    "type": "group",
+    "label": "LFRTX",
+    "desc": "LFRT extended curve",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 143
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "CrvType",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "CEASE_TO_ENERGIZE",
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 143
+}

--- a/models/model_144.json
+++ b/models/model_144.json
@@ -1,0 +1,571 @@
+{
+  "group": {
+    "name": "hfrtx",
+    "type": "group",
+    "label": "HFRTX",
+    "desc": "HFRT extended curve",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 144
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "CrvType",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "CEASE_TO_ENERGIZE",
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 duration."
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 frequency."
+          },
+          {
+            "name": "Tms2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 duration."
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 frequency."
+          },
+          {
+            "name": "Tms3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 duration."
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 frequency."
+          },
+          {
+            "name": "Tms4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 duration."
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 frequency."
+          },
+          {
+            "name": "Tms5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 duration."
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 frequency."
+          },
+          {
+            "name": "Tms6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 duration."
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 frequency."
+          },
+          {
+            "name": "Tms7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 duration."
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 frequency."
+          },
+          {
+            "name": "Tms8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 duration."
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 frequency."
+          },
+          {
+            "name": "Tms9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 duration."
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 frequency."
+          },
+          {
+            "name": "Tms10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 duration."
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 frequency."
+          },
+          {
+            "name": "Tms11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 duration."
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 frequency."
+          },
+          {
+            "name": "Tms12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 duration."
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 frequency."
+          },
+          {
+            "name": "Tms13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 duration."
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 frequency."
+          },
+          {
+            "name": "Tms14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 duration."
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 frequency."
+          },
+          {
+            "name": "Tms15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 duration."
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 frequency."
+          },
+          {
+            "name": "Tms16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 duration."
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 frequency."
+          },
+          {
+            "name": "Tms17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 duration."
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 frequency."
+          },
+          {
+            "name": "Tms18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 duration."
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 frequency."
+          },
+          {
+            "name": "Tms19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 duration."
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 frequency."
+          },
+          {
+            "name": "Tms20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 duration."
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 frequency."
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 144
+}

--- a/models/model_145.json
+++ b/models/model_145.json
@@ -1,0 +1,107 @@
+{
+  "group": {
+    "name": "ext_settings",
+    "type": "group",
+    "label": "Extended Settings",
+    "desc": "Inverter controls extended settings ",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 145
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "NomRmpUpRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Ramp Up Rate",
+        "desc": "Ramp up rate as a percentage of max current."
+      },
+      {
+        "name": "NomRmpDnRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "NomRmpDnRte",
+        "desc": "Ramp down rate as a percentage of max current."
+      },
+      {
+        "name": "EmgRmpUpRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Emergency Ramp Up Rate",
+        "desc": "Emergency ramp up rate as a percentage of max current."
+      },
+      {
+        "name": "EmgRmpDnRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Emergency Ramp Down Rate",
+        "desc": "Emergency ramp down rate as a percentage of max current."
+      },
+      {
+        "name": "ConnRmpUpRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Connect Ramp Up Rate",
+        "desc": "Connect ramp up rate as a percentage of max current."
+      },
+      {
+        "name": "ConnRmpDnRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Connect Ramp Down Rate",
+        "desc": "Connect ramp down rate as a percentage of max current."
+      },
+      {
+        "name": "AGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Default Ramp Rate",
+        "desc": "Ramp rate specified in percent of max current."
+      },
+      {
+        "name": "Rmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Ramp Rate Scale Factor",
+        "desc": "Ramp Rate Scale Factor"
+      }
+    ]
+  },
+  "id": 145
+}

--- a/models/model_15.json
+++ b/models/model_15.json
@@ -1,0 +1,120 @@
+{
+  "group": {
+    "name": "model_15",
+    "type": "group",
+    "label": "Interface Counters Model",
+    "desc": "Interface counters",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 15
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Clr",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "label": "Clear",
+        "desc": "Write a \"1\" to clear all counters"
+      },
+      {
+        "name": "InCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Count",
+        "desc": "Number of bytes received"
+      },
+      {
+        "name": "InUcCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Unicast Count",
+        "desc": "Number of Unicast packets received"
+      },
+      {
+        "name": "InNUcCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Non-Unicast Count",
+        "desc": "Number of non-Unicast packets received"
+      },
+      {
+        "name": "InDscCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Discarded Count",
+        "desc": "Number of inbound packets received on the interface but discarded"
+      },
+      {
+        "name": "InErrCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Error Count",
+        "desc": "Number of inbound packets that contain errors (excluding discards)"
+      },
+      {
+        "name": "InUnkCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Input Unknown Count",
+        "desc": "Number of inbound packets with unknown protocol"
+      },
+      {
+        "name": "OutCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Output Count",
+        "desc": "Total number of bytes transmitted on this interface"
+      },
+      {
+        "name": "OutUcCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Output Unicast Count",
+        "desc": "Number of Unicast packets transmitted"
+      },
+      {
+        "name": "OutNUcCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Output Non-Unicast Count",
+        "desc": "Number of Non-Unicast packets transmitted"
+      },
+      {
+        "name": "OutDscCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Output Discarded Count",
+        "desc": "Number of Discarded output packets"
+      },
+      {
+        "name": "OutErrCnt",
+        "type": "acc32",
+        "size": 2,
+        "label": "Output Error Count",
+        "desc": "Number of outbound error packets"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 15
+}

--- a/models/model_16.json
+++ b/models/model_16.json
@@ -1,0 +1,178 @@
+{
+  "group": {
+    "name": "ip_settings",
+    "type": "group",
+    "label": "Simple IP Network Settings",
+    "desc": "Simple IPv4 network stack configuration",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 16
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name. (8 chars)"
+      },
+      {
+        "name": "Cfg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Config",
+        "desc": "Enumerated value. Force IPv4 configuration method",
+        "symbols": [
+          {
+            "name": "STATIC",
+            "value": 0,
+            "label": "static",
+            "desc": "A static IP address is assigned"
+          },
+          {
+            "name": "DHCP",
+            "value": 1,
+            "label": "DHCP",
+            "desc": "Use DHCP to acquire an IP address"
+          }
+        ]
+      },
+      {
+        "name": "Ctl",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Control",
+        "desc": "Bitmask value Configure use of services",
+        "symbols": [
+          {
+            "name": "ENABLE_DNS",
+            "value": 0,
+            "label": "DNS",
+            "desc": "Enable DNS use"
+          },
+          {
+            "name": "ENABLE_NTP",
+            "value": 1,
+            "label": "NTP",
+            "desc": "Enable NTP use"
+          }
+        ]
+      },
+      {
+        "name": "Addr",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Address",
+        "desc": "IP address"
+      },
+      {
+        "name": "Msk",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Netmask",
+        "desc": "Netmask"
+      },
+      {
+        "name": "Gw",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Gateway",
+        "desc": "Gateway IP address"
+      },
+      {
+        "name": "DNS1",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "DNS1",
+        "desc": "32 bit IP address of DNS server"
+      },
+      {
+        "name": "DNS2",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "DNS2",
+        "desc": "32 bit IP address of DNS server"
+      },
+      {
+        "name": "MAC",
+        "type": "eui48",
+        "size": 4,
+        "label": "MAC",
+        "desc": "IEEE MAC address of this interface"
+      },
+      {
+        "name": "LnkCtl",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "label": "Link Control",
+        "desc": "Bitmask value. Link control flags",
+        "symbols": [
+          {
+            "name": "AUTONEGOTIATE",
+            "value": 0,
+            "label": "auto-negotiate",
+            "desc": "Enable auto-negotiation"
+          },
+          {
+            "name": "FULL_DUPLEX",
+            "value": 1,
+            "label": "full duplex",
+            "desc": "Force full duplex operation"
+          },
+          {
+            "name": "FORCE_10MB",
+            "value": 2,
+            "label": "10Mbs",
+            "desc": "Force 10 Mb/s link speed"
+          },
+          {
+            "name": "FORCE_100MB",
+            "value": 3,
+            "label": "100Mbs",
+            "desc": "Force 100 Mb/s link speed"
+          },
+          {
+            "name": "FORCE_1GB",
+            "value": 4,
+            "label": "1Gbs",
+            "desc": "Force 1 Gb/s link speed"
+          }
+        ]
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 16
+}

--- a/models/model_160.json
+++ b/models/model_160.json
@@ -1,0 +1,415 @@
+{
+  "group": {
+    "name": "mppt",
+    "type": "group",
+    "label": "Multiple MPPT Inverter Extension Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 160
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Current Scale Factor"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Voltage Scale Factor"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Power Scale Factor"
+      },
+      {
+        "name": "DCWH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Energy Scale Factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Global Events",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground Fault"
+          },
+          {
+            "name": "INPUT_OVER_VOLTAGE",
+            "value": 1,
+            "label": "Input Over Voltage"
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 2
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "DC Disconnect"
+          },
+          {
+            "name": "RESERVED_4",
+            "value": 4
+          },
+          {
+            "name": "CABINET_OPEN",
+            "value": 5,
+            "label": "Cabinet Open"
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual Shutdown"
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 7,
+            "label": "Over Temperature"
+          },
+          {
+            "name": "RESERVED_8",
+            "value": 8
+          },
+          {
+            "name": "RESERVED_9",
+            "value": 9
+          },
+          {
+            "name": "RESERVED_10",
+            "value": 10
+          },
+          {
+            "name": "RESERVED_11",
+            "value": 11
+          },
+          {
+            "name": "BLOWN_FUSE",
+            "value": 12,
+            "label": "Blown Fuse"
+          },
+          {
+            "name": "UNDER_TEMP",
+            "value": 13,
+            "label": "Under Temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Memory Loss"
+          },
+          {
+            "name": "ARC_DETECTION",
+            "value": 15,
+            "label": "Arc Detection"
+          },
+          {
+            "name": "RESERVED_16",
+            "value": 16
+          },
+          {
+            "name": "RESERVED_17",
+            "value": 17
+          },
+          {
+            "name": "RESERVED_18",
+            "value": 18
+          },
+          {
+            "name": "RESERVED_19",
+            "value": 19
+          },
+          {
+            "name": "TEST_FAILED",
+            "value": 20,
+            "label": "Test Failed"
+          },
+          {
+            "name": "INPUT_UNDER_VOLTAGE",
+            "value": 21,
+            "label": "Under Voltage"
+          },
+          {
+            "name": "INPUT_OVER_CURRENT",
+            "value": 22,
+            "label": "Over Current"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "count",
+        "size": 1,
+        "label": "Number of Modules"
+      },
+      {
+        "name": "TmsPer",
+        "type": "uint16",
+        "size": 1,
+        "label": "Timestamp Period"
+      }
+    ],
+    "groups": [
+      {
+        "name": "module",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ID",
+            "type": "uint16",
+            "size": 1,
+            "label": "Input ID"
+          },
+          {
+            "name": "IDStr",
+            "type": "string",
+            "size": 8,
+            "label": "Input ID Sting"
+          },
+          {
+            "name": "DCA",
+            "type": "uint16",
+            "size": 1,
+            "sf": "DCA_SF",
+            "units": "A",
+            "label": "DC Current"
+          },
+          {
+            "name": "DCV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "DCV_SF",
+            "units": "V",
+            "label": "DC Voltage"
+          },
+          {
+            "name": "DCW",
+            "type": "uint16",
+            "size": 1,
+            "sf": "DCW_SF",
+            "units": "W",
+            "label": "DC Power"
+          },
+          {
+            "name": "DCWH",
+            "type": "acc32",
+            "size": 2,
+            "sf": "DCWH_SF",
+            "units": "Wh",
+            "label": "Lifetime Energy"
+          },
+          {
+            "name": "Tms",
+            "type": "uint32",
+            "size": 2,
+            "units": "Secs",
+            "label": "Timestamp"
+          },
+          {
+            "name": "Tmp",
+            "type": "int16",
+            "size": 1,
+            "units": "C",
+            "label": "Temperature"
+          },
+          {
+            "name": "DCSt",
+            "type": "enum16",
+            "size": 1,
+            "label": "Operating State",
+            "symbols": [
+              {
+                "name": "OFF",
+                "value": 1,
+                "label": "Off"
+              },
+              {
+                "name": "SLEEPING",
+                "value": 2,
+                "label": "Sleeping"
+              },
+              {
+                "name": "STARTING",
+                "value": 3,
+                "label": "Starting"
+              },
+              {
+                "name": "MPPT",
+                "value": 4,
+                "label": "MPPT"
+              },
+              {
+                "name": "THROTTLED",
+                "value": 5,
+                "label": "Throttled"
+              },
+              {
+                "name": "SHUTTING_DOWN",
+                "value": 6,
+                "label": "Shutting Down"
+              },
+              {
+                "name": "FAULT",
+                "value": 7,
+                "label": "Fault"
+              },
+              {
+                "name": "STANDBY",
+                "value": 8,
+                "label": "Standby"
+              },
+              {
+                "name": "TEST",
+                "value": 9,
+                "label": "Test"
+              },
+              {
+                "name": "RESERVED_10",
+                "value": 10
+              }
+            ]
+          },
+          {
+            "name": "DCEvt",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Module Events",
+            "symbols": [
+              {
+                "name": "GROUND_FAULT",
+                "value": 0,
+                "label": "Ground Fault"
+              },
+              {
+                "name": "INPUT_OVER_VOLTAGE",
+                "value": 1,
+                "label": "Input Over Voltage"
+              },
+              {
+                "name": "RESERVED_2",
+                "value": 2
+              },
+              {
+                "name": "DC_DISCONNECT",
+                "value": 3,
+                "label": "DC Disconnect"
+              },
+              {
+                "name": "RESERVED_4",
+                "value": 4
+              },
+              {
+                "name": "CABINET_OPEN",
+                "value": 5,
+                "label": "Cabinet Open"
+              },
+              {
+                "name": "MANUAL_SHUTDOWN",
+                "value": 6,
+                "label": "Manual Shutdown"
+              },
+              {
+                "name": "OVER_TEMP",
+                "value": 7,
+                "label": "Over Temperature"
+              },
+              {
+                "name": "RESERVED_8",
+                "value": 8
+              },
+              {
+                "name": "RESERVED_9",
+                "value": 9
+              },
+              {
+                "name": "RESERVED_10",
+                "value": 10
+              },
+              {
+                "name": "RESERVED_11",
+                "value": 11
+              },
+              {
+                "name": "BLOWN_FUSE",
+                "value": 12,
+                "label": "Blown Fuse"
+              },
+              {
+                "name": "UNDER_TEMP",
+                "value": 13,
+                "label": "Under Temperature"
+              },
+              {
+                "name": "MEMORY_LOSS",
+                "value": 14,
+                "label": "Memory Loss"
+              },
+              {
+                "name": "ARC_DETECTION",
+                "value": 15,
+                "label": "Arc Detection"
+              },
+              {
+                "name": "RESERVED_16",
+                "value": 16
+              },
+              {
+                "name": "RESERVED_17",
+                "value": 17
+              },
+              {
+                "name": "RESERVED_18",
+                "value": 18
+              },
+              {
+                "name": "RESERVED_19",
+                "value": 19
+              },
+              {
+                "name": "TEST_FAILED",
+                "value": 20,
+                "label": "Test Failed"
+              },
+              {
+                "name": "INPUT_UNDER_VOLTAGE",
+                "value": 21,
+                "label": "Under Voltage"
+              },
+              {
+                "name": "INPUT_OVER_CURRENT",
+                "value": 22,
+                "label": "Over Current"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 160
+}

--- a/models/model_17.json
+++ b/models/model_17.json
@@ -1,0 +1,189 @@
+{
+  "group": {
+    "name": "model_17",
+    "type": "group",
+    "label": "Serial Interface",
+    "desc": "Include this model for serial interface configuration support",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 17
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name (8 chars)"
+      },
+      {
+        "name": "Rte",
+        "type": "uint32",
+        "size": 2,
+        "units": "bps",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Rate",
+        "desc": "Interface baud rate in bits per second"
+      },
+      {
+        "name": "Bits",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Bits",
+        "desc": "Number of data bits per character"
+      },
+      {
+        "name": "Pty",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Parity",
+        "desc": "Bitmask value.  Parity setting",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "none",
+            "desc": "No Parity"
+          },
+          {
+            "name": "ODD",
+            "value": 1,
+            "label": "odd",
+            "desc": "Odd Parity"
+          },
+          {
+            "name": "EVEN",
+            "value": 2,
+            "label": "even",
+            "desc": "Even Parity"
+          }
+        ]
+      },
+      {
+        "name": "Dup",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Duplex",
+        "desc": "Enumerated value.  Duplex mode",
+        "symbols": [
+          {
+            "name": "FULL",
+            "value": 0,
+            "label": "full",
+            "desc": "Full Duplex"
+          },
+          {
+            "name": "HALF",
+            "value": 1,
+            "label": "half",
+            "desc": "Half Duplex"
+          }
+        ]
+      },
+      {
+        "name": "Flw",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Flow Control",
+        "desc": "Flow Control Method",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "none",
+            "desc": "No flow control"
+          },
+          {
+            "name": "HW",
+            "value": 1,
+            "label": "hardware",
+            "desc": "Hardware flow control"
+          },
+          {
+            "name": "XONXOFF",
+            "value": 2,
+            "label": "software",
+            "desc": "Soft (XON/XOFF) flow control"
+          }
+        ]
+      },
+      {
+        "name": "Typ",
+        "type": "enum16",
+        "size": 1,
+        "label": "Interface Type",
+        "desc": "Enumerated value.  Interface type",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "unknown",
+            "desc": "Unknown interface type"
+          },
+          {
+            "name": "RS232",
+            "value": 1,
+            "label": "RS232",
+            "desc": "RS232 interface type"
+          },
+          {
+            "name": "RS485",
+            "value": 2,
+            "label": "RS485",
+            "desc": "RS485 interface type"
+          }
+        ]
+      },
+      {
+        "name": "Pcol",
+        "type": "enum16",
+        "size": 1,
+        "label": "Protocol",
+        "desc": "Enumerated value. Serial protocol selection",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "unknown",
+            "desc": "Unknown protocol"
+          },
+          {
+            "name": "MODBUS",
+            "value": 1,
+            "label": "Modbus",
+            "desc": "Modbus protocol"
+          },
+          {
+            "name": "VENDOR",
+            "value": 2,
+            "label": "vendor specific"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 17
+}

--- a/models/model_18.json
+++ b/models/model_18.json
@@ -1,0 +1,70 @@
+{
+  "group": {
+    "name": "model_18",
+    "type": "group",
+    "label": "Cellular Link",
+    "desc": "Include this model to support a cellular interface link",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 18
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name"
+      },
+      {
+        "name": "IMEI",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "label": "IMEI",
+        "desc": "International Mobile Equipment Identifier for the interface"
+      },
+      {
+        "name": "APN",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "APN",
+        "desc": "Access Point Name for the interface"
+      },
+      {
+        "name": "Num",
+        "type": "string",
+        "size": 6,
+        "access": "RW",
+        "label": "Number",
+        "desc": "Phone number for the interface"
+      },
+      {
+        "name": "Pin",
+        "type": "string",
+        "size": 6,
+        "access": "RW",
+        "label": "PIN",
+        "desc": "Personal Identification Number for the interface"
+      }
+    ]
+  },
+  "id": 18
+}

--- a/models/model_19.json
+++ b/models/model_19.json
@@ -1,0 +1,182 @@
+{
+  "group": {
+    "name": "model_19",
+    "type": "group",
+    "label": "PPP Link",
+    "desc": "Include this model to configure a Point-to-Point Protocol link",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 19
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 4,
+        "access": "RW",
+        "label": "Name",
+        "desc": "Interface name"
+      },
+      {
+        "name": "Rte",
+        "type": "uint32",
+        "size": 2,
+        "units": "bps",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Rate",
+        "desc": "Interface baud rate in bits per second"
+      },
+      {
+        "name": "Bits",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Bits",
+        "desc": "Number of data bits per character"
+      },
+      {
+        "name": "Pty",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Parity",
+        "desc": "Bitmask value.  Parity setting",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "none",
+            "desc": "No Parity"
+          },
+          {
+            "name": "ODD",
+            "value": 1,
+            "label": "odd",
+            "desc": "Odd Parity"
+          },
+          {
+            "name": "EVEN",
+            "value": 2,
+            "label": "even",
+            "desc": "Even Parity"
+          }
+        ]
+      },
+      {
+        "name": "Dup",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Duplex",
+        "desc": "Enumerated value.  Duplex mode",
+        "symbols": [
+          {
+            "name": "FULL",
+            "value": 0,
+            "label": "full",
+            "desc": "Full Duplex"
+          },
+          {
+            "name": "HALF",
+            "value": 1,
+            "label": "half",
+            "desc": "Half Duplex"
+          }
+        ]
+      },
+      {
+        "name": "Flw",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Flow Control",
+        "desc": "Flow Control Method",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "none",
+            "desc": "No flow control"
+          },
+          {
+            "name": "HW",
+            "value": 1,
+            "label": "hardware",
+            "desc": "Hardware flow control"
+          },
+          {
+            "name": "XONXOFF",
+            "value": 2,
+            "label": "software",
+            "desc": "Soft (XON/XOFF) flow control"
+          }
+        ]
+      },
+      {
+        "name": "Auth",
+        "type": "enum16",
+        "size": 1,
+        "label": "Authentication",
+        "desc": "Enumerated value.  Authentication method",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "none",
+            "desc": "No Authentication"
+          },
+          {
+            "name": "PAP",
+            "value": 1,
+            "label": "PAP",
+            "desc": "Use PAP authentication"
+          },
+          {
+            "name": "CHAP",
+            "value": 2,
+            "label": "CHAP",
+            "desc": "Use CHAP authentication"
+          }
+        ]
+      },
+      {
+        "name": "UsrNam",
+        "type": "string",
+        "size": 12,
+        "label": "Username",
+        "desc": "Username for authentication"
+      },
+      {
+        "name": "Pw",
+        "type": "string",
+        "size": 6,
+        "label": "Password",
+        "desc": "Password for authentication"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 19
+}

--- a/models/model_2.json
+++ b/models/model_2.json
@@ -1,0 +1,231 @@
+{
+  "group": {
+    "name": "aggregator",
+    "type": "group",
+    "label": "Basic Aggregator",
+    "desc": "Aggregates a collection of models for a given model id",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 2
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "AID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AID",
+        "desc": "Aggregated model id"
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of aggregated models"
+      },
+      {
+        "name": "UN",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "UN",
+        "desc": "Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status",
+        "desc": "Enumerated status code",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1
+          },
+          {
+            "name": "ON",
+            "value": 2
+          },
+          {
+            "name": "FULL",
+            "value": 3
+          },
+          {
+            "name": "FAULT",
+            "value": 4
+          }
+        ]
+      },
+      {
+        "name": "StVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Status",
+        "desc": "Vendor specific status code"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event Code",
+        "desc": "Bitmask event code",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0
+          },
+          {
+            "name": "INPUT_OVER_VOLTAGE",
+            "value": 1
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 2
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3
+          },
+          {
+            "name": "RESERVED_4",
+            "value": 4
+          },
+          {
+            "name": "RESERVED_5",
+            "value": 5
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 7
+          },
+          {
+            "name": "RESERVED_8",
+            "value": 8
+          },
+          {
+            "name": "RESERVED_9",
+            "value": 9
+          },
+          {
+            "name": "RESERVED_10",
+            "value": 10
+          },
+          {
+            "name": "RESERVED_11",
+            "value": 11
+          },
+          {
+            "name": "BLOWN_FUSE",
+            "value": 12
+          },
+          {
+            "name": "UNDER_TEMPERATURE",
+            "value": 13
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14
+          },
+          {
+            "name": "ARC_DETECTION",
+            "value": 15
+          },
+          {
+            "name": "THEFT_DETECTION",
+            "value": 16
+          },
+          {
+            "name": "OUTPUT_OVER_CURRENT",
+            "value": 17
+          },
+          {
+            "name": "OUTPUT_OVER_VOLTAGE",
+            "value": 18
+          },
+          {
+            "name": "OUTPUT_UNDER_VOLTAGE",
+            "value": 19
+          },
+          {
+            "name": "TEST_FAILED",
+            "value": 20
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Code",
+        "desc": "Vendor specific event code"
+      },
+      {
+        "name": "Ctl",
+        "type": "enum16",
+        "size": 1,
+        "label": "Control",
+        "desc": "Control register for all aggregated devices",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0
+          },
+          {
+            "name": "AUTOMATIC",
+            "value": 1
+          },
+          {
+            "name": "FORCE_OFF",
+            "value": 2
+          },
+          {
+            "name": "TEST",
+            "value": 3
+          },
+          {
+            "name": "THROTTLE",
+            "value": 4
+          }
+        ]
+      },
+      {
+        "name": "CtlVnd",
+        "type": "enum32",
+        "size": 2,
+        "label": "Vendor Control",
+        "desc": "Vendor control register for all aggregated devices"
+      },
+      {
+        "name": "CtlVl",
+        "type": "enum32",
+        "size": 2,
+        "label": "Control Value",
+        "desc": "Numerical value used as a parameter to the control"
+      }
+    ]
+  },
+  "id": 2
+}

--- a/models/model_201.json
+++ b/models/model_201.json
@@ -1,0 +1,749 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "Meter (Single Phase)single phase (AN or AB) meter",
+    "desc": "Include this model for single phase (AN or AB) metering",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 201
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "PhV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "Hz",
+        "type": "int16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Frequency scale factor"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Power scale factor"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Power scale factor"
+      },
+      {
+        "name": "VAR",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "VAR_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Power scale factor"
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase C"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power Factor scale factor"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Energy scale factor"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVAh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Energy scale factor"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "TotVArh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Energy scale factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "Power_Failure",
+            "value": 2,
+            "label": "Power Failure",
+            "desc": "Loss of power or phase"
+          },
+          {
+            "name": "Under_Voltage",
+            "value": 3,
+            "label": "Under Voltage",
+            "desc": "Voltage below threshold (Phase Loss)"
+          },
+          {
+            "name": "Low_PF",
+            "value": 4,
+            "label": "Low PF",
+            "desc": "Power Factor below threshold"
+          },
+          {
+            "name": "Over_Current",
+            "value": 5,
+            "label": "Over Current",
+            "desc": "Current Input over threshold"
+          },
+          {
+            "name": "Over_Voltage",
+            "value": 6,
+            "label": "Over Voltage",
+            "desc": "Voltage Input over threshold"
+          },
+          {
+            "name": "Missing_Sensor",
+            "value": 7,
+            "label": "Missing Sensor",
+            "desc": "Sensor not connected"
+          },
+          {
+            "name": "OEM01",
+            "value": 16,
+            "label": "OEM01",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM02",
+            "value": 17,
+            "label": "OEM02",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM03",
+            "value": 18,
+            "label": "OEM01",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM04",
+            "value": 19,
+            "label": "OEM04",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM05",
+            "value": 20,
+            "label": "OEM05",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM06",
+            "value": 21,
+            "label": "OEM06",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM07",
+            "value": 22,
+            "label": "OEM07",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM08",
+            "value": 23,
+            "label": "OEM08",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM09",
+            "value": 24,
+            "label": "OEM09",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM10",
+            "value": 25,
+            "label": "OEM10",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM11",
+            "value": 26,
+            "label": "OEM11",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM12",
+            "value": 27,
+            "label": "OEM12",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM13",
+            "value": 28,
+            "label": "OEM13",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM14",
+            "value": 29,
+            "label": "OEM14",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM15",
+            "value": 30,
+            "label": "OEM15",
+            "desc": "Reserved for OEM use"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 201
+}

--- a/models/model_202.json
+++ b/models/model_202.json
@@ -1,0 +1,744 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "split single phase (ABN) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 202
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "PhV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphAB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PhVphBC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PhVphCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "Hz",
+        "type": "int16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Frequency scale factor"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Power scale factor"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Power scale factor"
+      },
+      {
+        "name": "VAR",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "VAR_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Power scale factor"
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase C"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power Factor scale factor"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Energy scale factor"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVAh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Energy scale factor"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "TotVArh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Energy scale factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 202
+}

--- a/models/model_203.json
+++ b/models/model_203.json
@@ -1,0 +1,748 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "wye-connect three phase (abcn) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 203
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "PhV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphAB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PhVphBC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PhVphCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "Hz",
+        "type": "int16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Frequency scale factor"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Power scale factor"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Power scale factor"
+      },
+      {
+        "name": "VAR",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "VAR_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Power scale factor"
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase C"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power Factor scale factor"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Energy scale factor"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVAh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Energy scale factor"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "TotVArh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Energy scale factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 203
+}

--- a/models/model_204.json
+++ b/models/model_204.json
@@ -1,0 +1,744 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "delta-connect three phase (abc) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 204
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "PhV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphAB",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PhVphBC",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PhVphCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "Hz",
+        "type": "int16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Frequency scale factor"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Power scale factor"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Power scale factor"
+      },
+      {
+        "name": "VAR",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "VAR_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Power scale factor"
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF phase C"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power Factor scale factor"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Energy scale factor"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVAh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Energy scale factor"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4PhA",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4PhB",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4PhC",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "TotVArh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Energy scale factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 204
+}

--- a/models/model_211.json
+++ b/models/model_211.json
@@ -1,0 +1,613 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "single phase (AN or AB) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 211
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PhV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VAR",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase C"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 211
+}

--- a/models/model_212.json
+++ b/models/model_212.json
@@ -1,0 +1,619 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "split single phase (ABN) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 212
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PhV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VAR",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase C"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 212
+}

--- a/models/model_213.json
+++ b/models/model_213.json
@@ -1,0 +1,623 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "wye-connect three phase (abcn) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 213
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PhV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VAR",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase C"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 213
+}

--- a/models/model_214.json
+++ b/models/model_214.json
@@ -1,0 +1,619 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "delta-connect three phase (abc) meter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 214
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "AphA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseA",
+        "desc": "Phase A Current"
+      },
+      {
+        "name": "AphB",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseB",
+        "desc": "Phase B Current"
+      },
+      {
+        "name": "AphC",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps PhaseC",
+        "desc": "Phase C Current"
+      },
+      {
+        "name": "PhV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Voltage LN",
+        "desc": "Line to Neutral AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PhVphA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage AN",
+        "desc": "Phase Voltage AN"
+      },
+      {
+        "name": "PhVphB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage BN",
+        "desc": "Phase Voltage BN"
+      },
+      {
+        "name": "PhVphC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Phase Voltage CN",
+        "desc": "Phase Voltage CN"
+      },
+      {
+        "name": "PPV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Voltage LL",
+        "desc": "Line to Line AC Voltage (average of active phases)"
+      },
+      {
+        "name": "PPVphAB",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage AB",
+        "desc": "Phase Voltage AB"
+      },
+      {
+        "name": "PPVphBC",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage BC",
+        "desc": "Phase Voltage BC"
+      },
+      {
+        "name": "PPVphCA",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "mandatory": "M",
+        "label": "Phase Voltage CA",
+        "desc": "Phase Voltage CA"
+      },
+      {
+        "name": "Hz",
+        "type": "float32",
+        "size": 2,
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "W",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "WphA",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase A"
+      },
+      {
+        "name": "WphB",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase B"
+      },
+      {
+        "name": "WphC",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Watts phase C"
+      },
+      {
+        "name": "VA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VAphA",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase A"
+      },
+      {
+        "name": "VAphB",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase B"
+      },
+      {
+        "name": "VAphC",
+        "type": "float32",
+        "size": 2,
+        "units": "VA",
+        "label": "VA phase C"
+      },
+      {
+        "name": "VAR",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VARphA",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase A"
+      },
+      {
+        "name": "VARphB",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase B"
+      },
+      {
+        "name": "VARphC",
+        "type": "float32",
+        "size": 2,
+        "units": "var",
+        "label": "VAR phase C"
+      },
+      {
+        "name": "PF",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PFphA",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase A"
+      },
+      {
+        "name": "PFphB",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase B"
+      },
+      {
+        "name": "PFphC",
+        "type": "float32",
+        "size": 2,
+        "units": "PF",
+        "label": "PF phase C"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase A"
+      },
+      {
+        "name": "TotWhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase B"
+      },
+      {
+        "name": "TotWhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Exported phase C"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase A"
+      },
+      {
+        "name": "TotWhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase B"
+      },
+      {
+        "name": "TotWhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Total Watt-hours Imported phase C"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhExpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase A"
+      },
+      {
+        "name": "TotVAhExpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase B"
+      },
+      {
+        "name": "TotVAhExpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Exported phase C"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAhImpPhA",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase A"
+      },
+      {
+        "name": "TotVAhImpPhB",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase B"
+      },
+      {
+        "name": "TotVAhImpPhC",
+        "type": "float32",
+        "size": 2,
+        "units": "VAh",
+        "label": "Total VA-hours Imported phase C"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ1phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase A"
+      },
+      {
+        "name": "TotVArhImpQ1phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase B"
+      },
+      {
+        "name": "TotVArhImpQ1phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q1 phase C"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhImpQ2phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase A"
+      },
+      {
+        "name": "TotVArhImpQ2phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase B"
+      },
+      {
+        "name": "TotVArhImpQ2phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2 phase C"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ3phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase A"
+      },
+      {
+        "name": "TotVArhExpQ3phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase B"
+      },
+      {
+        "name": "TotVArhExpQ3phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3 phase C"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArhExpQ4phA",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase A"
+      },
+      {
+        "name": "TotVArhExpQ4phB",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase B"
+      },
+      {
+        "name": "TotVArhExpQ4phC",
+        "type": "float32",
+        "size": 2,
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4 Imported phase C"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "M_EVENT_Power_Failure",
+            "value": 2
+          },
+          {
+            "name": "M_EVENT_Under_Voltage",
+            "value": 3
+          },
+          {
+            "name": "M_EVENT_Low_PF",
+            "value": 4
+          },
+          {
+            "name": "M_EVENT_Over_Current",
+            "value": 5
+          },
+          {
+            "name": "M_EVENT_Over_Voltage",
+            "value": 6
+          },
+          {
+            "name": "M_EVENT_Missing_Sensor",
+            "value": 7
+          },
+          {
+            "name": "M_EVENT_Reserved1",
+            "value": 8
+          },
+          {
+            "name": "M_EVENT_Reserved2",
+            "value": 9
+          },
+          {
+            "name": "M_EVENT_Reserved3",
+            "value": 10
+          },
+          {
+            "name": "M_EVENT_Reserved4",
+            "value": 11
+          },
+          {
+            "name": "M_EVENT_Reserved5",
+            "value": 12
+          },
+          {
+            "name": "M_EVENT_Reserved6",
+            "value": 13
+          },
+          {
+            "name": "M_EVENT_Reserved7",
+            "value": 14
+          },
+          {
+            "name": "M_EVENT_Reserved8",
+            "value": 15
+          },
+          {
+            "name": "M_EVENT_OEM01",
+            "value": 16
+          },
+          {
+            "name": "M_EVENT_OEM02",
+            "value": 17
+          },
+          {
+            "name": "M_EVENT_OEM03",
+            "value": 18
+          },
+          {
+            "name": "M_EVENT_OEM04",
+            "value": 19
+          },
+          {
+            "name": "M_EVENT_OEM05",
+            "value": 20
+          },
+          {
+            "name": "M_EVENT_OEM06",
+            "value": 21
+          },
+          {
+            "name": "M_EVENT_OEM07",
+            "value": 22
+          },
+          {
+            "name": "M_EVENT_OEM08",
+            "value": 23
+          },
+          {
+            "name": "M_EVENT_OEM09",
+            "value": 24
+          },
+          {
+            "name": "M_EVENT_OEM10",
+            "value": 25
+          },
+          {
+            "name": "M_EVENT_OEM11",
+            "value": 26
+          },
+          {
+            "name": "M_EVENT_OEM12",
+            "value": 27
+          },
+          {
+            "name": "M_EVENT_OEM13",
+            "value": 28
+          },
+          {
+            "name": "M_EVENT_OEM14",
+            "value": 29
+          },
+          {
+            "name": "M_EVENT_OEM15",
+            "value": 30
+          }
+        ]
+      }
+    ]
+  },
+  "id": 214
+}

--- a/models/model_220.json
+++ b/models/model_220.json
@@ -1,0 +1,451 @@
+{
+  "group": {
+    "name": "ac_meter",
+    "type": "group",
+    "label": "Secure AC Meter Selected Readings",
+    "desc": "Include this model for secure metering",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 220
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total AC Current"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "PhV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Voltage",
+        "desc": "Average phase or line voltage"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "Hz",
+        "type": "int16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "mandatory": "M",
+        "label": "Hz",
+        "desc": "Frequency"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Frequency scale factor"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Watts",
+        "desc": "Total Real Power"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Power scale factor"
+      },
+      {
+        "name": "VA",
+        "type": "int16",
+        "size": 1,
+        "sf": "VA_SF",
+        "units": "VA",
+        "label": "VA",
+        "desc": "AC Apparent Power"
+      },
+      {
+        "name": "VA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Power scale factor"
+      },
+      {
+        "name": "VAR",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_SF",
+        "units": "var",
+        "label": "VAR",
+        "desc": "Reactive Power"
+      },
+      {
+        "name": "VAR_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Power scale factor"
+      },
+      {
+        "name": "PF",
+        "type": "int16",
+        "size": 1,
+        "sf": "PF_SF",
+        "units": "Pct",
+        "label": "PF",
+        "desc": "Power Factor"
+      },
+      {
+        "name": "PF_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power Factor scale factor"
+      },
+      {
+        "name": "TotWhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Exported",
+        "desc": "Total Real Energy Exported"
+      },
+      {
+        "name": "TotWhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Watt-hours Imported",
+        "desc": "Total Real Energy Imported"
+      },
+      {
+        "name": "TotWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Real Energy scale factor"
+      },
+      {
+        "name": "TotVAhExp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Exported",
+        "desc": "Total Apparent Energy Exported"
+      },
+      {
+        "name": "TotVAhImp",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVAh_SF",
+        "units": "VAh",
+        "label": "Total VA-hours Imported",
+        "desc": "Total Apparent Energy Imported"
+      },
+      {
+        "name": "TotVAh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Apparent Energy scale factor"
+      },
+      {
+        "name": "TotVArhImpQ1",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAR-hours Imported Q1",
+        "desc": "Total Reactive Energy Imported Quadrant 1"
+      },
+      {
+        "name": "TotVArhImpQ2",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Imported Q2",
+        "desc": "Total Reactive Power Imported Quadrant 2"
+      },
+      {
+        "name": "TotVArhExpQ3",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q3",
+        "desc": "Total Reactive Power Exported Quadrant 3"
+      },
+      {
+        "name": "TotVArhExpQ4",
+        "type": "acc32",
+        "size": 2,
+        "sf": "TotVArh_SF",
+        "units": "varh",
+        "label": "Total VAr-hours Exported Q4",
+        "desc": "Total Reactive Power Exported Quadrant 4"
+      },
+      {
+        "name": "TotVArh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Reactive Energy scale factor"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Meter Event Flags",
+        "symbols": [
+          {
+            "name": "Power_Failure",
+            "value": 2,
+            "label": "Power Failure",
+            "desc": "Loss of power or phase"
+          },
+          {
+            "name": "Under_Voltage",
+            "value": 3,
+            "label": "Under Voltage",
+            "desc": "Voltage below threshold (Phase Loss)"
+          },
+          {
+            "name": "Low_PF",
+            "value": 4,
+            "label": "Low PF",
+            "desc": "Power Factor below threshold"
+          },
+          {
+            "name": "Over_Current",
+            "value": 5,
+            "label": "Over Current",
+            "desc": "Current Input over threshold"
+          },
+          {
+            "name": "Over_Voltage",
+            "value": 6,
+            "label": "Over Voltage",
+            "desc": "Voltage Input over threshold"
+          },
+          {
+            "name": "Missing_Sensor",
+            "value": 7,
+            "label": "Missing Sensor",
+            "desc": "Sensor not connected"
+          },
+          {
+            "name": "OEM01",
+            "value": 16,
+            "label": "OEM01",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM02",
+            "value": 17,
+            "label": "OEM02",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM03",
+            "value": 18,
+            "label": "OEM01",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM04",
+            "value": 19,
+            "label": "OEM04",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM05",
+            "value": 20,
+            "label": "OEM05",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM06",
+            "value": 21,
+            "label": "OEM06",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM07",
+            "value": 22,
+            "label": "OEM07",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM08",
+            "value": 23,
+            "label": "OEM08",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM09",
+            "value": 24,
+            "label": "OEM09",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM10",
+            "value": 25,
+            "label": "OEM10",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM11",
+            "value": 26,
+            "label": "OEM11",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM12",
+            "value": 27,
+            "label": "OEM12",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM13",
+            "value": 28,
+            "label": "OEM13",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM14",
+            "value": 29,
+            "label": "OEM14",
+            "desc": "Reserved for OEM use"
+          },
+          {
+            "name": "OEM15",
+            "value": 30,
+            "label": "OEM15",
+            "desc": "Reserved for OEM use"
+          }
+        ]
+      },
+      {
+        "name": "Rsrvd",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of request"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 220
+}

--- a/models/model_3.json
+++ b/models/model_3.json
@@ -1,0 +1,480 @@
+{
+  "group": {
+    "name": "model_3",
+    "type": "group",
+    "label": "Secure Dataset Read Request",
+    "desc": "Request a digital signature over a specified set of data registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 3
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "X",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "X",
+        "desc": "Number of registers being requested"
+      },
+      {
+        "name": "Off1",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Offset1",
+        "desc": "Offset of value to read"
+      },
+      {
+        "name": "Off2",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off3",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off4",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off5",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off6",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off7",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off8",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off9",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off10",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off11",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off12",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off13",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off14",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off15",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off16",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off17",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off18",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off19",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off20",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off21",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off22",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off23",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off24",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off25",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off26",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off27",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off28",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off29",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off30",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off31",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off32",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off33",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off34",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off35",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off36",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off37",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off38",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off39",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off40",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off41",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off42",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off43",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off44",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off45",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off46",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off47",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off48",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off49",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off50",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of request"
+      },
+      {
+        "name": "Role",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Role",
+        "desc": "Digital Signature ID"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "DS",
+            "desc": "Digital Signature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 3
+}

--- a/models/model_302.json
+++ b/models/model_302.json
@@ -1,0 +1,79 @@
+{
+  "group": {
+    "name": "irradiance",
+    "type": "group",
+    "label": "Irradiance Model",
+    "desc": "Include to support various irradiance measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 302
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "GHI",
+            "type": "uint16",
+            "size": 1,
+            "units": "W/m2",
+            "label": "GHI",
+            "desc": "Global Horizontal Irradiance"
+          },
+          {
+            "name": "POAI",
+            "type": "uint16",
+            "size": 1,
+            "units": "W/m2",
+            "label": "POAI",
+            "desc": "Plane-of-Array Irradiance"
+          },
+          {
+            "name": "DFI",
+            "type": "uint16",
+            "size": 1,
+            "units": "W/m2",
+            "label": "DFI",
+            "desc": "Diffuse Irradiance"
+          },
+          {
+            "name": "DNI",
+            "type": "uint16",
+            "size": 1,
+            "units": "W/m2",
+            "label": "DNI",
+            "desc": "Direct Normal Irradiance"
+          },
+          {
+            "name": "OTI",
+            "type": "uint16",
+            "size": 1,
+            "units": "W/m2",
+            "label": "OTI",
+            "desc": "Other Irradiance"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 302
+}

--- a/models/model_303.json
+++ b/models/model_303.json
@@ -1,0 +1,49 @@
+{
+  "group": {
+    "name": "bom_temp",
+    "type": "group",
+    "label": "Back of Module Temperature Model",
+    "desc": "Include to support variable number of  back of module temperature measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 303
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      }
+    ],
+    "groups": [
+      {
+        "name": "temp",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "TmpBOM",
+            "type": "int16",
+            "size": 1,
+            "sf": -1,
+            "units": "C",
+            "mandatory": "M",
+            "label": "Temp",
+            "desc": "Back of module temperature measurement"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 303
+}

--- a/models/model_304.json
+++ b/models/model_304.json
@@ -1,0 +1,67 @@
+{
+  "group": {
+    "name": "inclinometer",
+    "type": "group",
+    "label": "Inclinometer Model",
+    "desc": "Include to support orientation measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 304
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      }
+    ],
+    "groups": [
+      {
+        "name": "incl",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "Inclx",
+            "type": "int32",
+            "size": 2,
+            "sf": -2,
+            "units": "Degrees",
+            "mandatory": "M",
+            "label": "X",
+            "desc": "X-Axis inclination"
+          },
+          {
+            "name": "Incly",
+            "type": "int32",
+            "size": 2,
+            "sf": -2,
+            "units": "Degrees",
+            "label": "Y",
+            "desc": "Y-Axis inclination"
+          },
+          {
+            "name": "Inclz",
+            "type": "int32",
+            "size": 2,
+            "sf": -2,
+            "units": "Degrees",
+            "label": "Z",
+            "desc": "Z-Axis inclination"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 304
+}

--- a/models/model_305.json
+++ b/models/model_305.json
@@ -1,0 +1,80 @@
+{
+  "group": {
+    "name": "location",
+    "type": "group",
+    "label": "GPS",
+    "desc": "Include to support location measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 305
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Tm",
+        "type": "string",
+        "size": 6,
+        "units": "hhmmss.sssZ",
+        "label": "Tm",
+        "desc": "UTC 24 hour time stamp to millisecond hhmmss.sssZ format"
+      },
+      {
+        "name": "Date",
+        "type": "string",
+        "size": 4,
+        "units": "YYYYMMDD",
+        "label": "Date",
+        "desc": "UTC Date string YYYYMMDD format"
+      },
+      {
+        "name": "Loc",
+        "type": "string",
+        "size": 20,
+        "units": "text",
+        "label": "Location",
+        "desc": "Location string (40 chars max)"
+      },
+      {
+        "name": "Lat",
+        "type": "int32",
+        "size": 2,
+        "sf": -7,
+        "units": "Degrees",
+        "label": "Lat",
+        "desc": "Latitude with seven degrees of precision"
+      },
+      {
+        "name": "Long",
+        "type": "int32",
+        "size": 2,
+        "sf": -7,
+        "units": "Degrees",
+        "label": "Long",
+        "desc": "Longitude with seven degrees of precision"
+      },
+      {
+        "name": "Alt",
+        "type": "int32",
+        "size": 2,
+        "units": "meters",
+        "label": "Altitude",
+        "desc": "Altitude measurement in meters"
+      }
+    ]
+  },
+  "id": 305
+}

--- a/models/model_306.json
+++ b/models/model_306.json
@@ -1,0 +1,62 @@
+{
+  "group": {
+    "name": "ref_point",
+    "type": "group",
+    "label": "Reference Point Model",
+    "desc": "Include to support a standard reference point",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 306
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "GHI",
+        "type": "uint16",
+        "size": 1,
+        "units": "W/m2",
+        "label": "GHI",
+        "desc": "Global Horizontal Irradiance"
+      },
+      {
+        "name": "A",
+        "type": "uint16",
+        "size": 1,
+        "units": "W/m2",
+        "label": "Amps",
+        "desc": "Current measurement at reference point"
+      },
+      {
+        "name": "V",
+        "type": "uint16",
+        "size": 1,
+        "units": "W/m2",
+        "label": "Voltage",
+        "desc": "Voltage  measurement at reference point"
+      },
+      {
+        "name": "Tmp",
+        "type": "uint16",
+        "size": 1,
+        "units": "W/m2",
+        "label": "Temperature",
+        "desc": "Temperature measurement at reference point"
+      }
+    ]
+  },
+  "id": 306
+}

--- a/models/model_307.json
+++ b/models/model_307.json
@@ -1,0 +1,108 @@
+{
+  "group": {
+    "name": "base_met",
+    "type": "group",
+    "label": "Base Met",
+    "desc": "Base Meteorological Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 307
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "TmpAmb",
+        "type": "int16",
+        "size": 1,
+        "sf": -1,
+        "units": "C",
+        "label": "Ambient Temperature"
+      },
+      {
+        "name": "RH",
+        "type": "int16",
+        "size": 1,
+        "units": "Pct",
+        "label": "Relative Humidity"
+      },
+      {
+        "name": "Pres",
+        "type": "int16",
+        "size": 1,
+        "units": "HPa",
+        "label": "Barometric Pressure"
+      },
+      {
+        "name": "WndSpd",
+        "type": "int16",
+        "size": 1,
+        "units": "mps",
+        "label": "Wind Speed"
+      },
+      {
+        "name": "WndDir",
+        "type": "int16",
+        "size": 1,
+        "units": "deg",
+        "label": "Wind Direction"
+      },
+      {
+        "name": "Rain",
+        "type": "int16",
+        "size": 1,
+        "units": "mm",
+        "label": "Rainfall"
+      },
+      {
+        "name": "Snw",
+        "type": "int16",
+        "size": 1,
+        "units": "mm",
+        "label": "Snow Depth"
+      },
+      {
+        "name": "PPT",
+        "type": "int16",
+        "size": 1,
+        "label": "Precipitation Type",
+        "desc": "\u00a0Precipitation Type (WMO 4680 SYNOP code reference)"
+      },
+      {
+        "name": "ElecFld",
+        "type": "int16",
+        "size": 1,
+        "units": "Vm",
+        "label": "Electric Field"
+      },
+      {
+        "name": "SurWet",
+        "type": "int16",
+        "size": 1,
+        "units": "kO",
+        "label": "Surface Wetness"
+      },
+      {
+        "name": "SoilWet",
+        "type": "int16",
+        "size": 1,
+        "units": "Pct",
+        "label": "Soil Wetness"
+      }
+    ]
+  },
+  "id": 307
+}

--- a/models/model_308.json
+++ b/models/model_308.json
@@ -1,0 +1,62 @@
+{
+  "group": {
+    "name": "mini_met",
+    "type": "group",
+    "label": "Mini Met Model",
+    "desc": "Include to support a few basic measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 308
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "GHI",
+        "type": "uint16",
+        "size": 1,
+        "units": "W/m2",
+        "label": "GHI",
+        "desc": "Global Horizontal Irradiance"
+      },
+      {
+        "name": "TmpBOM",
+        "type": "int16",
+        "size": 1,
+        "sf": -1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Back of module temperature measurement"
+      },
+      {
+        "name": "TmpAmb",
+        "type": "int16",
+        "size": 1,
+        "sf": -1,
+        "units": "C",
+        "label": "Ambient Temperature"
+      },
+      {
+        "name": "WndSpd",
+        "type": "uint16",
+        "size": 1,
+        "units": "m/s",
+        "label": "Wind Speed"
+      }
+    ]
+  },
+  "id": 308
+}

--- a/models/model_4.json
+++ b/models/model_4.json
@@ -1,0 +1,481 @@
+{
+  "group": {
+    "name": "model_4",
+    "type": "group",
+    "label": "Secure Dataset Read Response",
+    "desc": "Compute a digital signature over a specified set of data registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 4
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "RqSeq",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Request Sequence",
+        "desc": "Sequence number from the request"
+      },
+      {
+        "name": "Sts",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status",
+        "desc": "Status of last read operation",
+        "symbols": [
+          {
+            "name": "SUCCESS",
+            "value": 0,
+            "label": "SUCCESS",
+            "desc": "Operation succeeded"
+          },
+          {
+            "name": "DS",
+            "value": 1,
+            "label": "DS",
+            "desc": "Operation failed digital signature check"
+          },
+          {
+            "name": "ACL",
+            "value": 2,
+            "label": "ACL",
+            "desc": "Operation failed access control check"
+          },
+          {
+            "name": "OFF",
+            "value": 3,
+            "label": "OFF",
+            "desc": "Operation failed offset check"
+          }
+        ]
+      },
+      {
+        "name": "X",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "X",
+        "desc": "Number of values from the request"
+      },
+      {
+        "name": "Val1",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Value1",
+        "desc": "Copy of value from register Off1."
+      },
+      {
+        "name": "Val2",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val3",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val4",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val5",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val6",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val7",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val8",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val9",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val10",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val11",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val12",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val13",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val14",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val15",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val16",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val17",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val18",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val19",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val20",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val21",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val22",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val23",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val24",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val25",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val26",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val27",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val28",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val29",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val30",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val31",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val32",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val33",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val34",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val35",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val36",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val37",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val38",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val39",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val40",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val41",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val42",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val43",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val44",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val45",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val46",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val47",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val48",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val49",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Val50",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of response"
+      },
+      {
+        "name": "Alm",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Alarm",
+        "desc": "Bitmask alarm code",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No Alarms"
+          },
+          {
+            "name": "ALM",
+            "value": 1,
+            "label": "ALARM",
+            "desc": "Security Alarm"
+          }
+        ]
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "DS",
+            "desc": "Digital Signature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 4
+}

--- a/models/model_401.json
+++ b/models/model_401.json
@@ -1,0 +1,325 @@
+{
+  "group": {
+    "name": "string_combiner",
+    "type": "group",
+    "label": "String Combiner (Current)",
+    "desc": "A basic string combiner",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 401
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "DCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "DCAMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Rating",
+        "desc": "Maximum DC Current Rating"
+      },
+      {
+        "name": "N",
+        "type": "count",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of Inputs"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event",
+        "desc": "Bitmask value.  Events",
+        "symbols": [
+          {
+            "name": "LOW_VOLTAGE",
+            "value": 0
+          },
+          {
+            "name": "LOW_POWER",
+            "value": 1
+          },
+          {
+            "name": "LOW_EFFICIENCY",
+            "value": 2
+          },
+          {
+            "name": "CURRENT",
+            "value": 3
+          },
+          {
+            "name": "VOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "POWER",
+            "value": 5
+          },
+          {
+            "name": "PR",
+            "value": 6
+          },
+          {
+            "name": "DISCONNECTED",
+            "value": 7
+          },
+          {
+            "name": "FUSE_FAULT",
+            "value": 8
+          },
+          {
+            "name": "COMBINER_FUSE_FAULT",
+            "value": 9
+          },
+          {
+            "name": "COMBINER_CABINET_OPEN",
+            "value": 10
+          },
+          {
+            "name": "TEMP",
+            "value": 11
+          },
+          {
+            "name": "GROUNDFAULT",
+            "value": 12
+          },
+          {
+            "name": "REVERSED_POLARITY",
+            "value": 13
+          },
+          {
+            "name": "INCOMPATIBLE",
+            "value": 14
+          },
+          {
+            "name": "COMM_ERROR",
+            "value": 15
+          },
+          {
+            "name": "INTERNAL_ERROR",
+            "value": 16
+          },
+          {
+            "name": "THEFT",
+            "value": 17
+          },
+          {
+            "name": "ARC_DETECTED",
+            "value": 18
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event",
+        "desc": "Bitmask value.  Vendor defined events"
+      },
+      {
+        "name": "DCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total measured current"
+      },
+      {
+        "name": "DCAhr",
+        "type": "uint32",
+        "size": 2,
+        "sf": "DCAhr_SF",
+        "units": "Ah",
+        "label": "Amp-hours",
+        "desc": "Total metered Amp-hours"
+      },
+      {
+        "name": "DCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Internal operating temperature"
+      }
+    ],
+    "groups": [
+      {
+        "name": "string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "InID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ID",
+            "desc": "Uniquely identifies this input set"
+          },
+          {
+            "name": "InEvt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Input Event",
+            "desc": "String Input Event Flags",
+            "symbols": [
+              {
+                "name": "LOW_VOLTAGE",
+                "value": 0
+              },
+              {
+                "name": "LOW_POWER",
+                "value": 1
+              },
+              {
+                "name": "LOW_EFFICIENCY",
+                "value": 2
+              },
+              {
+                "name": "CURRENT",
+                "value": 3
+              },
+              {
+                "name": "VOLTAGE",
+                "value": 4
+              },
+              {
+                "name": "POWER",
+                "value": 5
+              },
+              {
+                "name": "PR",
+                "value": 6
+              },
+              {
+                "name": "DISCONNECTED",
+                "value": 7
+              },
+              {
+                "name": "FUSE_FAULT",
+                "value": 8
+              },
+              {
+                "name": "COMBINER_FUSE_FAULT",
+                "value": 9
+              },
+              {
+                "name": "COMBINER_CABINET_OPEN",
+                "value": 10
+              },
+              {
+                "name": "TEMP",
+                "value": 11
+              },
+              {
+                "name": "GROUNDFAULT",
+                "value": 12
+              },
+              {
+                "name": "REVERSED_POLARITY",
+                "value": 13
+              },
+              {
+                "name": "INCOMPATIBLE",
+                "value": 14
+              },
+              {
+                "name": "COMM_ERROR",
+                "value": 15
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "value": 16
+              },
+              {
+                "name": "THEFT",
+                "value": 17
+              },
+              {
+                "name": "ARC_DETECTED",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "name": "InEvtVnd",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Input Event Vendor",
+            "desc": "String Input Vendor Event Flags"
+          },
+          {
+            "name": "InDCA",
+            "type": "int16",
+            "size": 1,
+            "sf": "DCA_SF",
+            "units": "A",
+            "mandatory": "M",
+            "label": "Amps",
+            "desc": "String Input Current"
+          },
+          {
+            "name": "InDCAhr",
+            "type": "uint32",
+            "size": 2,
+            "sf": "DCAhr_SF",
+            "units": "Ah",
+            "label": "Amp-hours",
+            "desc": "String Input Amp-Hours"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 401
+}

--- a/models/model_402.json
+++ b/models/model_402.json
@@ -1,0 +1,403 @@
+{
+  "group": {
+    "name": "string_combiner",
+    "type": "group",
+    "label": "String Combiner (Advanced)",
+    "desc": "An advanced string combiner",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 402
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "DCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power scale factor"
+      },
+      {
+        "name": "DCWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Energy scale factor"
+      },
+      {
+        "name": "DCAMax",
+        "type": "uint16",
+        "size": 1,
+        "units": "A",
+        "label": "Rating",
+        "desc": "Maximum DC Current Rating"
+      },
+      {
+        "name": "N",
+        "type": "count",
+        "size": 1,
+        "label": "N",
+        "desc": "Number of Inputs"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event",
+        "desc": "Bitmask value.  Events",
+        "symbols": [
+          {
+            "name": "LOW_VOLTAGE",
+            "value": 0
+          },
+          {
+            "name": "LOW_POWER",
+            "value": 1
+          },
+          {
+            "name": "LOW_EFFICIENCY",
+            "value": 2
+          },
+          {
+            "name": "CURRENT",
+            "value": 3
+          },
+          {
+            "name": "VOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "POWER",
+            "value": 5
+          },
+          {
+            "name": "PR",
+            "value": 6
+          },
+          {
+            "name": "DISCONNECTED",
+            "value": 7
+          },
+          {
+            "name": "FUSE_FAULT",
+            "value": 8
+          },
+          {
+            "name": "COMBINER_FUSE_FAULT",
+            "value": 9
+          },
+          {
+            "name": "COMBINER_CABINET_OPEN",
+            "value": 10
+          },
+          {
+            "name": "TEMP",
+            "value": 11
+          },
+          {
+            "name": "GROUNDFAULT",
+            "value": 12
+          },
+          {
+            "name": "REVERSED_POLARITY",
+            "value": 13
+          },
+          {
+            "name": "INCOMPATIBLE",
+            "value": 14
+          },
+          {
+            "name": "COMM_ERROR",
+            "value": 15
+          },
+          {
+            "name": "INTERNAL_ERROR",
+            "value": 16
+          },
+          {
+            "name": "THEFT",
+            "value": 17
+          },
+          {
+            "name": "ARC_DETECTED",
+            "value": 18
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event",
+        "desc": "Bitmask value.  Vendor defined events"
+      },
+      {
+        "name": "DCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total measured current"
+      },
+      {
+        "name": "DCAhr",
+        "type": "uint32",
+        "size": 2,
+        "sf": "DCAhr_SF",
+        "units": "Ah",
+        "label": "Amp-hours",
+        "desc": "Total metered Amp-hours"
+      },
+      {
+        "name": "DCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Internal operating temperature"
+      },
+      {
+        "name": "DCW",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCW_SF",
+        "units": "W",
+        "label": "Watts",
+        "desc": "Output power"
+      },
+      {
+        "name": "DCPR",
+        "type": "uint16",
+        "size": 1,
+        "units": "Pct",
+        "label": "PR",
+        "desc": "DC Performance ratio value"
+      },
+      {
+        "name": "DCWh",
+        "type": "uint32",
+        "size": 2,
+        "sf": "DCWh_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Watt-hours",
+        "desc": "Output energy"
+      }
+    ],
+    "groups": [
+      {
+        "name": "string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "InID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ID",
+            "desc": "Uniquely identifies this input set"
+          },
+          {
+            "name": "InEvt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Input Event",
+            "desc": "String Input Event Flags",
+            "symbols": [
+              {
+                "name": "LOW_VOLTAGE",
+                "value": 0
+              },
+              {
+                "name": "LOW_POWER",
+                "value": 1
+              },
+              {
+                "name": "LOW_EFFICIENCY",
+                "value": 2
+              },
+              {
+                "name": "CURRENT",
+                "value": 3
+              },
+              {
+                "name": "VOLTAGE",
+                "value": 4
+              },
+              {
+                "name": "POWER",
+                "value": 5
+              },
+              {
+                "name": "PR",
+                "value": 6
+              },
+              {
+                "name": "DISCONNECTED",
+                "value": 7
+              },
+              {
+                "name": "FUSE_FAULT",
+                "value": 8
+              },
+              {
+                "name": "COMBINER_FUSE_FAULT",
+                "value": 9
+              },
+              {
+                "name": "COMBINER_CABINET_OPEN",
+                "value": 10
+              },
+              {
+                "name": "TEMP",
+                "value": 11
+              },
+              {
+                "name": "GROUNDFAULT",
+                "value": 12
+              },
+              {
+                "name": "REVERSED_POLARITY",
+                "value": 13
+              },
+              {
+                "name": "INCOMPATIBLE",
+                "value": 14
+              },
+              {
+                "name": "COMM_ERROR",
+                "value": 15
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "value": 16
+              },
+              {
+                "name": "THEFT",
+                "value": 17
+              },
+              {
+                "name": "ARC_DETECTED",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "name": "EvtVnd",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Vendor Event",
+            "desc": "Bitmask value.  Vendor defined events"
+          },
+          {
+            "name": "InDCA",
+            "type": "int16",
+            "size": 1,
+            "sf": "DCA_SF",
+            "units": "A",
+            "mandatory": "M",
+            "label": "Amps",
+            "desc": "String Input Current"
+          },
+          {
+            "name": "InDCAhr",
+            "type": "uint32",
+            "size": 2,
+            "sf": "DCAhr_SF",
+            "units": "Ah",
+            "label": "Amp-hours",
+            "desc": "String Input Amp-Hours"
+          },
+          {
+            "name": "InDCV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "DCV_SF",
+            "units": "V",
+            "label": "Voltage",
+            "desc": "String Input Voltage"
+          },
+          {
+            "name": "InDCW",
+            "type": "int16",
+            "size": 1,
+            "sf": "DCWh_SF",
+            "units": "W",
+            "label": "Watts",
+            "desc": "String Input Power"
+          },
+          {
+            "name": "InDCWh",
+            "type": "uint32",
+            "size": 2,
+            "units": "Wh",
+            "label": "Watt-hours",
+            "desc": "String Input Energy"
+          },
+          {
+            "name": "InDCPR",
+            "type": "uint16",
+            "size": 1,
+            "units": "Pct",
+            "label": "PR",
+            "desc": "String Performance Ratio"
+          },
+          {
+            "name": "InN",
+            "type": "uint16",
+            "size": 1,
+            "label": "N",
+            "desc": "Number of modules in this input string"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 402
+}

--- a/models/model_403.json
+++ b/models/model_403.json
@@ -1,0 +1,337 @@
+{
+  "group": {
+    "name": "string_combiner",
+    "type": "group",
+    "label": "String Combiner (Current)",
+    "desc": "A basic string combiner model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 403
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "DCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "DCAMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Rating",
+        "desc": "Maximum DC Current Rating"
+      },
+      {
+        "name": "N",
+        "type": "count",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of Inputs"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event",
+        "desc": "Bitmask value.  Events",
+        "symbols": [
+          {
+            "name": "LOW_VOLTAGE",
+            "value": 0
+          },
+          {
+            "name": "LOW_POWER",
+            "value": 1
+          },
+          {
+            "name": "LOW_EFFICIENCY",
+            "value": 2
+          },
+          {
+            "name": "CURRENT",
+            "value": 3
+          },
+          {
+            "name": "VOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "POWER",
+            "value": 5
+          },
+          {
+            "name": "PR",
+            "value": 6
+          },
+          {
+            "name": "DISCONNECTED",
+            "value": 7
+          },
+          {
+            "name": "FUSE_FAULT",
+            "value": 8
+          },
+          {
+            "name": "COMBINER_FUSE_FAULT",
+            "value": 9
+          },
+          {
+            "name": "COMBINER_CABINET_OPEN",
+            "value": 10
+          },
+          {
+            "name": "TEMP",
+            "value": 11
+          },
+          {
+            "name": "GROUNDFAULT",
+            "value": 12
+          },
+          {
+            "name": "REVERSED_POLARITY",
+            "value": 13
+          },
+          {
+            "name": "INCOMPATIBLE",
+            "value": 14
+          },
+          {
+            "name": "COMM_ERROR",
+            "value": 15
+          },
+          {
+            "name": "INTERNAL_ERROR",
+            "value": 16
+          },
+          {
+            "name": "THEFT",
+            "value": 17
+          },
+          {
+            "name": "ARC_DETECTED",
+            "value": 18
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event",
+        "desc": "Bitmask value.  Vendor defined events"
+      },
+      {
+        "name": "DCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total measured current"
+      },
+      {
+        "name": "DCAhr",
+        "type": "acc32",
+        "size": 2,
+        "sf": "DCAhr_SF",
+        "units": "Ah",
+        "label": "Amp-hours",
+        "desc": "Total metered Amp-hours"
+      },
+      {
+        "name": "DCV",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Internal operating temperature"
+      },
+      {
+        "name": "InDCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Current scale factor for inputs"
+      },
+      {
+        "name": "InDCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor for inputs"
+      }
+    ],
+    "groups": [
+      {
+        "name": "string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "InID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ID",
+            "desc": "Uniquely identifies this input set"
+          },
+          {
+            "name": "InEvt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Input Event",
+            "desc": "String Input Event Flags",
+            "symbols": [
+              {
+                "name": "LOW_VOLTAGE",
+                "value": 0
+              },
+              {
+                "name": "LOW_POWER",
+                "value": 1
+              },
+              {
+                "name": "LOW_EFFICIENCY",
+                "value": 2
+              },
+              {
+                "name": "CURRENT",
+                "value": 3
+              },
+              {
+                "name": "VOLTAGE",
+                "value": 4
+              },
+              {
+                "name": "POWER",
+                "value": 5
+              },
+              {
+                "name": "PR",
+                "value": 6
+              },
+              {
+                "name": "DISCONNECTED",
+                "value": 7
+              },
+              {
+                "name": "FUSE_FAULT",
+                "value": 8
+              },
+              {
+                "name": "COMBINER_FUSE_FAULT",
+                "value": 9
+              },
+              {
+                "name": "COMBINER_CABINET_OPEN",
+                "value": 10
+              },
+              {
+                "name": "TEMP",
+                "value": 11
+              },
+              {
+                "name": "GROUNDFAULT",
+                "value": 12
+              },
+              {
+                "name": "REVERSED_POLARITY",
+                "value": 13
+              },
+              {
+                "name": "INCOMPATIBLE",
+                "value": 14
+              },
+              {
+                "name": "COMM_ERROR",
+                "value": 15
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "value": 16
+              },
+              {
+                "name": "THEFT",
+                "value": 17
+              },
+              {
+                "name": "ARC_DETECTED",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "name": "InEvtVnd",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Input Event Vendor",
+            "desc": "String Input Vendor Event Flags"
+          },
+          {
+            "name": "InDCA",
+            "type": "int16",
+            "size": 1,
+            "sf": "InDCA_SF",
+            "units": "A",
+            "mandatory": "M",
+            "label": "Amps",
+            "desc": "String Input Current"
+          },
+          {
+            "name": "InDCAhr",
+            "type": "acc32",
+            "size": 2,
+            "sf": "InDCAhr_SF",
+            "units": "Ah",
+            "label": "Amp-hours",
+            "desc": "String Input Amp-Hours"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 403
+}

--- a/models/model_404.json
+++ b/models/model_404.json
@@ -1,0 +1,435 @@
+{
+  "group": {
+    "name": "string_combiner",
+    "type": "group",
+    "label": "String Combiner (Advanced)",
+    "desc": "An advanced string combiner including voltage and energy measurements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 404
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "DCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor"
+      },
+      {
+        "name": "DCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "DCW_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power scale factor"
+      },
+      {
+        "name": "DCWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Energy scale factor"
+      },
+      {
+        "name": "DCAMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Rating",
+        "desc": "Maximum DC Current Rating"
+      },
+      {
+        "name": "N",
+        "type": "count",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of Inputs"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Event",
+        "desc": "Bitmask value.  Events",
+        "symbols": [
+          {
+            "name": "LOW_VOLTAGE",
+            "value": 0
+          },
+          {
+            "name": "LOW_POWER",
+            "value": 1
+          },
+          {
+            "name": "LOW_EFFICIENCY",
+            "value": 2
+          },
+          {
+            "name": "CURRENT",
+            "value": 3
+          },
+          {
+            "name": "VOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "POWER",
+            "value": 5
+          },
+          {
+            "name": "PR",
+            "value": 6
+          },
+          {
+            "name": "DISCONNECTED",
+            "value": 7
+          },
+          {
+            "name": "FUSE_FAULT",
+            "value": 8
+          },
+          {
+            "name": "COMBINER_FUSE_FAULT",
+            "value": 9
+          },
+          {
+            "name": "COMBINER_CABINET_OPEN",
+            "value": 10
+          },
+          {
+            "name": "TEMP",
+            "value": 11
+          },
+          {
+            "name": "GROUNDFAULT",
+            "value": 12
+          },
+          {
+            "name": "REVERSED_POLARITY",
+            "value": 13
+          },
+          {
+            "name": "INCOMPATIBLE",
+            "value": 14
+          },
+          {
+            "name": "COMM_ERROR",
+            "value": 15
+          },
+          {
+            "name": "INTERNAL_ERROR",
+            "value": 16
+          },
+          {
+            "name": "THEFT",
+            "value": 17
+          },
+          {
+            "name": "ARC_DETECTED",
+            "value": 18
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event",
+        "desc": "Bitmask value.  Vendor defined events"
+      },
+      {
+        "name": "DCA",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCA_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Amps",
+        "desc": "Total measured current"
+      },
+      {
+        "name": "DCAhr",
+        "type": "acc32",
+        "size": 2,
+        "sf": "DCAhr_SF",
+        "units": "Ah",
+        "label": "Amp-hours",
+        "desc": "Total metered Amp-hours"
+      },
+      {
+        "name": "DCV",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCV_SF",
+        "units": "V",
+        "label": "Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Internal operating temperature"
+      },
+      {
+        "name": "DCW",
+        "type": "int16",
+        "size": 1,
+        "sf": "DCW_SF",
+        "units": "W",
+        "label": "Watts",
+        "desc": "Output power"
+      },
+      {
+        "name": "DCPR",
+        "type": "int16",
+        "size": 1,
+        "units": "Pct",
+        "label": "PR",
+        "desc": "DC Performance ratio value"
+      },
+      {
+        "name": "DCWh",
+        "type": "acc32",
+        "size": 2,
+        "sf": "DCWh_SF",
+        "units": "Wh",
+        "label": "Watt-hours",
+        "desc": "Output energy"
+      },
+      {
+        "name": "InDCA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Current scale factor for inputs"
+      },
+      {
+        "name": "InDCAhr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Amp-hour scale factor for inputs"
+      },
+      {
+        "name": "InDCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor for inputs"
+      },
+      {
+        "name": "InDCW_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power scale factor for inputs"
+      },
+      {
+        "name": "InDCWh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Energy scale factor for inputs"
+      }
+    ],
+    "groups": [
+      {
+        "name": "string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "InID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ID",
+            "desc": "Uniquely identifies this input set"
+          },
+          {
+            "name": "InEvt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Input Event",
+            "desc": "String Input Event Flags",
+            "symbols": [
+              {
+                "name": "LOW_VOLTAGE",
+                "value": 0
+              },
+              {
+                "name": "LOW_POWER",
+                "value": 1
+              },
+              {
+                "name": "LOW_EFFICIENCY",
+                "value": 2
+              },
+              {
+                "name": "CURRENT",
+                "value": 3
+              },
+              {
+                "name": "VOLTAGE",
+                "value": 4
+              },
+              {
+                "name": "POWER",
+                "value": 5
+              },
+              {
+                "name": "PR",
+                "value": 6
+              },
+              {
+                "name": "DISCONNECTED",
+                "value": 7
+              },
+              {
+                "name": "FUSE_FAULT",
+                "value": 8
+              },
+              {
+                "name": "COMBINER_FUSE_FAULT",
+                "value": 9
+              },
+              {
+                "name": "COMBINER_CABINET_OPEN",
+                "value": 10
+              },
+              {
+                "name": "TEMP",
+                "value": 11
+              },
+              {
+                "name": "GROUNDFAULT",
+                "value": 12
+              },
+              {
+                "name": "REVERSED_POLARITY",
+                "value": 13
+              },
+              {
+                "name": "INCOMPATIBLE",
+                "value": 14
+              },
+              {
+                "name": "COMM_ERROR",
+                "value": 15
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "value": 16
+              },
+              {
+                "name": "THEFT",
+                "value": 17
+              },
+              {
+                "name": "ARC_DETECTED",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "name": "InEvtVnd",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Input Event Vendor",
+            "desc": "String Input Vendor Event Flags"
+          },
+          {
+            "name": "InDCA",
+            "type": "int16",
+            "size": 1,
+            "sf": "InDCA_SF",
+            "units": "A",
+            "mandatory": "M",
+            "label": "Amps",
+            "desc": "String Input Current"
+          },
+          {
+            "name": "InDCAhr",
+            "type": "acc32",
+            "size": 2,
+            "sf": "InDCAhr_SF",
+            "units": "Ah",
+            "label": "Amp-hours",
+            "desc": "String Input Amp-Hours"
+          },
+          {
+            "name": "InDCV",
+            "type": "int16",
+            "size": 1,
+            "sf": "InDCV_SF",
+            "units": "V",
+            "label": "Voltage",
+            "desc": "String Input Voltage"
+          },
+          {
+            "name": "InDCW",
+            "type": "int16",
+            "size": 1,
+            "sf": "InDCW_SF",
+            "units": "W",
+            "label": "Watts",
+            "desc": "String Input Power"
+          },
+          {
+            "name": "InDCWh",
+            "type": "acc32",
+            "size": 2,
+            "sf": "InDCWh_SF",
+            "units": "Wh",
+            "label": "Watt-hours",
+            "desc": "String Input Energy"
+          },
+          {
+            "name": "InDCPR",
+            "type": "uint16",
+            "size": 1,
+            "units": "Pct",
+            "label": "PR",
+            "desc": "String Performance Ratio"
+          },
+          {
+            "name": "InN",
+            "type": "uint16",
+            "size": 1,
+            "label": "N",
+            "desc": "Number of modules in this input string"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 404
+}

--- a/models/model_5.json
+++ b/models/model_5.json
@@ -1,0 +1,695 @@
+{
+  "group": {
+    "name": "model_5",
+    "type": "group",
+    "label": "Secure Write Request",
+    "desc": "Include a digital signature along with the control data",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 5
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "X",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "X",
+        "desc": "Number of (offset, value) pairs being written"
+      },
+      {
+        "name": "Off1",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Offset1",
+        "desc": "Offset of control register to write value to"
+      },
+      {
+        "name": "Val1",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Value1",
+        "desc": "Value to write to control register at offset"
+      },
+      {
+        "name": "Off2",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val2",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off3",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val3",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off4",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val4",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off5",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val5",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off6",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val6",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off7",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val7",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off8",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val8",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off9",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val9",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off10",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val10",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off11",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val11",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off12",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val12",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off13",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val13",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off14",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val14",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off15",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val15",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off16",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val16",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off17",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val17",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off18",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val18",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off19",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val19",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off20",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val20",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off21",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val21",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off22",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val22",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off23",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val23",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off24",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val24",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off25",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val25",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off26",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val26",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off27",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val27",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off28",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val28",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off29",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val29",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off30",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val30",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off31",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val31",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off32",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val32",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off33",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val33",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off34",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val34",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off35",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val35",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off36",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val36",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off37",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val37",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off38",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val38",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off39",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val39",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Off40",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val40",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of request"
+      },
+      {
+        "name": "Role",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Role",
+        "desc": "Signing key used 0-5"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "DS",
+            "desc": "Digital Signature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 5
+}

--- a/models/model_501.json
+++ b/models/model_501.json
@@ -1,0 +1,340 @@
+{
+  "group": {
+    "name": "solar_module",
+    "type": "group",
+    "label": "Solar Module",
+    "desc": "A solar module model supporting DC-DC converter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 501
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Stat",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status",
+        "desc": "Enumerated value.  Module Status Code",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Module is in the OFF state"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "SLEEPING",
+            "desc": "Sleeping (auto-shutdown) or panel is at low/safe output power/voltage"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "STARTING",
+            "desc": "Starting up or ON but not producing power; panel might have high voltage but is not producing power"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Tracking MPPT power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "THROTTLED",
+            "desc": "Forced power reduction / power de-rating"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "SHUTTING_DOWN",
+            "desc": "Shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "FAULT",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "STANDBY",
+            "desc": "Standby (service or unit) - unlike SLEEPING in this mode the module might be at a high (unsafe) output voltage or power"
+          },
+          {
+            "name": "TEST",
+            "value": 9,
+            "label": "TEST",
+            "desc": "Test mode"
+          },
+          {
+            "name": "OTHER",
+            "value": 10,
+            "label": "OTHER",
+            "desc": "As defined in vendor specific status"
+          }
+        ]
+      },
+      {
+        "name": "StatVend",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Status",
+        "desc": "Module Vendor Status Code"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Bitmask value.  Module Event Flags",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground Fault",
+            "desc": "Ground Fault"
+          },
+          {
+            "name": "INPUT_OVER_VOLTAGE",
+            "value": 1,
+            "label": "Over Voltage",
+            "desc": "DC input over-voltage"
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 2
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "Disconnect",
+            "desc": "DC disconnect open"
+          },
+          {
+            "name": "RESERVED_4",
+            "value": 4
+          },
+          {
+            "name": "RESERVED_5",
+            "value": 5
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown",
+            "desc": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 7,
+            "label": "Over Temperature",
+            "desc": "Over Temperature"
+          },
+          {
+            "name": "RESERVED_8",
+            "value": 8
+          },
+          {
+            "name": "RESERVED_9",
+            "value": 9
+          },
+          {
+            "name": "RESERVED_10",
+            "value": 10
+          },
+          {
+            "name": "RESERVED_11",
+            "value": 11
+          },
+          {
+            "name": "BLOWN_FUSE",
+            "value": 12,
+            "label": "Blown Fuse",
+            "desc": "Input fuse is blown"
+          },
+          {
+            "name": "UNDER_TEMPERATURE",
+            "value": 13,
+            "label": "Under Temperature",
+            "desc": "Under Temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Memory Loss",
+            "desc": "Generic Memory or Communication Error"
+          },
+          {
+            "name": "ARC_DETECTION",
+            "value": 15,
+            "label": "Arc Detection",
+            "desc": "Arc Detection"
+          },
+          {
+            "name": "THEFT_DETECTION",
+            "value": 16,
+            "label": "Theft Detection",
+            "desc": "Theft Detection"
+          },
+          {
+            "name": "OUTPUT_OVER_CURRENT",
+            "value": 17,
+            "label": "Over Current",
+            "desc": "Output Over Current"
+          },
+          {
+            "name": "OUTPUT_OVER_VOLTAGE",
+            "value": 18,
+            "label": "Output Over Voltage",
+            "desc": "DC Output Over Voltage"
+          },
+          {
+            "name": "OUTPUT_UNDER_VOLTAGE",
+            "value": 19,
+            "label": "Output Under Voltage",
+            "desc": "DC Output Under Voltage"
+          },
+          {
+            "name": "TEST_FAILED",
+            "value": 20,
+            "label": "Test Failed",
+            "desc": "Last Self Test failed; see vendor event for details"
+          }
+        ]
+      },
+      {
+        "name": "EvtVend",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Module Event Flags",
+        "desc": "Vendor specific flags"
+      },
+      {
+        "name": "Ctl",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Control",
+        "desc": "Module Control"
+      },
+      {
+        "name": "CtlVend",
+        "type": "enum32",
+        "size": 2,
+        "access": "RW",
+        "label": "Vendor Control",
+        "desc": "Vendor Module Control"
+      },
+      {
+        "name": "CtlVal",
+        "type": "int32",
+        "size": 2,
+        "access": "RW",
+        "label": "Control Value",
+        "desc": "Module Control Value"
+      },
+      {
+        "name": "Tms",
+        "type": "uint32",
+        "size": 2,
+        "units": "Secs",
+        "label": "Timestamp",
+        "desc": "Time in seconds since 2000 epoch"
+      },
+      {
+        "name": "OutA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Output Current",
+        "desc": "Output Current"
+      },
+      {
+        "name": "OutV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Output Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "OutWh",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Output Energy",
+        "desc": "Output Energy"
+      },
+      {
+        "name": "OutW",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Output Power",
+        "desc": "Output Power"
+      },
+      {
+        "name": "Tmp",
+        "type": "float32",
+        "size": 2,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Module Temperature"
+      },
+      {
+        "name": "InA",
+        "type": "float32",
+        "size": 2,
+        "units": "A",
+        "label": "Input Current",
+        "desc": "Input Current"
+      },
+      {
+        "name": "InV",
+        "type": "float32",
+        "size": 2,
+        "units": "V",
+        "label": "Input Voltage",
+        "desc": "Input Voltage"
+      },
+      {
+        "name": "InWh",
+        "type": "float32",
+        "size": 2,
+        "units": "Wh",
+        "label": "Input Energy",
+        "desc": "Input Energy"
+      },
+      {
+        "name": "InW",
+        "type": "float32",
+        "size": 2,
+        "units": "W",
+        "label": "Input Power",
+        "desc": "Input Power"
+      }
+    ]
+  },
+  "id": 501
+}

--- a/models/model_502.json
+++ b/models/model_502.json
@@ -1,0 +1,372 @@
+{
+  "group": {
+    "name": "solar_module",
+    "type": "group",
+    "label": "Solar Module",
+    "desc": "A solar module model supporting DC-DC converter",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 502
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Current scale factor"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Voltage scale factor"
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Power scale factor"
+      },
+      {
+        "name": "Wh_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Energy scale factor"
+      },
+      {
+        "name": "Stat",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status",
+        "desc": "Enumerated value.  Module Status Code",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1,
+            "label": "Off",
+            "desc": "Module is in the OFF state"
+          },
+          {
+            "name": "SLEEPING",
+            "value": 2,
+            "label": "SLEEPING",
+            "desc": "Sleeping (auto-shutdown) or panel is at low/safe output power/voltage"
+          },
+          {
+            "name": "STARTING",
+            "value": 3,
+            "label": "STARTING",
+            "desc": "Starting up or ON but not producing power; panel might have high voltage but is not producing power"
+          },
+          {
+            "name": "MPPT",
+            "value": 4,
+            "label": "MPPT",
+            "desc": "Tracking MPPT power point"
+          },
+          {
+            "name": "THROTTLED",
+            "value": 5,
+            "label": "THROTTLED",
+            "desc": "Forced power reduction / power de-rating"
+          },
+          {
+            "name": "SHUTTING_DOWN",
+            "value": 6,
+            "label": "SHUTTING_DOWN",
+            "desc": "Shutting down"
+          },
+          {
+            "name": "FAULT",
+            "value": 7,
+            "label": "FAULT",
+            "desc": "One or more faults exist"
+          },
+          {
+            "name": "STANDBY",
+            "value": 8,
+            "label": "STANDBY",
+            "desc": "Standby (service or unit) - unlike SLEEPING in this mode the module might be at a high (unsafe) output voltage or power"
+          },
+          {
+            "name": "TEST",
+            "value": 9,
+            "label": "TEST",
+            "desc": "Test mode"
+          },
+          {
+            "name": "OTHER",
+            "value": 10,
+            "label": "OTHER",
+            "desc": "As defined in vendor specific status"
+          }
+        ]
+      },
+      {
+        "name": "StatVend",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Status",
+        "desc": "Module Vendor Status Code"
+      },
+      {
+        "name": "Evt",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Events",
+        "desc": "Bitmask value.  Module Event Flags",
+        "symbols": [
+          {
+            "name": "GROUND_FAULT",
+            "value": 0,
+            "label": "Ground Fault",
+            "desc": "Ground Fault"
+          },
+          {
+            "name": "INPUT_OVER_VOLTAGE",
+            "value": 1,
+            "label": "Over Voltage",
+            "desc": "DC input over-voltage"
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 2
+          },
+          {
+            "name": "DC_DISCONNECT",
+            "value": 3,
+            "label": "Disconnect",
+            "desc": "DC disconnect open"
+          },
+          {
+            "name": "RESERVED_4",
+            "value": 4
+          },
+          {
+            "name": "RESERVED_5",
+            "value": 5
+          },
+          {
+            "name": "MANUAL_SHUTDOWN",
+            "value": 6,
+            "label": "Manual shutdown",
+            "desc": "Manual shutdown"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 7,
+            "label": "Over Temperature",
+            "desc": "Over Temperature"
+          },
+          {
+            "name": "RESERVED_8",
+            "value": 8
+          },
+          {
+            "name": "RESERVED_9",
+            "value": 9
+          },
+          {
+            "name": "RESERVED_10",
+            "value": 10
+          },
+          {
+            "name": "RESERVED_11",
+            "value": 11
+          },
+          {
+            "name": "BLOWN_FUSE",
+            "value": 12,
+            "label": "Blown Fuse",
+            "desc": "Input fuse is blown"
+          },
+          {
+            "name": "UNDER_TEMPERATURE",
+            "value": 13,
+            "label": "Under Temperature",
+            "desc": "Under Temperature"
+          },
+          {
+            "name": "MEMORY_LOSS",
+            "value": 14,
+            "label": "Memory Loss",
+            "desc": "Generic Memory or Communication Error"
+          },
+          {
+            "name": "ARC_DETECTION",
+            "value": 15,
+            "label": "Arc Detection",
+            "desc": "Arc Detection"
+          },
+          {
+            "name": "THEFT_DETECTION",
+            "value": 16,
+            "label": "Theft Detection",
+            "desc": "Theft Detection"
+          },
+          {
+            "name": "OUTPUT_OVER_CURRENT",
+            "value": 17,
+            "label": "Over Current",
+            "desc": "Output Over Current"
+          },
+          {
+            "name": "OUTPUT_OVER_VOLTAGE",
+            "value": 18,
+            "label": "Output Over Voltage",
+            "desc": "DC Output Over Voltage"
+          },
+          {
+            "name": "OUTPUT_UNDER_VOLTAGE",
+            "value": 19,
+            "label": "Output Under Voltage",
+            "desc": "DC Output Under Voltage"
+          },
+          {
+            "name": "TEST_FAILED",
+            "value": 20,
+            "label": "Test Failed",
+            "desc": "Last Self Test failed; see vendor event for details"
+          }
+        ]
+      },
+      {
+        "name": "EvtVend",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Module Event Flags",
+        "desc": "Vendor specific flags"
+      },
+      {
+        "name": "Ctl",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Control",
+        "desc": "Module Control"
+      },
+      {
+        "name": "CtlVend",
+        "type": "enum32",
+        "size": 2,
+        "access": "RW",
+        "label": "Vendor Control",
+        "desc": "Vendor Module Control"
+      },
+      {
+        "name": "CtlVal",
+        "type": "int32",
+        "size": 2,
+        "access": "RW",
+        "label": "Control Value",
+        "desc": "Module Control Value"
+      },
+      {
+        "name": "Tms",
+        "type": "uint32",
+        "size": 2,
+        "units": "Secs",
+        "label": "Timestamp",
+        "desc": "Time in seconds since 2000 epoch"
+      },
+      {
+        "name": "OutA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Output Current",
+        "desc": "Output Current"
+      },
+      {
+        "name": "OutV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Output Voltage",
+        "desc": "Output Voltage"
+      },
+      {
+        "name": "OutWh",
+        "type": "acc32",
+        "size": 2,
+        "sf": "Wh_SF",
+        "units": "Wh",
+        "label": "Output Energy",
+        "desc": "Output Energy"
+      },
+      {
+        "name": "OutPw",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Output Power",
+        "desc": "Output Power"
+      },
+      {
+        "name": "Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Temp",
+        "desc": "Module Temperature"
+      },
+      {
+        "name": "InA",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Input Current",
+        "desc": "Input Current"
+      },
+      {
+        "name": "InV",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Input Voltage",
+        "desc": "Input Voltage"
+      },
+      {
+        "name": "InWh",
+        "type": "acc32",
+        "size": 2,
+        "sf": "Wh_SF",
+        "units": "Wh",
+        "label": "Input Energy",
+        "desc": "Input Energy"
+      },
+      {
+        "name": "InW",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Input Power",
+        "desc": "Input Power"
+      }
+    ]
+  },
+  "id": 502
+}

--- a/models/model_6.json
+++ b/models/model_6.json
@@ -1,0 +1,709 @@
+{
+  "group": {
+    "name": "model_6",
+    "type": "group",
+    "label": "Secure Write Sequential Request",
+    "desc": "Include a digital signature along with the control data",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 6
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "X",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "X",
+        "desc": "Number of (offset, value) pairs being written"
+      },
+      {
+        "name": "Off",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Offset",
+        "desc": "Starting offset for write operation"
+      },
+      {
+        "name": "Val1",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Value1",
+        "desc": "Value to write to control register at offset"
+      },
+      {
+        "name": "Val2",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val3",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val4",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val5",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val6",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val7",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val8",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val9",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val10",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val11",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val12",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val13",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val14",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val15",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val16",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val17",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val18",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val19",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val20",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val21",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val22",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val23",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val24",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val25",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val26",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val27",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val28",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val29",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val30",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val31",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val32",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val33",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val34",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val35",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val36",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val37",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val38",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val39",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val40",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val41",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val42",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val43",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val44",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val45",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val46",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val47",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val48",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val49",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val50",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val51",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val52",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val53",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val54",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val55",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val56",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val57",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val58",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val59",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val60",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val61",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val62",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val63",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val64",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val65",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val66",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val67",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val68",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val69",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val70",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val71",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val72",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val73",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val74",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val75",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val76",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val77",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val78",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val79",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Val80",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of request"
+      },
+      {
+        "name": "Role",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Role",
+        "desc": "Signing key used 0-5"
+      },
+      {
+        "name": "Rsrvd",
+        "type": "pad",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "DS",
+            "desc": "Digital Signature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 6
+}

--- a/models/model_601.json
+++ b/models/model_601.json
@@ -1,0 +1,330 @@
+{
+  "group": {
+    "name": "tracker_controller",
+    "type": "group",
+    "label": "Tracker Controller DRAFT 2",
+    "desc": "Monitors and controls multiple trackers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 601
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Nam",
+        "type": "string",
+        "size": 8,
+        "label": "Controller",
+        "desc": "Descriptive name for this control unit"
+      },
+      {
+        "name": "Typ",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Type",
+        "desc": "Type of tracker",
+        "symbols": [
+          {
+            "name": "Unknown",
+            "value": 0,
+            "label": "Unknown",
+            "desc": "Not Set"
+          },
+          {
+            "name": "Fixed",
+            "value": 1,
+            "label": "Fixed",
+            "desc": "Documented orientation information"
+          },
+          {
+            "name": "Horizontal",
+            "value": 2,
+            "label": "Horizontal",
+            "desc": "Single Axis Horizontal"
+          },
+          {
+            "name": "Tilted",
+            "value": 3,
+            "label": "Tilted",
+            "desc": "Single Axis Tilted Horizontal"
+          },
+          {
+            "name": "Azimuth",
+            "value": 4,
+            "label": "Azimuth",
+            "desc": "Single Axis Azimuth"
+          },
+          {
+            "name": "Dual",
+            "value": 5,
+            "label": "Dual",
+            "desc": "Dual Axis"
+          },
+          {
+            "name": "Other",
+            "value": 99,
+            "label": "Other",
+            "desc": "Other type"
+          }
+        ]
+      },
+      {
+        "name": "DtLoc",
+        "type": "string",
+        "size": 5,
+        "units": "YYYYMMDD",
+        "label": "Date",
+        "desc": "Local date in YYYYMMDD format"
+      },
+      {
+        "name": "TmLoc",
+        "type": "string",
+        "size": 3,
+        "units": "hhmmss",
+        "label": "Time",
+        "desc": "24 hour local time stamp to second"
+      },
+      {
+        "name": "Day",
+        "type": "uint16",
+        "size": 1,
+        "label": "Day",
+        "desc": "Number of the day in the year (1-366)"
+      },
+      {
+        "name": "GlblElCtl",
+        "type": "int32",
+        "size": 2,
+        "sf": "Dgr_SF",
+        "units": "Degrees",
+        "access": "RW",
+        "label": "Manual Elevation",
+        "desc": "Global manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"
+      },
+      {
+        "name": "GlblAzCtl",
+        "type": "int32",
+        "size": 2,
+        "sf": "Dgr_SF",
+        "units": "Degrees",
+        "access": "RW",
+        "label": "Manual Azimuth",
+        "desc": "Global manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"
+      },
+      {
+        "name": "GlblCtl",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Global Mode",
+        "desc": "Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
+        "symbols": [
+          {
+            "name": "Automatic",
+            "value": 0,
+            "label": "Auto",
+            "desc": "Follow programmed path"
+          },
+          {
+            "name": "Manual",
+            "value": 1,
+            "label": "Manual",
+            "desc": "Go to a fixed position"
+          },
+          {
+            "name": "Calibrate",
+            "value": 2,
+            "label": "Calibrate",
+            "desc": "Execute test mode"
+          }
+        ]
+      },
+      {
+        "name": "GlblAlm",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "Global Alarm",
+        "desc": "Global tracker alarm conditions",
+        "symbols": [
+          {
+            "name": "SetPoint",
+            "value": 0,
+            "label": "SetPoint",
+            "desc": "One or more trackers are NOT at SetPoint"
+          },
+          {
+            "name": "ObsEl",
+            "value": 1,
+            "label": "ObsEl",
+            "desc": "One or more trackers ELEVATION motor is obstructed"
+          },
+          {
+            "name": "ObsAz",
+            "value": 2,
+            "label": "ObsAz",
+            "desc": "One or more trackers AZIMUTH motor is obstructed"
+          }
+        ]
+      },
+      {
+        "name": "Dgr_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "SF",
+        "desc": "Scale Factor for targets and position measurements in degrees"
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Trackers",
+        "desc": "Number of trackers being controlled.  Size of repeating block."
+      }
+    ],
+    "groups": [
+      {
+        "name": "tracker",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "Id",
+            "type": "string",
+            "size": 8,
+            "label": "Tracker",
+            "desc": "Descriptive name for this tracker unit"
+          },
+          {
+            "name": "ElTrgt",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "label": "Target Elevation",
+            "desc": "Auto target elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"
+          },
+          {
+            "name": "AzTrgt",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "label": "Target Azimuth",
+            "desc": "Auto target azimuth  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"
+          },
+          {
+            "name": "ElPos",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "label": "Elevation",
+            "desc": "Actual elevation position  in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"
+          },
+          {
+            "name": "AzPos",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "label": "Azimuth",
+            "desc": "Actual azimuth position  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type"
+          },
+          {
+            "name": "ElCtl",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "access": "RW",
+            "label": "Manual Elevation",
+            "desc": "Manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type"
+          },
+          {
+            "name": "AzCtl",
+            "type": "int32",
+            "size": 2,
+            "sf": "Dgr_SF",
+            "units": "Degrees",
+            "access": "RW",
+            "label": "Manual Azimuth",
+            "desc": "Manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type"
+          },
+          {
+            "name": "Ctl",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Mode",
+            "desc": "Control register. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
+            "symbols": [
+              {
+                "name": "Automatic",
+                "value": 0,
+                "label": "Auto",
+                "desc": "Follow programmed path"
+              },
+              {
+                "name": "Manual",
+                "value": 1,
+                "label": "Manual",
+                "desc": "Go to a fixed position"
+              },
+              {
+                "name": "Calibrate",
+                "value": 2,
+                "label": "Calibrate",
+                "desc": "Execute test mode"
+              }
+            ]
+          },
+          {
+            "name": "Alm",
+            "type": "bitfield16",
+            "size": 1,
+            "label": "Alarm",
+            "desc": "Tracker alarm conditions",
+            "symbols": [
+              {
+                "name": "SetPoint",
+                "value": 0,
+                "label": "SetPoint",
+                "desc": "Tracker NOT at SetPoint"
+              },
+              {
+                "name": "ObsEl",
+                "value": 1,
+                "label": "ObsEl",
+                "desc": "Tracker ELEVATION motor is obstructed"
+              },
+              {
+                "name": "ObsAz",
+                "value": 2,
+                "label": "ObsAz",
+                "desc": "Tracker AZIMUTH motor is obstructed"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 601
+}

--- a/models/model_63001.json
+++ b/models/model_63001.json
@@ -1,0 +1,421 @@
+{
+  "group": {
+    "name": "model_63001",
+    "type": "group",
+    "label": "SunSpec Test Model 1",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 63001
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "sunssf_1",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "sunssf_2",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "sunssf_3",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "sunssf_4",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "int16_1",
+        "type": "int16",
+        "size": 1,
+        "sf": "sunssf_1"
+      },
+      {
+        "name": "int16_2",
+        "type": "int16",
+        "size": 1,
+        "sf": "sunssf_2"
+      },
+      {
+        "name": "int16_3",
+        "type": "int16",
+        "size": 1,
+        "sf": "sunssf_3"
+      },
+      {
+        "name": "int16_4",
+        "type": "int16",
+        "size": 1,
+        "sf": "sunssf_4",
+        "access": "RW"
+      },
+      {
+        "name": "int16_5",
+        "type": "int16",
+        "size": 1
+      },
+      {
+        "name": "int16_u",
+        "type": "int16",
+        "size": 1
+      },
+      {
+        "name": "uint16_1",
+        "type": "uint16",
+        "size": 1,
+        "sf": "sunssf_1"
+      },
+      {
+        "name": "uint16_2",
+        "type": "uint16",
+        "size": 1,
+        "sf": "sunssf_2"
+      },
+      {
+        "name": "uint16_3",
+        "type": "uint16",
+        "size": 1,
+        "sf": "sunssf_3"
+      },
+      {
+        "name": "uint16_4",
+        "type": "uint16",
+        "size": 1,
+        "sf": "sunssf_4",
+        "access": "RW"
+      },
+      {
+        "name": "uint16_5",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "uint16_u",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "acc16",
+        "type": "acc16",
+        "size": 1
+      },
+      {
+        "name": "acc16_u",
+        "type": "acc16",
+        "size": 1
+      },
+      {
+        "name": "enum16",
+        "type": "enum16",
+        "size": 1
+      },
+      {
+        "name": "enum16_u",
+        "type": "enum16",
+        "size": 1
+      },
+      {
+        "name": "bitfield16",
+        "type": "bitfield16",
+        "size": 1
+      },
+      {
+        "name": "bitfield16_u",
+        "type": "bitfield16",
+        "size": 1
+      },
+      {
+        "name": "int32_1",
+        "type": "int32",
+        "size": 2,
+        "sf": "sunssf_5"
+      },
+      {
+        "name": "int32_2",
+        "type": "int32",
+        "size": 2,
+        "sf": "sunssf_6"
+      },
+      {
+        "name": "int32_3",
+        "type": "int32",
+        "size": 2,
+        "sf": "sunssf_7",
+        "access": "RW"
+      },
+      {
+        "name": "int32_4",
+        "type": "int32",
+        "size": 2
+      },
+      {
+        "name": "int32_5",
+        "type": "int32",
+        "size": 2
+      },
+      {
+        "name": "int32_u",
+        "type": "int32",
+        "size": 2
+      },
+      {
+        "name": "uint32_1",
+        "type": "uint32",
+        "size": 2,
+        "sf": "sunssf_5"
+      },
+      {
+        "name": "uint32_2",
+        "type": "uint32",
+        "size": 2,
+        "sf": "sunssf_6"
+      },
+      {
+        "name": "uint32_3",
+        "type": "uint32",
+        "size": 2,
+        "sf": "sunssf_7",
+        "access": "RW"
+      },
+      {
+        "name": "uint32_4",
+        "type": "uint32",
+        "size": 2,
+        "sf": 1
+      },
+      {
+        "name": "uint32_5",
+        "type": "uint32",
+        "size": 2
+      },
+      {
+        "name": "uint32_u",
+        "type": "uint32",
+        "size": 2
+      },
+      {
+        "name": "acc32",
+        "type": "acc32",
+        "size": 2
+      },
+      {
+        "name": "acc32_u",
+        "type": "acc32",
+        "size": 2
+      },
+      {
+        "name": "enum32",
+        "type": "enum32",
+        "size": 2
+      },
+      {
+        "name": "enum32_u",
+        "type": "enum32",
+        "size": 2
+      },
+      {
+        "name": "bitfield32",
+        "type": "bitfield32",
+        "size": 2
+      },
+      {
+        "name": "bitfield32_u",
+        "type": "bitfield32",
+        "size": 2
+      },
+      {
+        "name": "ipaddr",
+        "type": "ipaddr",
+        "size": 2,
+        "access": "RW"
+      },
+      {
+        "name": "ipaddr_u",
+        "type": "ipaddr",
+        "size": 2
+      },
+      {
+        "name": "int64",
+        "type": "int64",
+        "size": 4,
+        "access": "RW"
+      },
+      {
+        "name": "int64_u",
+        "type": "int64",
+        "size": 4
+      },
+      {
+        "name": "acc64",
+        "type": "acc64",
+        "size": 4
+      },
+      {
+        "name": "acc64_u",
+        "type": "acc64",
+        "size": 4
+      },
+      {
+        "name": "ipv6addr",
+        "type": "ipv6addr",
+        "size": 8
+      },
+      {
+        "name": "ipv6addr_u",
+        "type": "ipv6addr",
+        "size": 8
+      },
+      {
+        "name": "float32",
+        "type": "float32",
+        "size": 2,
+        "access": "RW"
+      },
+      {
+        "name": "float32_u",
+        "type": "float32",
+        "size": 2
+      },
+      {
+        "name": "string",
+        "type": "string",
+        "size": 16,
+        "access": "RW"
+      },
+      {
+        "name": "string_u",
+        "type": "string",
+        "size": 16
+      },
+      {
+        "name": "sunssf_5",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "sunssf_6",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "sunssf_7",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "pad_1",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "sunssf_8",
+            "type": "sunssf",
+            "size": 1
+          },
+          {
+            "name": "int16_11",
+            "type": "int16",
+            "size": 1,
+            "sf": "sunssf_8",
+            "access": "RW"
+          },
+          {
+            "name": "int16_12",
+            "type": "int16",
+            "size": 1,
+            "sf": "sunssf_9"
+          },
+          {
+            "name": "int16_u",
+            "type": "int16",
+            "size": 1
+          },
+          {
+            "name": "uint16_11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sunssf_8",
+            "access": "RW"
+          },
+          {
+            "name": "uint16_12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sunssf_9"
+          },
+          {
+            "name": "uint16_13",
+            "type": "uint16",
+            "size": 1
+          },
+          {
+            "name": "uint16_u",
+            "type": "uint16",
+            "size": 1
+          },
+          {
+            "name": "int32",
+            "type": "int32",
+            "size": 2,
+            "sf": "sunssf_1",
+            "access": "RW"
+          },
+          {
+            "name": "int32_u",
+            "type": "int32",
+            "size": 2
+          },
+          {
+            "name": "uint32",
+            "type": "uint32",
+            "size": 2,
+            "sf": "sunssf_9",
+            "access": "RW"
+          },
+          {
+            "name": "uint32_u",
+            "type": "uint32",
+            "size": 2
+          },
+          {
+            "name": "sunssf_9",
+            "type": "sunssf",
+            "size": 1
+          },
+          {
+            "name": "pad_2",
+            "type": "pad",
+            "size": 1
+          }
+        ]
+      }
+    ]
+  },
+  "id": 63001
+}

--- a/models/model_63002.json
+++ b/models/model_63002.json
@@ -1,0 +1,61 @@
+{
+  "group": {
+    "name": "model_63002",
+    "type": "group",
+    "label": "SunSpec Test Model 2",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 63002
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "sunssf_1",
+            "type": "sunssf",
+            "size": 1
+          },
+          {
+            "name": "int16_1",
+            "type": "int16",
+            "size": 1,
+            "sf": "sunssf_1",
+            "access": "RW"
+          },
+          {
+            "name": "int16_2",
+            "type": "int16",
+            "size": 1,
+            "sf": "sunssf_2"
+          },
+          {
+            "name": "sunssf_2",
+            "type": "sunssf",
+            "size": 1
+          }
+        ]
+      }
+    ]
+  },
+  "id": 63002
+}

--- a/models/model_64001.json
+++ b/models/model_64001.json
@@ -1,0 +1,241 @@
+{
+  "group": {
+    "name": "model_64001",
+    "type": "group",
+    "label": "Veris Status and Configuration",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64001
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Cmd",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Command Code"
+      },
+      {
+        "name": "HWRev",
+        "type": "uint16",
+        "size": 1,
+        "label": "Hardware Revision"
+      },
+      {
+        "name": "RSFWRev",
+        "type": "uint16",
+        "size": 1,
+        "label": "RS FW Revision"
+      },
+      {
+        "name": "OSFWRev",
+        "type": "uint16",
+        "size": 1,
+        "label": "OS FW Revision"
+      },
+      {
+        "name": "ProdRev",
+        "type": "string",
+        "size": 2,
+        "label": "Product Revision"
+      },
+      {
+        "name": "Boots",
+        "type": "uint16",
+        "size": 1,
+        "label": "Boot Count"
+      },
+      {
+        "name": "Switch",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "DIP Switches"
+      },
+      {
+        "name": "Sensors",
+        "type": "uint16",
+        "size": 1,
+        "label": "Num Detected Sensors"
+      },
+      {
+        "name": "Talking",
+        "type": "uint16",
+        "size": 1,
+        "label": "Num Communicating Sensors"
+      },
+      {
+        "name": "Status",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "System Status"
+      },
+      {
+        "name": "Config",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "System Configuration"
+      },
+      {
+        "name": "LEDblink",
+        "type": "uint16",
+        "size": 1,
+        "units": "Pct",
+        "label": "LED Blink Threshold"
+      },
+      {
+        "name": "LEDon",
+        "type": "uint16",
+        "size": 1,
+        "units": "Pct",
+        "label": "LED On Threshold"
+      },
+      {
+        "name": "Reserved",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Loc",
+        "type": "string",
+        "size": 16,
+        "label": "Location String"
+      },
+      {
+        "name": "S1ID",
+        "type": "enum16",
+        "size": 1,
+        "label": "Sensor 1 Unit ID"
+      },
+      {
+        "name": "S1Addr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 1 Address"
+      },
+      {
+        "name": "S1OSVer",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 1 OS Version"
+      },
+      {
+        "name": "S1Ver",
+        "type": "string",
+        "size": 2,
+        "label": "Sensor 1 Product Version"
+      },
+      {
+        "name": "S1Serial",
+        "type": "string",
+        "size": 5,
+        "label": "Sensor 1 Serial Num"
+      },
+      {
+        "name": "S2ID",
+        "type": "enum16",
+        "size": 1,
+        "label": "Sensor 2 Unit ID"
+      },
+      {
+        "name": "S2Addr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 2 Address"
+      },
+      {
+        "name": "S2OSVer",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 2 OS Version"
+      },
+      {
+        "name": "S2Ver",
+        "type": "string",
+        "size": 2,
+        "label": "Sensor 2 Product Version"
+      },
+      {
+        "name": "S2Serial",
+        "type": "string",
+        "size": 5,
+        "label": "Sensor 2 Serial Num"
+      },
+      {
+        "name": "S3ID",
+        "type": "enum16",
+        "size": 1,
+        "label": "Sensor 3 Unit ID"
+      },
+      {
+        "name": "S3Addr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 3 Address"
+      },
+      {
+        "name": "S3OSVer",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 3 OS Version"
+      },
+      {
+        "name": "S3Ver",
+        "type": "string",
+        "size": 2,
+        "label": "Sensor 3 Product Version"
+      },
+      {
+        "name": "S3Serial",
+        "type": "string",
+        "size": 5,
+        "label": "Sensor 3 Serial Num"
+      },
+      {
+        "name": "S4ID",
+        "type": "enum16",
+        "size": 1,
+        "label": "Sensor 4 Unit ID"
+      },
+      {
+        "name": "S4Addr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 4 Address"
+      },
+      {
+        "name": "S4OSVer",
+        "type": "uint16",
+        "size": 1,
+        "label": "Sensor 4 OS Version"
+      },
+      {
+        "name": "S4Ver",
+        "type": "string",
+        "size": 2,
+        "label": "Sensor 4 Product Version"
+      },
+      {
+        "name": "S4Serial",
+        "type": "string",
+        "size": 5,
+        "label": "Sensor 4 Serial Num"
+      }
+    ]
+  },
+  "id": 64001
+}

--- a/models/model_64020.json
+++ b/models/model_64020.json
@@ -1,0 +1,300 @@
+{
+  "group": {
+    "name": "model_64020",
+    "type": "group",
+    "label": "Mersen GreenString",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64020
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Aux0Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Aux 0 temperature"
+      },
+      {
+        "name": "Aux1Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Aux 1 temperature"
+      },
+      {
+        "name": "Aux2Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Aux 2 temperature"
+      },
+      {
+        "name": "Aux3Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Aux 3 temperature"
+      },
+      {
+        "name": "Aux4Tmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "label": "Aux 4 temperature"
+      },
+      {
+        "name": "ProbeTmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "mandatory": "M",
+        "label": "Probe Temperature"
+      },
+      {
+        "name": "MainTmp",
+        "type": "int16",
+        "size": 1,
+        "units": "C",
+        "mandatory": "M",
+        "label": "Main Temperature"
+      },
+      {
+        "name": "SensorV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Voltage scale factor for the sensors"
+      },
+      {
+        "name": "SensorA_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Current scale factor for the sensors"
+      },
+      {
+        "name": "SensorHz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Frequency scale factor for the sensors"
+      },
+      {
+        "name": "Sensor1Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor1 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor2Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor2 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor3Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor3 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor4Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor4 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor5Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor5 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor6Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor6 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor7Voltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorV_SF",
+        "units": "V",
+        "label": "Sensor7 Voltage",
+        "desc": "scale of 0-10V"
+      },
+      {
+        "name": "Sensor1Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor1 Current",
+        "desc": "scale of 4-20mA"
+      },
+      {
+        "name": "Sensor2Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor2 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor3Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor3 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor4Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor4 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor5Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor5 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor6Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor6 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor7Current",
+        "type": "int16",
+        "size": 1,
+        "sf": "SensorA_SF",
+        "units": "A",
+        "label": "Sensor7 Current",
+        "desc": "in 4-20mA or 4-20mA"
+      },
+      {
+        "name": "Sensor8",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SensorHz_SF",
+        "units": "Hz",
+        "label": "Sensor8 frequency",
+        "desc": "frequency in Hz"
+      },
+      {
+        "name": "Relay1",
+        "type": "uint16",
+        "size": 1,
+        "label": "Relay 1 state"
+      },
+      {
+        "name": "Relay2",
+        "type": "uint16",
+        "size": 1,
+        "label": "Relay 2 state"
+      },
+      {
+        "name": "Relay3",
+        "type": "uint16",
+        "size": 1,
+        "label": "Relay 3 state"
+      },
+      {
+        "name": "ResetAccumulators",
+        "type": "uint16",
+        "size": 1,
+        "label": "Reset the accumulators",
+        "desc": "always 0 in reading, used the code 0xC0DA during the writing for resetting them"
+      },
+      {
+        "name": "Reset",
+        "type": "uint16",
+        "size": 1,
+        "label": "Reset the system",
+        "desc": "always 0 in reading, used the code 0xC0DA during the writing for resetting the system"
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "SerialNumber",
+            "type": "string",
+            "size": 9,
+            "mandatory": "M",
+            "label": "Serial number",
+            "desc": "strings of 16 characters"
+          },
+          {
+            "name": "Firmware",
+            "type": "string",
+            "size": 6,
+            "mandatory": "M",
+            "label": "Firmware version",
+            "desc": "string of 11 characters"
+          },
+          {
+            "name": "Hardware",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Hardware version"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64020
+}

--- a/models/model_64101.json
+++ b/models/model_64101.json
@@ -1,0 +1,64 @@
+{
+  "group": {
+    "name": "model_64101",
+    "type": "group",
+    "label": "Eltek Inverter Extension",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64101
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Eltek_Country_Code",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_Feeding_Phase",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_APD_Method",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_APD_Power_Ref",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_RPS_Method",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_RPS_Q_Ref",
+        "type": "uint16",
+        "size": 1
+      },
+      {
+        "name": "Eltek_RPS_CosPhi_Ref",
+        "type": "int16",
+        "size": 1
+      }
+    ]
+  },
+  "id": 64101
+}

--- a/models/model_64110.json
+++ b/models/model_64110.json
@@ -1,0 +1,417 @@
+{
+  "group": {
+    "name": "model_64110",
+    "type": "group",
+    "label": "OutBack AXS device",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64110
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "MajorFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AXS Major Firmware Number"
+      },
+      {
+        "name": "MidFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AXS Mid Firmware Number"
+      },
+      {
+        "name": "MinorFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AXS Minor Firmware Number"
+      },
+      {
+        "name": "EncrypKey",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Encryption Key"
+      },
+      {
+        "name": "MAC_Address",
+        "type": "string",
+        "size": 7,
+        "mandatory": "M",
+        "label": "MAC Address"
+      },
+      {
+        "name": "WritePassword",
+        "type": "string",
+        "size": 8,
+        "mandatory": "M",
+        "label": "Write Password"
+      },
+      {
+        "name": "EnableDHCP",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable DHCP"
+      },
+      {
+        "name": "TCPIP_address",
+        "type": "ipaddr",
+        "size": 2,
+        "mandatory": "M",
+        "label": "TCPIP Address"
+      },
+      {
+        "name": "Gateway_address",
+        "type": "ipaddr",
+        "size": 2,
+        "mandatory": "M",
+        "label": "TCPIP Gateway"
+      },
+      {
+        "name": "TCPIP_Netmask",
+        "type": "ipaddr",
+        "size": 2,
+        "mandatory": "M",
+        "label": "TCPIP Netmask"
+      },
+      {
+        "name": "DNS1_address",
+        "type": "ipaddr",
+        "size": 2,
+        "mandatory": "M",
+        "label": "TCPIP DNS1"
+      },
+      {
+        "name": "DNS2_address",
+        "type": "ipaddr",
+        "size": 2,
+        "mandatory": "M",
+        "label": "TCPIP DNS2"
+      },
+      {
+        "name": "Modbus_port",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "ModBus Port"
+      },
+      {
+        "name": "SMTP_server_nm",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "SMTP Server Name"
+      },
+      {
+        "name": "SMTP_account_nm",
+        "type": "string",
+        "size": 16,
+        "mandatory": "M",
+        "label": "SMTP Account Name"
+      },
+      {
+        "name": "SMTP_enable_SSL",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable SMTP SSL",
+        "symbols": [
+          {
+            "name": "ASX_DISABLED",
+            "value": 0,
+            "label": "Disabled"
+          },
+          {
+            "name": "ASX_ENABLED",
+            "value": 1,
+            "label": "Enabled"
+          }
+        ]
+      },
+      {
+        "name": "SMTP_password",
+        "type": "string",
+        "size": 8,
+        "mandatory": "M",
+        "label": "SMTP Password"
+      },
+      {
+        "name": "SMTP_user_nm",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "SMTP User Name"
+      },
+      {
+        "name": "Stat_email_int",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status Email Interval"
+      },
+      {
+        "name": "Stat_start_HR",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status Email Start Hour"
+      },
+      {
+        "name": "Stat_email_sub",
+        "type": "string",
+        "size": 25,
+        "mandatory": "M",
+        "label": "Status Email Subject"
+      },
+      {
+        "name": "Stat_email_addr1",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "Status Email to Address 1"
+      },
+      {
+        "name": "Stat_email_addr2",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "Status Email to Address 2"
+      },
+      {
+        "name": "Alarm_email_en",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable Alarm Email",
+        "symbols": [
+          {
+            "name": "ASX_DISABLED",
+            "value": 0,
+            "label": "Disabled"
+          },
+          {
+            "name": "ASX_ENABLED",
+            "value": 1,
+            "label": "Enabled"
+          }
+        ]
+      },
+      {
+        "name": "Alarm_email_sub",
+        "type": "string",
+        "size": 25,
+        "mandatory": "M",
+        "label": "Alarm Email Subject"
+      },
+      {
+        "name": "Alarm_email_addr1",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "Alarm Email to Address 1"
+      },
+      {
+        "name": "Alarm_email_addr2",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "Alarm Email to Address 2"
+      },
+      {
+        "name": "FTP_password",
+        "type": "string",
+        "size": 8,
+        "mandatory": "M",
+        "label": "FTP Password"
+      },
+      {
+        "name": "TELNET_password",
+        "type": "string",
+        "size": 8,
+        "mandatory": "M",
+        "label": "Telnet Password"
+      },
+      {
+        "name": "Log_write_int",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "SD-Card Datalog Write Interval"
+      },
+      {
+        "name": "Log_retain",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tmd",
+        "mandatory": "M",
+        "label": "SD-Card Datalog Retain"
+      },
+      {
+        "name": "Log_mode",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "SD-Card Datalog Mode",
+        "symbols": [
+          {
+            "name": "LOG_DISABLED",
+            "value": 0,
+            "label": "Disabled"
+          },
+          {
+            "name": "LOG_EXCEL",
+            "value": 1,
+            "label": "Excel"
+          },
+          {
+            "name": "LOG_COMPACT",
+            "value": 2,
+            "label": "Compact"
+          }
+        ]
+      },
+      {
+        "name": "NTP_server_nm",
+        "type": "string",
+        "size": 20,
+        "mandatory": "M",
+        "label": "NTP Timer Server Name"
+      },
+      {
+        "name": "NTP_enable",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable Network Time",
+        "symbols": [
+          {
+            "name": "ASX_DISABLED",
+            "value": 0,
+            "label": "Disabled"
+          },
+          {
+            "name": "ASX_ENABLED",
+            "value": 1,
+            "label": "Enabled"
+          }
+        ]
+      },
+      {
+        "name": "TimeZone",
+        "type": "int16",
+        "size": 1,
+        "units": "Tmh",
+        "mandatory": "M",
+        "label": "Time Zone"
+      },
+      {
+        "name": "Date_year",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Year"
+      },
+      {
+        "name": "Date_month",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Month"
+      },
+      {
+        "name": "Date_Day",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Day"
+      },
+      {
+        "name": "Time_hour",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hour"
+      },
+      {
+        "name": "Time_minute",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Minute"
+      },
+      {
+        "name": "Time_second",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Second"
+      },
+      {
+        "name": "Battery_temp",
+        "type": "int16",
+        "size": 1,
+        "sf": "Temp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Battery Temperature"
+      },
+      {
+        "name": "Ambient_temp",
+        "type": "int16",
+        "size": 1,
+        "sf": "Temp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Ambient Temperature"
+      },
+      {
+        "name": "Temp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "AXS_Error",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AXS Error"
+      },
+      {
+        "name": "AXS_Status",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AXS Status"
+      },
+      {
+        "name": "AXS_Spare",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Spare"
+      }
+    ]
+  },
+  "id": 64110
+}

--- a/models/model_64111.json
+++ b/models/model_64111.json
@@ -1,0 +1,244 @@
+{
+  "group": {
+    "name": "model_64111",
+    "type": "group",
+    "label": "Basic Charge Controller",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64111
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Port",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Port Number"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "P_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "AH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "KWH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "BattV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Battery Voltage"
+      },
+      {
+        "name": "ArrayV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Array Voltage"
+      },
+      {
+        "name": "OutputA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Output Current"
+      },
+      {
+        "name": "InputA",
+        "type": "uint16",
+        "size": 1,
+        "sf": "P_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Array Current"
+      },
+      {
+        "name": "ChargerSt",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Operating State",
+        "symbols": [
+          {
+            "name": "Off",
+            "value": 0,
+            "label": "Off"
+          },
+          {
+            "name": "Float",
+            "value": 1,
+            "label": "Float Charging"
+          },
+          {
+            "name": "Bulk",
+            "value": 2,
+            "label": "Bulk Charging"
+          },
+          {
+            "name": "Absorb",
+            "value": 3,
+            "label": "Absorb Charging"
+          },
+          {
+            "name": "EQ",
+            "value": 4,
+            "label": "Equalize Charging"
+          }
+        ]
+      },
+      {
+        "name": "OutputW",
+        "type": "uint16",
+        "size": 1,
+        "sf": "P_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Output Wattage"
+      },
+      {
+        "name": "TodayMinBatV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Today's Minimum Battery Voltage"
+      },
+      {
+        "name": "TodayMaxBatV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Today's Maximum Battery Voltage"
+      },
+      {
+        "name": "VOCV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "VOC"
+      },
+      {
+        "name": "TodayMaxVOC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Today's Maximum VOC"
+      },
+      {
+        "name": "TodaykWhOutput",
+        "type": "uint16",
+        "size": 1,
+        "sf": "KWH_SF",
+        "units": "kWh",
+        "mandatory": "M",
+        "label": "Today's kWh"
+      },
+      {
+        "name": "TodayAHOutput",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AH_SF",
+        "units": "AH",
+        "mandatory": "M",
+        "label": "Today's AH"
+      },
+      {
+        "name": "LifeTimeKWHOut",
+        "type": "uint16",
+        "size": 1,
+        "sf": "P_SF",
+        "units": "kWh",
+        "mandatory": "M",
+        "label": "Lifetime kWh"
+      },
+      {
+        "name": "LifeTimeAHOut",
+        "type": "uint16",
+        "size": 1,
+        "sf": "KWH_SF",
+        "units": "kAH",
+        "mandatory": "M",
+        "label": "Lifetime kAH"
+      },
+      {
+        "name": "LifeTimeMaxOut",
+        "type": "uint16",
+        "size": 1,
+        "sf": "P_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Lifetime Maximum Output Wattage"
+      },
+      {
+        "name": "LifeTimeMaxBatt",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Lifetime Maximum Battery Voltage"
+      },
+      {
+        "name": "LifeTimeMaxVOC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Lifetime Maximum VOC Voltage"
+      }
+    ]
+  },
+  "id": 64111
+}

--- a/models/model_64112.json
+++ b/models/model_64112.json
@@ -1,0 +1,720 @@
+{
+  "group": {
+    "name": "model_64112",
+    "type": "group",
+    "label": "OutBack FM Charge Controller",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64112
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Port",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Port Number"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "C_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "H_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "P_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "AH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "KWH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "CC_Config_fault",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Faults"
+      },
+      {
+        "name": "CC_Config_absorb_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Absorb"
+      },
+      {
+        "name": "CC_Config_absorb_Hr",
+        "type": "uint16",
+        "size": 1,
+        "sf": "H_SF",
+        "units": "Tmh",
+        "mandatory": "M",
+        "label": "Absorb Time"
+      },
+      {
+        "name": "CC_Config_absorb_End_A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Absorb End"
+      },
+      {
+        "name": "CC_Config_rebulk_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Rebulk"
+      },
+      {
+        "name": "CC_Config_float_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Float"
+      },
+      {
+        "name": "CC_Config_max_Chg_A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Maximum Charge"
+      },
+      {
+        "name": "CC_Config_equalize_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Equalize"
+      },
+      {
+        "name": "CC_Config_equalize_Hr",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tmh",
+        "mandatory": "M",
+        "label": "Equalize Time"
+      },
+      {
+        "name": "CC_Config_auto_equalize",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tmd",
+        "mandatory": "M",
+        "label": "Auto Equalize Interval"
+      },
+      {
+        "name": "CC_Config_MPPT_mode",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "MPPT mode",
+        "symbols": [
+          {
+            "name": "Auto",
+            "value": 0,
+            "label": "Auto"
+          },
+          {
+            "name": "U_Pick",
+            "value": 1,
+            "label": "U-Pick"
+          },
+          {
+            "name": "Wind",
+            "value": 2,
+            "label": "Wind"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_sweep_width",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sweep Width",
+        "symbols": [
+          {
+            "name": "Half",
+            "value": 0,
+            "label": "Half"
+          },
+          {
+            "name": "Full",
+            "value": 1,
+            "label": "Full"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_sweep_max",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sweep Maximum",
+        "symbols": [
+          {
+            "name": "Eighty_Percent",
+            "value": 0,
+            "label": "80 %"
+          },
+          {
+            "name": "Eighty_Five_Percent",
+            "value": 1,
+            "label": "85 %"
+          },
+          {
+            "name": "Ninty_Percent",
+            "value": 2,
+            "label": "90 %"
+          },
+          {
+            "name": "Ninty_Nine_Percent",
+            "value": 3,
+            "label": "99 %"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_U_Pick_Duty_cyc",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "Pct",
+        "mandatory": "M",
+        "label": "U-Pick PWM Duty Cycle"
+      },
+      {
+        "name": "CC_Config_grid_tie",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Grid Tie Mode",
+        "symbols": [
+          {
+            "name": "Disabled",
+            "value": 0,
+            "label": "Grid Tie Mode Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": 1,
+            "label": "Grid Tie Mode Enabled"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_temp_comp",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Temp Comp Mode",
+        "symbols": [
+          {
+            "name": "Wide",
+            "value": 0,
+            "label": "Wide"
+          },
+          {
+            "name": "Limited",
+            "value": 1,
+            "label": "Limited"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_temp_comp_llimt",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Temp Comp Lower Limit"
+      },
+      {
+        "name": "CC_Config_temp_comp_hlimt",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Temp Comp Upper Limit"
+      },
+      {
+        "name": "CC_Config_auto_restart",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Auto Restart Mode",
+        "symbols": [
+          {
+            "name": "Off",
+            "value": 0,
+            "label": "Off"
+          },
+          {
+            "name": "Every_90_Minutes",
+            "value": 1,
+            "label": "Every 90 Minutes"
+          },
+          {
+            "name": "Every_90_Minutes_if_Absorb_or_Float",
+            "value": 2,
+            "label": "Every 90 Minutes if Absorb or Float"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_wakeup_VOC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Wakeup VOC Change"
+      },
+      {
+        "name": "CC_Config_snooze_mode_A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Snooze Mode"
+      },
+      {
+        "name": "CC_Config_wakeup_interval",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "Wakeup Interval"
+      },
+      {
+        "name": "CC_Config_AUX_mode",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AUX Output Mode",
+        "symbols": [
+          {
+            "name": "Float",
+            "value": 0,
+            "label": "Float"
+          },
+          {
+            "name": "Diversion_Relay",
+            "value": 1,
+            "label": "Diversion: Relay"
+          },
+          {
+            "name": "Diversion_Solid_St",
+            "value": 2,
+            "label": "Diversion: Solid St"
+          },
+          {
+            "name": "Low_Batt_Disconnect",
+            "value": 3,
+            "label": "Low Batt Disconnect"
+          },
+          {
+            "name": "Remote",
+            "value": 4,
+            "label": "Remote"
+          },
+          {
+            "name": "Vent_Fan",
+            "value": 5,
+            "label": "Vent Fan"
+          },
+          {
+            "name": "PV_Trigger",
+            "value": 6,
+            "label": "PV Trigger"
+          },
+          {
+            "name": "Error_Output",
+            "value": 7,
+            "label": "Alarm Output"
+          },
+          {
+            "name": "Night_Light",
+            "value": 8,
+            "label": "Night Light"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_AUX_control",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AUX Output Control",
+        "symbols": [
+          {
+            "name": "Off",
+            "value": 0,
+            "label": "Off"
+          },
+          {
+            "name": "Auto",
+            "value": 1,
+            "label": "Auto"
+          },
+          {
+            "name": "On",
+            "value": 2,
+            "label": "On"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_AUX_state",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AUX Output State",
+        "symbols": [
+          {
+            "name": "Disabled",
+            "value": 0,
+            "label": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": 1,
+            "label": "Enabled"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_AUX_polarity",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AUX Output Polarity",
+        "symbols": [
+          {
+            "name": "Low",
+            "value": 0,
+            "label": "Low"
+          },
+          {
+            "name": "High",
+            "value": 1,
+            "label": "High"
+          }
+        ]
+      },
+      {
+        "name": "CC_Config_AUX_L_Batt_disc",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Low Battery Disconnect"
+      },
+      {
+        "name": "CC_Config_AUX_L_Batt_rcon",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Low Battery Reconnect"
+      },
+      {
+        "name": "CC_Config_AUX_L_Batt_dly",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX Low Battery Disconnect Delay"
+      },
+      {
+        "name": "CC_Config_AUX_Vent_fan_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Vent Fan"
+      },
+      {
+        "name": "CC_Config_AUX_PV_triggerV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX PV Trigger"
+      },
+      {
+        "name": "CC_Config_AUX_PV_trg_h_tm",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX PV Trigger Hold Time"
+      },
+      {
+        "name": "CC_Config_AUX_Nlite_ThrsV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Night Light Threshold"
+      },
+      {
+        "name": "CC_Config_AUX_Nlite_On_tm",
+        "type": "uint16",
+        "size": 1,
+        "sf": "H_SF",
+        "units": "Tmh",
+        "mandatory": "M",
+        "label": "AUX Night Light On Time"
+      },
+      {
+        "name": "CC_Config_AUX_Nlite_On_hist",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX Night Light On Hysteresis"
+      },
+      {
+        "name": "CC_Config_AUX_Nlite_Off_hist",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX Night Light Off Hysteresis"
+      },
+      {
+        "name": "CC_Config_AUX_Error_batt_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Error Output Low Battery"
+      },
+      {
+        "name": "CC_Config_AUX_Divert_h_time",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX Divert Hold Time"
+      },
+      {
+        "name": "CC_Config_AUX_Divert_dly_time",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "AUX Divert Delay Time"
+      },
+      {
+        "name": "CC_Config_AUX_Divert_Rel_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Divert Relative"
+      },
+      {
+        "name": "CC_Config_AUX_Divert_Hyst_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "AUX Divert Hysteresis"
+      },
+      {
+        "name": "CC_Config_MajorFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "FM CC Major Firmware Number"
+      },
+      {
+        "name": "CC_Config_MidFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "FM CC Mid Firmware Number"
+      },
+      {
+        "name": "CC_Config_MinorFWRev",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "FM CC Minor Firmware Number"
+      },
+      {
+        "name": "CC_Config_DataLog_Day_offset",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tmd",
+        "mandatory": "M",
+        "label": "Set Data Log Day Offset"
+      },
+      {
+        "name": "CC_Config_DataLog_Cur_Day_off",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tmd",
+        "mandatory": "M",
+        "label": "Current Data Log Day Offset"
+      },
+      {
+        "name": "CC_Config_DataLog_Daily_AH",
+        "type": "uint16",
+        "size": 1,
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "Data Log Daily (Ah)"
+      },
+      {
+        "name": "CC_Config_DataLog_Daily_KWH",
+        "type": "uint16",
+        "size": 1,
+        "sf": "KWH_SF",
+        "units": "kWh",
+        "mandatory": "M",
+        "label": "Data Log Daily (kWh)"
+      },
+      {
+        "name": "CC_Config_DataLog_Max_Out_A",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Data Log Daily Maximum Output (A)"
+      },
+      {
+        "name": "CC_Config_DataLog_Max_Out_W",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Data Log Daily Maximum Output (W)"
+      },
+      {
+        "name": "CC_Config_DataLog_Absorb_T",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "Data Log Daily Absorb Time"
+      },
+      {
+        "name": "CC_Config_DataLog_Float_T",
+        "type": "uint16",
+        "size": 1,
+        "units": "Tms",
+        "mandatory": "M",
+        "label": "Data Log Daily Float Time"
+      },
+      {
+        "name": "CC_Config_DataLog_Min_Batt_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Data Log Daily Minimum Battery"
+      },
+      {
+        "name": "CC_Config_DataLog_Max_Batt_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Data Log Daily Maximum Battery"
+      },
+      {
+        "name": "CC_Config_DataLog_Max_Input_V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Data Log Daily Maximum Input"
+      },
+      {
+        "name": "CC_Config_DataLog_Clear",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Data Log Clear"
+      },
+      {
+        "name": "CC_Config_DataLog_Clr_Comp",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Data Log Clear Complement"
+      }
+    ]
+  },
+  "id": 64112
+}

--- a/models/model_64200.json
+++ b/models/model_64200.json
@@ -1,0 +1,765 @@
+{
+  "group": {
+    "name": "REbus_dir",
+    "type": "group",
+    "label": "REbus Device Directory",
+    "desc": "Device List",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64200
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "UpdtN",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Update number",
+        "desc": "Update Number. Incrementing number each time the mappping is changed.  If the number is not changed from the last reading then none of the Modbus device addresses have changed."
+      },
+      {
+        "name": "Ct",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Device count",
+        "desc": "The number of connected devices (and repetitions of repeating block)"
+      },
+      {
+        "name": "SysMd",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "System Operating Mode",
+        "desc": "REbus System mode (sysmode), also known as the operational mode",
+        "symbols": [
+          {
+            "name": "SAFETY_SHUTDOWN",
+            "value": 0
+          },
+          {
+            "name": "GRID_CONNECT",
+            "value": 1
+          },
+          {
+            "name": "SELF_SUPPLY",
+            "value": 2
+          },
+          {
+            "name": "CLEAN_BACKUP",
+            "value": 3
+          },
+          {
+            "name": "PRIORITY_BACKUP",
+            "value": 4
+          },
+          {
+            "name": "ARBITRAGE",
+            "value": 5
+          },
+          {
+            "name": "FULL_EXPORT",
+            "value": 6
+          }
+        ]
+      },
+      {
+        "name": "VT_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VT_sf",
+        "desc": "Scale factor for V and T of repeating block"
+      },
+      {
+        "name": "I_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "I_sf",
+        "desc": "Scale factor for I of repeating block"
+      },
+      {
+        "name": "Time",
+        "type": "uint32",
+        "size": 2,
+        "units": "s",
+        "mandatory": "M",
+        "label": "Current system time",
+        "desc": "Unix epoch time"
+      },
+      {
+        "name": "Clr",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Clear device list",
+        "symbols": [
+          {
+            "name": "NO",
+            "value": 0
+          },
+          {
+            "name": "CLEAR",
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "devices",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "Man",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Manufacturer",
+            "desc": "RCP number (manufacturer)",
+            "symbols": [
+              {
+                "name": "GENERAC",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Dev",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Device Type",
+            "desc": "RCP number (device type)",
+            "symbols": [
+              {
+                "name": "ICM",
+                "value": 0
+              },
+              {
+                "name": "PV_LINK",
+                "value": 3
+              },
+              {
+                "name": "INVERTER",
+                "value": 7
+              },
+              {
+                "name": "BATTERY",
+                "value": 8
+              },
+              {
+                "name": "BEACON",
+                "value": 18
+              },
+              {
+                "name": "PVLINK",
+                "value": 19
+              }
+            ]
+          },
+          {
+            "name": "ID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Device ID",
+            "desc": "RCP number (device ID)"
+          },
+          {
+            "name": "Ena",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Enable",
+            "desc": "enable/disable device",
+            "symbols": [
+              {
+                "name": "DISABLED",
+                "value": 0
+              },
+              {
+                "name": "ENABLED",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "UnitID",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ModBus ID",
+            "desc": "Modbus unit identifier"
+          },
+          {
+            "name": "UpdtTm",
+            "type": "uint32",
+            "size": 2,
+            "units": "s",
+            "mandatory": "M",
+            "label": "Update Time",
+            "desc": "Time of last update (Unix epoch time)"
+          },
+          {
+            "name": "St",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "State",
+            "symbols": [
+              {
+                "name": "UNKNOWN",
+                "value": 0,
+                "label": "device offline"
+              },
+              {
+                "name": "DISABLED",
+                "value": 16,
+                "label": "disabled"
+              },
+              {
+                "name": "INITIALIZING",
+                "value": 256,
+                "label": "initializing"
+              },
+              {
+                "name": "POWERING_UP",
+                "value": 272,
+                "label": "powering up"
+              },
+              {
+                "name": "CONNECTING_BUS",
+                "value": 288,
+                "label": "connecting to REbus"
+              },
+              {
+                "name": "DISCONNECTING_BUS",
+                "value": 304,
+                "label": "disconnecting REbus"
+              },
+              {
+                "name": "TESTING_BUS",
+                "value": 320,
+                "label": "testing REbus..."
+              },
+              {
+                "name": "LOW_BUS_VOLTAGE",
+                "value": 512,
+                "label": "low REbus voltage"
+              },
+              {
+                "name": "STANDBY",
+                "value": 768,
+                "label": "standby"
+              },
+              {
+                "name": "WAITING",
+                "value": 784,
+                "label": "waiting"
+              },
+              {
+                "name": "WAITING_NO_INPUT",
+                "value": 800,
+                "label": "waiting - no input"
+              },
+              {
+                "name": "CONNECTING_GRID",
+                "value": 2048,
+                "label": "connecting grid"
+              },
+              {
+                "name": "DISCONNECTING_GRID",
+                "value": 2064,
+                "label": "disconnecting grid"
+              },
+              {
+                "name": "GRID_CONNECTED",
+                "value": 2080,
+                "label": "grid connected"
+              },
+              {
+                "name": "ISLANDED",
+                "value": 2096,
+                "label": "islanded"
+              },
+              {
+                "name": "CONNECTING_GENERATOR",
+                "value": 2112,
+                "label": "connecting generator"
+              },
+              {
+                "name": "GENERATOR_PARALLEL",
+                "value": 2128,
+                "label": "generator parallel"
+              },
+              {
+                "name": "LOW_INPUT_VOLTAGE",
+                "value": 4096,
+                "label": "low input voltage"
+              },
+              {
+                "name": "TESTING_DEVICE_INPUT",
+                "value": 4112,
+                "label": "testing input..."
+              },
+              {
+                "name": "CONNECTING_INPUT",
+                "value": 4352,
+                "label": "connecting input"
+              },
+              {
+                "name": "DISCONNECTING_INPUT",
+                "value": 4368,
+                "label": "disconnecting input"
+              },
+              {
+                "name": "CALIBRATING",
+                "value": 4608,
+                "label": "calibrating"
+              },
+              {
+                "name": "CALIBRATION_SUCCESS",
+                "value": 4624,
+                "label": "calibration success!"
+              },
+              {
+                "name": "CALIBRATION_NEEDED",
+                "value": 4640,
+                "label": "calibration required"
+              },
+              {
+                "name": "BURN_IN",
+                "value": 4656,
+                "label": "burning in"
+              },
+              {
+                "name": "BURN_IN_DONE",
+                "value": 4672,
+                "label": "burn in done"
+              },
+              {
+                "name": "SCHEDULER_OVERRIDDEN",
+                "value": 4864,
+                "label": "running, overridden"
+              },
+              {
+                "name": "SCHEDULER_DISABLED",
+                "value": 4880,
+                "label": "scheduler disabled"
+              },
+              {
+                "name": "RUNNING",
+                "value": 8192,
+                "label": "running"
+              },
+              {
+                "name": "MAKING_POWER",
+                "value": 8208,
+                "label": "making power"
+              },
+              {
+                "name": "LIMITING_POWER",
+                "value": 8224,
+                "label": "limiting power"
+              },
+              {
+                "name": "LOW_WIND",
+                "value": 12288,
+                "label": "low wind"
+              },
+              {
+                "name": "HIGH_WIND",
+                "value": 12304,
+                "label": "high wind"
+              },
+              {
+                "name": "LOW_SUN",
+                "value": 12544,
+                "label": "low sun"
+              },
+              {
+                "name": "CHARGING_BATTERY",
+                "value": 24576,
+                "label": "charging"
+              },
+              {
+                "name": "FLOAT_CHARGING_BATTERY",
+                "value": 24592,
+                "label": "float charging"
+              },
+              {
+                "name": "BULK_CHARGING_BATTERY",
+                "value": 24608,
+                "label": "bulk charging"
+              },
+              {
+                "name": "ABSORPTION_CHARGING_BATTERY",
+                "value": 24624,
+                "label": "absorption charging"
+              },
+              {
+                "name": "EQUALIZE_CHARGING_BATTERY",
+                "value": 24640,
+                "label": "equalizing"
+              },
+              {
+                "name": "DISCHARGING_BATTERY",
+                "value": 24832,
+                "label": "discharging"
+              },
+              {
+                "name": "LOW_BATTERY_VOLTAGE",
+                "value": 24848,
+                "label": "low battery voltage"
+              },
+              {
+                "name": "ERROR_GENERIC",
+                "value": 28672,
+                "label": "error"
+              },
+              {
+                "name": "OVER_VOLTAGE_INPUT",
+                "value": 28688,
+                "label": "over voltage input"
+              },
+              {
+                "name": "OVER_VOLTAGE_OUTPUT",
+                "value": 28704,
+                "label": "over voltage output"
+              },
+              {
+                "name": "OVER_CURRENT_INPUT",
+                "value": 28720,
+                "label": "over current input"
+              },
+              {
+                "name": "OVER_CURRENT_OUTPUT",
+                "value": 28736,
+                "label": "over current output"
+              },
+              {
+                "name": "ERROR_LOW_BATTERY_VOLTAGE",
+                "value": 28752,
+                "label": "error: low batt volts"
+              },
+              {
+                "name": "OVER_TEMPERATURE",
+                "value": 28928,
+                "label": "over temperature"
+              },
+              {
+                "name": "GROUND_FAULT",
+                "value": 29184,
+                "label": "err: ground fault"
+              },
+              {
+                "name": "INSULATION_FAULT",
+                "value": 29200,
+                "label": "err: insulation fault"
+              },
+              {
+                "name": "CALIBRATION_0",
+                "value": 32256,
+                "label": "calibration mode"
+              },
+              {
+                "name": "CALIBRATION_1",
+                "value": 32272,
+                "label": "calibration 1"
+              },
+              {
+                "name": "CALIBRATION_2",
+                "value": 32288,
+                "label": "calibration 2"
+              },
+              {
+                "name": "CALIBRATION_3",
+                "value": 32304,
+                "label": "calibration 3"
+              }
+            ]
+          },
+          {
+            "name": "P",
+            "type": "int16",
+            "size": 1,
+            "units": "W",
+            "mandatory": "M",
+            "label": "REbus Power",
+            "desc": "REbus power (positive means the device is sourcing power onto REbus, negative means the device is sinking power from REbus) "
+          },
+          {
+            "name": "E",
+            "type": "uint32",
+            "size": 2,
+            "units": "Wh",
+            "mandatory": "M",
+            "label": "Accumulated Energy",
+            "desc": "Total accumulated energy (exact definition differs by device)"
+          },
+          {
+            "name": "Rb",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "REbus Bits",
+            "symbols": [
+              {
+                "name": "ENABLE_MASTER",
+                "value": 0
+              },
+              {
+                "name": "ENABLE_SOURCE",
+                "value": 1
+              },
+              {
+                "name": "ENABLE_SINK",
+                "value": 2
+              },
+              {
+                "name": "RESERVED3",
+                "value": 3
+              },
+              {
+                "name": "BUS_CONNECTED",
+                "value": 4
+              },
+              {
+                "name": "BUS_DISCONNECTED",
+                "value": 5
+              },
+              {
+                "name": "SOURCING",
+                "value": 6
+              },
+              {
+                "name": "SINKING",
+                "value": 7
+              },
+              {
+                "name": "BUS_VOLTAGE_LOW",
+                "value": 8
+              },
+              {
+                "name": "BUS_VOLTAGE_HIGH",
+                "value": 9
+              },
+              {
+                "name": "BUS_IMBALANCE",
+                "value": 10
+              },
+              {
+                "name": "RESERVED11",
+                "value": 11
+              },
+              {
+                "name": "PLC_GOOD",
+                "value": 12
+              },
+              {
+                "name": "HEARTBEAT_GOOD",
+                "value": 13
+              },
+              {
+                "name": "ADAPTIVE_VREBUS_ACTIVE",
+                "value": 14
+              },
+              {
+                "name": "RESERVED15",
+                "value": 15
+              }
+            ]
+          },
+          {
+            "name": "V",
+            "type": "int16",
+            "size": 1,
+            "sf": "VT_sf",
+            "units": "V",
+            "mandatory": "M",
+            "label": "REbus Voltage ",
+            "desc": "REbus voltage in V*10"
+          },
+          {
+            "name": "I",
+            "type": "int16",
+            "size": 1,
+            "sf": "I_sf",
+            "units": "A",
+            "mandatory": "M",
+            "label": "REbus Current",
+            "desc": "REbus current in A*10"
+          },
+          {
+            "name": "T",
+            "type": "int16",
+            "size": 1,
+            "sf": "VT_sf",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Device Temperature",
+            "desc": "Device temperature in C*10"
+          },
+          {
+            "name": "O0",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 0",
+            "desc": "Otherdata 0"
+          },
+          {
+            "name": "O1",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 1",
+            "desc": "Otherdata 1"
+          },
+          {
+            "name": "O2",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 2",
+            "desc": "Otherdata 2"
+          },
+          {
+            "name": "O3",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 3",
+            "desc": "Otherdata 3"
+          },
+          {
+            "name": "O4",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 4",
+            "desc": "Otherdata 4"
+          },
+          {
+            "name": "O5",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 5",
+            "desc": "Otherdata 5"
+          },
+          {
+            "name": "O6",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 6",
+            "desc": "Otherdata 6"
+          },
+          {
+            "name": "O7",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 7",
+            "desc": "Otherdata 7"
+          },
+          {
+            "name": "O8",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 8",
+            "desc": "Otherdata 8"
+          },
+          {
+            "name": "O9",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata 9",
+            "desc": "Otherdata 9"
+          },
+          {
+            "name": "OA",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata A",
+            "desc": "Otherdata A"
+          },
+          {
+            "name": "OB",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata B",
+            "desc": "Otherdata B"
+          },
+          {
+            "name": "OC",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata C",
+            "desc": "Otherdata C"
+          },
+          {
+            "name": "OD",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata D",
+            "desc": "Otherdata D"
+          },
+          {
+            "name": "OE",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata E",
+            "desc": "Otherdata E"
+          },
+          {
+            "name": "OF",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata F",
+            "desc": "Otherdata F"
+          },
+          {
+            "name": "OG",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Otherdata G",
+            "desc": "Otherdata G"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64200
+}

--- a/models/model_64201.json
+++ b/models/model_64201.json
@@ -1,0 +1,66 @@
+{
+  "group": {
+    "name": "REbus_exp",
+    "type": "group",
+    "label": "Generac Inverter Export model",
+    "desc": "Generac Vendor model for inverters with current transducers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64201
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Px1",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power export line 1",
+        "desc": "RMS power to/from grid on line 1"
+      },
+      {
+        "name": "Px2",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power export line 2",
+        "desc": "RMS power to/from grid on line 2"
+      },
+      {
+        "name": "Whx",
+        "type": "acc32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Energy exported",
+        "desc": "Energy exported to grid"
+      },
+      {
+        "name": "Whin",
+        "type": "acc32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Energy imported",
+        "desc": "Total imported energy to REbus"
+      }
+    ]
+  },
+  "id": 64201
+}

--- a/models/model_64202.json
+++ b/models/model_64202.json
@@ -1,0 +1,201 @@
+{
+  "group": {
+    "name": "REbus_arb",
+    "type": "group",
+    "label": "Generac Inverter Arbitrage Control",
+    "desc": "Power control model for PWRcell",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64202
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "SysMd",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "System Operating Mode",
+        "desc": "System operating mode",
+        "symbols": [
+          {
+            "name": "SAFETY_SHUTDOWN",
+            "value": 0
+          },
+          {
+            "name": "GRID_CONNECT",
+            "value": 1
+          },
+          {
+            "name": "SELF_SUPPLY",
+            "value": 2
+          },
+          {
+            "name": "CLEAN_BACKUP",
+            "value": 3
+          },
+          {
+            "name": "PRIORITY_BACKUP",
+            "value": 4
+          },
+          {
+            "name": "ARBITRAGE",
+            "value": 5
+          }
+        ]
+      },
+      {
+        "name": "PMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "PQMax_SF",
+        "mandatory": "M",
+        "label": "Max real power",
+        "desc": "Maximum real power magnitude"
+      },
+      {
+        "name": "QMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "PQMax_SF",
+        "mandatory": "M",
+        "label": "Max reactive power",
+        "desc": "Maximum reactive power magnitude"
+      },
+      {
+        "name": "PMaxLimPct",
+        "type": "int16",
+        "size": 1,
+        "sf": "PQLimPct_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Real power target",
+        "desc": "target real power - -100.0% to +100.0% of PMax"
+      },
+      {
+        "name": "QMaxLimPct",
+        "type": "int16",
+        "size": 1,
+        "sf": "PQLimPct_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Reactive power target",
+        "desc": "target reactive power - -100.0% to +100.0% of QMax"
+      },
+      {
+        "name": "PQGra",
+        "type": "uint16",
+        "size": 1,
+        "sf": "PQGra_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Ramp rate",
+        "desc": "ramp rate for slewing power to target"
+      },
+      {
+        "name": "PQMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PQMax_SF",
+        "desc": "scale factor for max power"
+      },
+      {
+        "name": "PQLimPct_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PQLimPct_SF",
+        "desc": "scale factor for target power percentages"
+      },
+      {
+        "name": "PQGra_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PQGra_SF",
+        "desc": "scale factor for ramp rate"
+      },
+      {
+        "name": "CtlPr",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Control priority",
+        "desc": "set control priority to real or reactive target",
+        "symbols": [
+          {
+            "name": "REAL",
+            "value": 0
+          },
+          {
+            "name": "REACTIVE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "PQSet_Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable arbitrage control",
+        "desc": "activate PQ control settings",
+        "symbols": [
+          {
+            "name": "DISABLE",
+            "value": 0
+          },
+          {
+            "name": "ENABLE",
+            "value": 1
+          },
+          {
+            "name": "UPDATE",
+            "value": 2
+          },
+          {
+            "name": "ENABLE_LATCHED",
+            "value": 3
+          }
+        ]
+      },
+      {
+        "name": "Conn",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Connect",
+        "desc": "enable/disable inverter",
+        "symbols": [
+          {
+            "name": "DISCONNECT",
+            "value": 0
+          },
+          {
+            "name": "CONNECT",
+            "value": 1
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64202
+}

--- a/models/model_64203.json
+++ b/models/model_64203.json
@@ -1,0 +1,156 @@
+{
+  "group": {
+    "name": "reconnect",
+    "type": "group",
+    "label": "Generac Reconnect Control",
+    "desc": "Define grid parameters required for reconnection",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64203
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ModEna",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "Enable this model's voltage and frequency window.",
+        "symbols": [
+          {
+            "name": "DISABLE",
+            "value": 0
+          },
+          {
+            "name": "ENABLE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "ReConn_Tms",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Tms_SF",
+        "units": "Secs",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ReConn_Tms",
+        "desc": "Time to reconnect after fault, and within frequency and voltage window."
+      },
+      {
+        "name": "ReConnMinV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ReConnMinV",
+        "desc": "Reconnect only above this voltage"
+      },
+      {
+        "name": "ReConnMaxV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "%VRef",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ReConnMaxV",
+        "desc": "Reconnect only below this voltage"
+      },
+      {
+        "name": "ReConnMinHz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ReConnMinHz",
+        "desc": "Reconnect only above this frequency"
+      },
+      {
+        "name": "ReConnMaxHz",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ReConnMaxHz",
+        "desc": "Reconnect only below this frequency"
+      },
+      {
+        "name": "VWLatchTms",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Tms_SF",
+        "units": "Secs",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "VoltWattLatchTime",
+        "desc": "Delay for this amount of time after voltage is restored before reconnecting"
+      },
+      {
+        "name": "FWLatchTms",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Tms_SF",
+        "units": "Secs",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "FreqWattLatchTime",
+        "desc": "Delay for this amount of time after frequency is restored before reconnecting"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for reconnect time."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for voltage percent of Vref."
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64203
+}

--- a/models/model_64204.json
+++ b/models/model_64204.json
@@ -1,0 +1,81 @@
+{
+  "group": {
+    "name": "REbus_exp",
+    "type": "group",
+    "label": "Inverter Export",
+    "desc": "Grid export measurements for inverters with current transducers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64204
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Px1",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power export line 1",
+        "desc": "RMS power to/from grid on line 1"
+      },
+      {
+        "name": "Px2",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power export line 2",
+        "desc": "RMS power to/from grid on line 2"
+      },
+      {
+        "name": "Px3",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power export line 3",
+        "desc": "RMS power to/from grid on line 3"
+      },
+      {
+        "name": "Whx",
+        "type": "acc32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Energy exported",
+        "desc": "Energy exported to grid"
+      },
+      {
+        "name": "Whin",
+        "type": "acc32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Energy imported",
+        "desc": "Total imported energy to REbus"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64204
+}

--- a/models/model_64205.json
+++ b/models/model_64205.json
@@ -1,0 +1,252 @@
+{
+  "group": {
+    "name": "SA_defaults",
+    "type": "group",
+    "label": "Utility Compliance Configuration",
+    "desc": "Configure inverter settings based on utility requirements",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64205
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "SRD",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Compliance selection",
+        "desc": "Select which utility your inverter is being installed under.",
+        "symbols": [
+          {
+            "name": "IEEE_1547",
+            "value": 0,
+            "label": "IEEE 1547-2003 (default)",
+            "desc": "'IEEE 1547' is the most common inverter compliance setting."
+          },
+          {
+            "name": "RULE_14H_1",
+            "value": 1,
+            "label": "HECO SRD V1.1",
+            "desc": "Configure for HI Rule 14H Islands of O'ahu, Maui, Hawai'i (Big Island). If your installation is not on one of these islands, do not use this selection. "
+          },
+          {
+            "name": "RULE_14H_2",
+            "value": 2,
+            "label": "HECO SRD V1.1 [L+M]",
+            "desc": "Configure for HI Rule 14H (Lana'i, Moloka'i)"
+          },
+          {
+            "name": "RULE_21",
+            "value": 3,
+            "label": "Rule 21 2017",
+            "desc": "Configure for California Rule 21 settings."
+          },
+          {
+            "name": "RULE_PREPA",
+            "value": 4,
+            "label": "PREPA 2017",
+            "desc": "Configure for Puerto Rico (PREPA) settings."
+          },
+          {
+            "name": "RULE_ISONE",
+            "value": 5,
+            "label": "ISO-NE (1547a-2014)",
+            "desc": "Configure ISO New England settings."
+          },
+          {
+            "name": "RULE_LADWP",
+            "value": 6,
+            "label": "LADWP 2019",
+            "desc": "Configure City of Los Angeles settings."
+          },
+          {
+            "name": "RULE_PECO",
+            "value": 7,
+            "label": "PECO (deprecated)",
+            "desc": "Configure PECO settings."
+          },
+          {
+            "name": "RULE_MISO",
+            "value": 8,
+            "label": "MISO (deprecated)",
+            "desc": "Configure MISO settings."
+          },
+          {
+            "name": "LPEA",
+            "value": 9,
+            "label": "LPEA 2019"
+          },
+          {
+            "name": "RULE_KIUC",
+            "value": 10,
+            "label": "KIUC 2021"
+          },
+          {
+            "name": "RULE_PECO_v2",
+            "value": 11,
+            "label": "PECO 2021"
+          },
+          {
+            "name": "RULE_21_v2",
+            "value": 12,
+            "label": "RULE 21 2019"
+          },
+          {
+            "name": "RULE_MISO_1547_2018",
+            "value": 13,
+            "label": "MISO 1547-2018"
+          },
+          {
+            "name": "IEEE_1547_2018",
+            "value": 14,
+            "label": "IEEE 1547-2018"
+          },
+          {
+            "name": "HECO_V2.0",
+            "value": 15,
+            "label": "HECO SRD V2.0"
+          },
+          {
+            "name": "PREPA_2023",
+            "value": 16,
+            "label": "PREPA 2023"
+          },
+          {
+            "name": "AmerenIL_Std_2018",
+            "value": 17,
+            "label": "AmerenIL Std 2018"
+          },
+          {
+            "name": "AmerenIL_Rebate_2018",
+            "value": 18,
+            "label": "AmerenIL Rebate 2018"
+          },
+          {
+            "name": "BC_HYDRO_2014",
+            "value": 19,
+            "label": "BC Hydro 2014"
+          },
+          {
+            "name": "ISO_NE_V2.0",
+            "value": 20,
+            "label": "ISO-NE 2023"
+          },
+          {
+            "name": "RULE_21_2023",
+            "value": 21,
+            "label": "Rule 21 2023"
+          },
+          {
+            "name": "National_Grid_NY_2023",
+            "value": 22,
+            "label": "National Grid NY 2023"
+          },
+          {
+            "name": "NYSEG_RGE_2023",
+            "value": 23,
+            "label": "NYSEG + RG&E 2023"
+          },
+          {
+            "name": "PSEG_LI_2023",
+            "value": 24,
+            "label": "PSEG-LI 2023"
+          },
+          {
+            "name": "ORU_2023",
+            "value": 25,
+            "label": "ORU 2023"
+          },
+          {
+            "name": "CHGE_2023",
+            "value": 26,
+            "label": "CHG&E 2023"
+          },
+          {
+            "name": "IEEE_1547a_2014",
+            "value": 27,
+            "label": "IEEE 1547a-2014"
+          },
+          {
+            "name": "IEEE_1547_2003_ReConnV_7_5",
+            "value": 28,
+            "label": "IEEE 1547-2003 (ReConnV 7.5%)"
+          },
+          {
+            "name": "IEEE_1547_2003_ReConnV_10",
+            "value": 29,
+            "label": "IEEE 1547-2003 (ReConnV 10%)"
+          },
+          {
+            "name": "MWEC_2023",
+            "value": 30,
+            "label": "MWEC 2023"
+          },
+          {
+            "name": "LADWP_2023",
+            "value": 31,
+            "label": "LADWP 2023"
+          },
+          {
+            "name": "BED_2022",
+            "value": 32,
+            "label": "BED 2022"
+          },
+          {
+            "name": "PREPA_LUMA_2024",
+            "value": 33,
+            "label": "PREPA-LUMA 2024"
+          },
+          {
+            "name": "ConEd_2024",
+            "value": 34,
+            "label": "Con Edison 2024"
+          },
+          {
+            "name": "IEEE_1547a_2014_ReConnV_10",
+            "value": 35,
+            "label": "IEEE 1547a-2014 (ReConnV 10%)"
+          }
+        ]
+      },
+      {
+        "name": "Def",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Defaulted",
+        "desc": "Indicates whether or not the default settings from the Compliance Selection field have been applied.",
+        "symbols": [
+          {
+            "name": "NOT_DEFAULTED",
+            "value": 0
+          },
+          {
+            "name": "DEFAULTED",
+            "value": 1
+          },
+          {
+            "name": "UNKNOWN",
+            "value": 2
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64205
+}

--- a/models/model_64206.json
+++ b/models/model_64206.json
@@ -1,0 +1,881 @@
+{
+  "group": {
+    "name": "EIconfig",
+    "type": "group",
+    "label": "PWRcell Configuration",
+    "desc": "Configure PWRcell system settings",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64206
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Conn",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable inverter",
+        "desc": "Enable inverter",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "Pwd",
+        "type": "uint64",
+        "size": 4,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Access code",
+        "desc": "Access code"
+      },
+      {
+        "name": "SRD",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Compliance selection",
+        "desc": "Select which utility your inverter is being installed under.",
+        "symbols": [
+          {
+            "name": "IEEE_1547",
+            "value": 0,
+            "label": "IEEE 1547-2003 (default)",
+            "desc": "'IEEE 1547' is the most common inverter compliance setting."
+          },
+          {
+            "name": "RULE_14H_1",
+            "value": 1,
+            "label": "HECO SRD V1.1",
+            "desc": "Configure for HI Rule 14H Islands of O'ahu, Maui, Hawai'i (Big Island). If your installation is not on one of these islands, do not use this selection. "
+          },
+          {
+            "name": "RULE_14H_2",
+            "value": 2,
+            "label": "HECO SRD V1.1 [L+M]",
+            "desc": "Configure for HI Rule 14H (Lana'i, Moloka'i)"
+          },
+          {
+            "name": "RULE_21",
+            "value": 3,
+            "label": "Rule 21 2017",
+            "desc": "Configure for California Rule 21 settings."
+          },
+          {
+            "name": "RULE_PREPA",
+            "value": 4,
+            "label": "PREPA 2017",
+            "desc": "Configure for Puerto Rico (PREPA) settings."
+          },
+          {
+            "name": "RULE_ISONE",
+            "value": 5,
+            "label": "ISO-NE (1547a-2014)",
+            "desc": "Configure ISO New England settings."
+          },
+          {
+            "name": "RULE_LADWP",
+            "value": 6,
+            "label": "LADWP 2019",
+            "desc": "Configure City of Los Angeles settings."
+          },
+          {
+            "name": "RULE_PECO",
+            "value": 7,
+            "label": "PECO (deprecated)",
+            "desc": "Configure PECO settings."
+          },
+          {
+            "name": "RULE_MISO",
+            "value": 8,
+            "label": "MISO (deprecated)",
+            "desc": "Configure MISO settings."
+          },
+          {
+            "name": "LPEA",
+            "value": 9,
+            "label": "LPEA 2019"
+          },
+          {
+            "name": "RULE_KIUC",
+            "value": 10,
+            "label": "KIUC 2021"
+          },
+          {
+            "name": "RULE_PECO_v2",
+            "value": 11,
+            "label": "PECO 2021"
+          },
+          {
+            "name": "RULE_21_v2",
+            "value": 12,
+            "label": "RULE 21 2019"
+          },
+          {
+            "name": "RULE_MISO_1547_2018",
+            "value": 13,
+            "label": "MISO 1547-2018"
+          },
+          {
+            "name": "IEEE_1547_2018",
+            "value": 14,
+            "label": "IEEE 1547-2018"
+          },
+          {
+            "name": "HECO_V2.0",
+            "value": 15,
+            "label": "HECO SRD V2.0"
+          },
+          {
+            "name": "PREPA_2023",
+            "value": 16,
+            "label": "PREPA 2023"
+          },
+          {
+            "name": "AmerenIL_Std_2018",
+            "value": 17,
+            "label": "AmerenIL Std 2018"
+          },
+          {
+            "name": "AmerenIL_Rebate_2018",
+            "value": 18,
+            "label": "AmerenIL Rebate 2018"
+          },
+          {
+            "name": "BC_HYDRO_2014",
+            "value": 19,
+            "label": "BC Hydro 2014"
+          },
+          {
+            "name": "ISO_NE_V2.0",
+            "value": 20,
+            "label": "ISO-NE 2023"
+          },
+          {
+            "name": "RULE_21_2023",
+            "value": 21,
+            "label": "Rule 21 2023"
+          },
+          {
+            "name": "National_Grid_NY_2023",
+            "value": 22,
+            "label": "National Grid NY 2023"
+          },
+          {
+            "name": "NYSEG_RGE_2023",
+            "value": 23,
+            "label": "NYSEG + RG&E 2023"
+          },
+          {
+            "name": "PSEG_LI_2023",
+            "value": 24,
+            "label": "PSEG-LI 2023"
+          },
+          {
+            "name": "ORU_2023",
+            "value": 25,
+            "label": "ORU 2023"
+          },
+          {
+            "name": "CHGE_2023",
+            "value": 26,
+            "label": "CHG&E 2023"
+          },
+          {
+            "name": "IEEE_1547a_2014",
+            "value": 27,
+            "label": "IEEE 1547a-2014"
+          },
+          {
+            "name": "IEEE_1547_2003_ReConnV_7_5",
+            "value": 28,
+            "label": "IEEE 1547-2003 (ReConnV 7.5%)"
+          },
+          {
+            "name": "IEEE_1547_2003_ReConnV_10",
+            "value": 29,
+            "label": "IEEE 1547-2003 (ReConnV 10%)"
+          },
+          {
+            "name": "MWEC_2023",
+            "value": 30,
+            "label": "MWEC 2023"
+          },
+          {
+            "name": "LADWP_2023",
+            "value": 31,
+            "label": "LADWP 2023"
+          },
+          {
+            "name": "BED_2022",
+            "value": 32,
+            "label": "BED 2022"
+          },
+          {
+            "name": "PREPA_LUMA_2024",
+            "value": 33,
+            "label": "PREPA-LUMA 2024"
+          },
+          {
+            "name": "ConEd_2024",
+            "value": 34,
+            "label": "Con Edison 2024"
+          },
+          {
+            "name": "IEEE_1547a_2014_ReConnV_10",
+            "value": 35,
+            "label": "IEEE 1547a-2014 (ReConnV 10%)"
+          }
+        ]
+      },
+      {
+        "name": "Def",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Compliance settings defaulted",
+        "desc": "Indicates whether or not the default settings from the Compliance Selection field have been applied.",
+        "symbols": [
+          {
+            "name": "NOT_DEFAULTED",
+            "value": 0
+          },
+          {
+            "name": "DEFAULTED",
+            "value": 1
+          },
+          {
+            "name": "UNKNOWN",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "ZExp",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Export Limiting",
+        "desc": "When enabled, reduces the inverter exporting power to the utility grid to the value of Export Limit (below). NOTE: THIS IS A SET ONCE ATTRIBUTE. To unset Export Limiting, please contact Generac.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "IslandEna",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable Islanding",
+        "desc": "When enabled, PWRcell Inverter shall export backup power at its Protected Loads output terminals to connected load. This setting does not override or interfere with the anti-islanding capabilities of the inverter.",
+        "symbols": [
+          {
+            "name": "ISLANDING_DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ISLANDING_ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "ActSysMds",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enabled SysModes",
+        "desc": "Select the Operational Modes that will be available to this installation",
+        "symbols": [
+          {
+            "name": "SAFETY_SHUTDOWN",
+            "value": 0
+          },
+          {
+            "name": "GRID_TIE",
+            "value": 1
+          },
+          {
+            "name": "SELF_SUPPLY",
+            "value": 2
+          },
+          {
+            "name": "CLEAN_BACKUP",
+            "value": 3
+          },
+          {
+            "name": "PRIORITY_BACKUP",
+            "value": 4
+          },
+          {
+            "name": "REMOTE_ARBITRAGE",
+            "value": 5
+          },
+          {
+            "name": "SELL",
+            "value": 6
+          }
+        ]
+      },
+      {
+        "name": "CTTrig",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Trigger CT calibration",
+        "desc": "Trigger CT calibration",
+        "symbols": [
+          {
+            "name": "AUTO",
+            "value": 0
+          },
+          {
+            "name": "TRIGGER",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "ClrDisp",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Clear display",
+        "desc": "Clear offline devices and reset the LCD display on the front cover of the inverter",
+        "symbols": [
+          {
+            "name": "NO",
+            "value": 0
+          },
+          {
+            "name": "CLEAR",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "PLMCh",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "PLM channel",
+        "desc": "Power line modem channel. Default is channel 1",
+        "symbols": [
+          {
+            "name": "CH_0",
+            "value": 0
+          },
+          {
+            "name": "CH_1",
+            "value": 1
+          },
+          {
+            "name": "CH_2",
+            "value": 2
+          },
+          {
+            "name": "CH_3",
+            "value": 3
+          },
+          {
+            "name": "CH_4",
+            "value": 4
+          },
+          {
+            "name": "CH_5",
+            "value": 5
+          },
+          {
+            "name": "CH_6",
+            "value": 6
+          },
+          {
+            "name": "CH_7",
+            "value": 7
+          },
+          {
+            "name": "CH_8",
+            "value": 8
+          },
+          {
+            "name": "CH_9",
+            "value": 9
+          },
+          {
+            "name": "CH_10",
+            "value": 10
+          },
+          {
+            "name": "CH_11",
+            "value": 11
+          },
+          {
+            "name": "CH_12",
+            "value": 12
+          }
+        ]
+      },
+      {
+        "name": "PLMEna",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "PLM enable",
+        "desc": "Enable the inverter's power line modem. Do not disable unless guided by Generac Technical Support",
+        "symbols": [
+          {
+            "name": "PLM_DISABLED",
+            "value": 0
+          },
+          {
+            "name": "PLM_ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "GPLMRst",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Global PLM Reset",
+        "desc": "Reset all online devices (including those currently on different channels) to the default PLM channel (Ch 1)",
+        "symbols": [
+          {
+            "name": "RESET",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "GPLMCh",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "PLM Group Set",
+        "desc": "Set PLM channel for all devices (including inverter) that are currently on the inverter's channel (PLMCh) to the channel indicated by this register. This will not affect devices that aren't currently on PLMCh. PLMCh will also be set to the value of this register.",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0
+          },
+          {
+            "name": "CH_1",
+            "value": 1
+          },
+          {
+            "name": "CH_2",
+            "value": 2
+          },
+          {
+            "name": "CH_3",
+            "value": 3
+          },
+          {
+            "name": "CH_4",
+            "value": 4
+          },
+          {
+            "name": "CH_5",
+            "value": 5
+          },
+          {
+            "name": "CH_6",
+            "value": 6
+          },
+          {
+            "name": "CH_7",
+            "value": 7
+          },
+          {
+            "name": "CH_8",
+            "value": 8
+          },
+          {
+            "name": "CH_9",
+            "value": 9
+          },
+          {
+            "name": "CH_10",
+            "value": 10
+          },
+          {
+            "name": "CH_11",
+            "value": 11
+          },
+          {
+            "name": "CH_12",
+            "value": 12
+          }
+        ]
+      },
+      {
+        "name": "SS_Src",
+        "type": "uint16",
+        "size": 1,
+        "units": "W",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Self Supply Source Power",
+        "desc": "When in Self-Supply, the CT import power level above which causes the inverter to start exporting. With sufficient battery storage and/or PV generation, this will be the maximum load the meter will see."
+      },
+      {
+        "name": "SS_Sink",
+        "type": "uint16",
+        "size": 1,
+        "units": "W",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Self Supply Sink Power",
+        "desc": "When in Self-Supply, the CT import power level below which causes the inverter to start importing. (i.e., max rate to charge batteries from the grid)"
+      },
+      {
+        "name": "XFREna",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Number of Transfer Switches",
+        "desc": "Defines the number of external automatic transfer switches installed and enables transfer switch controls. For AC Coupled PV, this must be 1. For AC Generator Integration, this must be 1 in the Flexible Coverage configuration or 2 in the Whole Home Backup configuration.",
+        "symbols": [
+          {
+            "name": "NO_TRANSFER_SWITCH",
+            "value": 0
+          },
+          {
+            "name": "ONE_TRANSFER_SWITCH",
+            "value": 1
+          },
+          {
+            "name": "TWO_TRANSFER_SWITCHES",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "XFRV_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "XFRV",
+        "type": "uint16",
+        "size": 1,
+        "sf": "XFRV_sf",
+        "units": "V",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "External Transfer Voltage",
+        "desc": "Grid voltage below which to transfer local loads to the inverter, and above which to transfer loads to utility mains."
+      },
+      {
+        "name": "XFRTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "s",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "External Transfer timeout",
+        "desc": "Amount of time after grid voltage returns to transfer local loads back to the utility mains. Grid voltage must be above External Transer Voltage for the entire time."
+      },
+      {
+        "name": "ZImp",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Zero Import",
+        "desc": "When enabled, prevents the batteries from charging with utility power. NOTE: THIS IS A SET ONCE ATTRIBUTE. This feature is only available for inverter firmware version >13130. To unset Zero Import or request a firmware update, please contact Generac.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          },
+          {
+            "name": "N/A",
+            "value": 32768
+          }
+        ]
+      },
+      {
+        "name": "ZExpLim",
+        "type": "uint16",
+        "size": 1,
+        "units": "W",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Export Limit",
+        "desc": "\n        The limit, in watts, that the inverter is allowed to push onto the grid. This setting will only take effect if Export Limiting (above) is ENABLED.\n        NOTE: This value can only be lowered. This feature is only available for inverter firmware version >13200. For older firmware versions, the value 32768 may appear, and it can be ignored. To reset this limit or request a firmware update, please contact Generac.\n        NOTE: This feature requires CTs to be properly installed and calibrated prior to use. For more information on CT calibration, see the PWRcell Inverter Installation and Owners Manual.\n      "
+      },
+      {
+        "name": "ExpOverride",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Export Override",
+        "desc": "Formerly called Zero Export, this setting will inhibit the PWRcell system from exporting power to the grid.\n        NOTE: This feature requires CTs to be properly installed and calibrated prior to use. For more information on CT calibration, see the PWRcell Inverter Installation and Owners Manual.\n      ",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          },
+          {
+            "name": "N/A",
+            "value": 32768
+          }
+        ]
+      },
+      {
+        "name": "ACPVPowerRating",
+        "type": "int16",
+        "size": 1,
+        "sf": "SF_X10",
+        "units": "kW",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "AC-coupled PV Power Rating",
+        "desc": "Power rating of the attached AC Coupled PV array. Set this value to the cumulative power rating of AC Coupled PV connected to this inverter."
+      },
+      {
+        "name": "SF_X10",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "LoadShedEnable",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable Load Shedding",
+        "desc": "Select 1 if using PWRmanager and / or SMM devices to manage loads. Select 2 if using the PWRcell ATS Controller to manage loads (with or without SMMs). Do not use PWRmanager and PWRcell ATS Controller together for load management.",
+        "symbols": [
+          {
+            "name": "LOAD_SHED_DISABLED",
+            "value": 0
+          },
+          {
+            "name": "LOAD_SHED_SMM_ONLY",
+            "value": 1
+          },
+          {
+            "name": "LOAD_SHED_ATS_AND_SMM",
+            "value": 2
+          },
+          {
+            "name": "N/A",
+            "value": 32768
+          }
+        ]
+      },
+      {
+        "name": "GridParallelInverters",
+        "type": "int16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Grid Parallel Inverters",
+        "desc": "This setting allows for two inverters to share one set of CTs. Set to 2 if daisy chaining CTs between two inverters."
+      },
+      {
+        "name": "CTTurnsRatio",
+        "type": "int16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "CT Turns Ratio",
+        "desc": "Allows setting a non-default turns ratio for the grid CTs. The default value is 1500"
+      },
+      {
+        "name": "GeneratorPower",
+        "type": "int16",
+        "size": 1,
+        "units": "kW",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "AC Generator Power Rating",
+        "desc": "Nameplate power rating of the AC coupled integrated generator. If no generator is integrated, leave at 0."
+      },
+      {
+        "name": "GeneratorControlMode",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "AC Generator Control Mode",
+        "desc": "Set AC Generator Control Mode for Single Transfer, Source Cycling, or Always On.",
+        "symbols": [
+          {
+            "name": "SINGLE_TRANSFER",
+            "value": 0
+          },
+          {
+            "name": "SOURCE_CYCLING",
+            "value": 1
+          },
+          {
+            "name": "ALWAYS_ON",
+            "value": 2
+          },
+          {
+            "name": "N/A",
+            "value": 32768
+          }
+        ]
+      },
+      {
+        "name": "ImportOverride",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Import Override",
+        "desc": "This setting will inhibit the PWRcell system from importing power from the grid to charge batteries.\n        NOTE: This feature requires CTs to be properly installed and calibrated prior to use. For more information on CT calibration, see the PWRcell Inverter Installation and Owners Manual.\n      ",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          },
+          {
+            "name": "N/A",
+            "value": 32768
+          }
+        ]
+      },
+      {
+        "name": "Pad11",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Large pad for future model expansion"
+      },
+      {
+        "name": "Pad12",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad13",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad14",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad15",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad16",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad17",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad18",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad19",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad20",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad21",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad22",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad23",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64206
+}

--- a/models/model_64207.json
+++ b/models/model_64207.json
@@ -1,0 +1,1117 @@
+{
+  "group": {
+    "name": "REbus_status",
+    "type": "group",
+    "label": "REbus Status",
+    "desc": "REbus status data that is defined commonly across Generac REbus devices",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64207
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "P",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "REbus Power",
+        "desc": "REbus power. Positive indicates the device is sourcing to REbus, and negative indicates sinking from REbus."
+      },
+      {
+        "name": "E",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Accumulated Energy",
+        "desc": "Total accumulated energy (exact definition differs by device)"
+      },
+      {
+        "name": "V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "V",
+        "mandatory": "M",
+        "label": "REbus Voltage ",
+        "desc": "REbus DC Bus Voltage"
+      },
+      {
+        "name": "I",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_sf",
+        "units": "A",
+        "mandatory": "M",
+        "label": "REbus Current",
+        "desc": "REbus current. Positive indicates the device is sourcing to REbus, and negative indicates sinking from REbus."
+      },
+      {
+        "name": "T",
+        "type": "int16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "Deg C",
+        "mandatory": "M",
+        "label": "Device Temperature",
+        "desc": "Device temperature"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "State",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "device offline"
+          },
+          {
+            "name": "DISABLED",
+            "value": 16,
+            "label": "disabled"
+          },
+          {
+            "name": "ESTOP_ACTIVE",
+            "value": 32,
+            "label": "e-stop active"
+          },
+          {
+            "name": "INITIALIZING",
+            "value": 256,
+            "label": "initializing"
+          },
+          {
+            "name": "POWERING_UP",
+            "value": 272,
+            "label": "powering up"
+          },
+          {
+            "name": "CONNECTING_BUS",
+            "value": 288,
+            "label": "connecting to REbus"
+          },
+          {
+            "name": "DISCONNECTING_BUS",
+            "value": 304,
+            "label": "disconnecting REbus"
+          },
+          {
+            "name": "TESTING_BUS",
+            "value": 320,
+            "label": "testing REbus..."
+          },
+          {
+            "name": "LOW_BUS_VOLTAGE",
+            "value": 512,
+            "label": "low REbus voltage"
+          },
+          {
+            "name": "STANDBY",
+            "value": 768,
+            "label": "standby"
+          },
+          {
+            "name": "WAITING",
+            "value": 784,
+            "label": "waiting"
+          },
+          {
+            "name": "WAITING_NO_INPUT",
+            "value": 800,
+            "label": "waiting: no input"
+          },
+          {
+            "name": "WAITING_HEARTBEAT",
+            "value": 816,
+            "label": "waiting: no heartbeat"
+          },
+          {
+            "name": "CONNECTING_GRID",
+            "value": 2048,
+            "label": "connecting grid"
+          },
+          {
+            "name": "DISCONNECTING_GRID",
+            "value": 2064,
+            "label": "disconnecting grid"
+          },
+          {
+            "name": "GRID_CONNECTED",
+            "value": 2080,
+            "label": "grid connected"
+          },
+          {
+            "name": "ISLANDED",
+            "value": 2096,
+            "label": "islanded"
+          },
+          {
+            "name": "CONNECTING_GENERATOR",
+            "value": 2112,
+            "label": "connecting gen"
+          },
+          {
+            "name": "GENERATOR_CONNECTED",
+            "value": 2128,
+            "label": "gen connected"
+          },
+          {
+            "name": "DISCONNECTING_GENERATOR",
+            "value": 2144,
+            "label": "disconnecting gen"
+          },
+          {
+            "name": "ISLAND_OVERLOAD",
+            "value": 2160,
+            "label": "island overload"
+          },
+          {
+            "name": "ISLANDED_WITH_ACCPV",
+            "value": 2176,
+            "label": "islanded: AC PV on "
+          },
+          {
+            "name": "ISLANDED_WITHOUT_ACCPV",
+            "value": 2192,
+            "label": "islanded: AC PV off"
+          },
+          {
+            "name": "LOW_INPUT_VOLTAGE",
+            "value": 4096,
+            "label": "low input voltage"
+          },
+          {
+            "name": "TESTING_DEVICE_INPUT",
+            "value": 4112,
+            "label": "testing input"
+          },
+          {
+            "name": "SAFETY_CHECKS",
+            "value": 4128,
+            "label": "safety checks"
+          },
+          {
+            "name": "CONNECTING_INPUT",
+            "value": 4352,
+            "label": "connecting input"
+          },
+          {
+            "name": "DISCONNECTING_INPUT",
+            "value": 4368,
+            "label": "disconnecting input"
+          },
+          {
+            "name": "CALIBRATING",
+            "value": 4608,
+            "label": "calibrating"
+          },
+          {
+            "name": "CALIBRATION_SUCCESS",
+            "value": 4624,
+            "label": "calibration success!"
+          },
+          {
+            "name": "CALIBRATION_NEEDED",
+            "value": 4640,
+            "label": "calibration required"
+          },
+          {
+            "name": "BURN_IN",
+            "value": 4656,
+            "label": "burning in"
+          },
+          {
+            "name": "BURN_IN_DONE",
+            "value": 4672,
+            "label": "burn in done"
+          },
+          {
+            "name": "SCHEDULER_OVERRIDDEN",
+            "value": 4864,
+            "label": "running, overridden"
+          },
+          {
+            "name": "SCHEDULER_DISABLED",
+            "value": 4880,
+            "label": "scheduler disabled"
+          },
+          {
+            "name": "SCHEDULER_NOT_CONFIGURED",
+            "value": 4896,
+            "label": "scheduler not configured"
+          },
+          {
+            "name": "RUNNING",
+            "value": 8192,
+            "label": "running"
+          },
+          {
+            "name": "MAKING_POWER",
+            "value": 8208,
+            "label": "making power"
+          },
+          {
+            "name": "LIMITING_POWER",
+            "value": 8224,
+            "label": "limiting power"
+          },
+          {
+            "name": "LOW_WIND",
+            "value": 12288,
+            "label": "low wind"
+          },
+          {
+            "name": "HIGH_WIND",
+            "value": 12304,
+            "label": "high wind"
+          },
+          {
+            "name": "LOW_SUN",
+            "value": 12544,
+            "label": "low sun"
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 16384,
+            "label": "ground fault"
+          },
+          {
+            "name": "INSULATION_FAULT",
+            "value": 16400,
+            "label": "insulation fault"
+          },
+          {
+            "name": "GROUND_FAULT_LOCKOUT",
+            "value": 16416,
+            "label": "ground fault lockout"
+          },
+          {
+            "name": "ARC_FAULT",
+            "value": 16640,
+            "label": "arc fault"
+          },
+          {
+            "name": "BUS_OVER_VOLTAGE",
+            "value": 16896,
+            "label": "high REbus voltage"
+          },
+          {
+            "name": "TEST_SUCCESS",
+            "value": 20480,
+            "label": "test success"
+          },
+          {
+            "name": "TEST_FAILURE",
+            "value": 20496,
+            "label": "test failure"
+          },
+          {
+            "name": "TESTING_AFD",
+            "value": 20512,
+            "label": "testing AFD"
+          },
+          {
+            "name": "TESTING_PVRSS",
+            "value": 20528,
+            "label": "testing PVRSS"
+          },
+          {
+            "name": "TESTING_GFD",
+            "value": 20544,
+            "label": "testing GFD"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS",
+            "value": 20752,
+            "label": "PVRSS selftest failed"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS_LOWVOC",
+            "value": 20768,
+            "label": "PVRSS fail: low input"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS_COUNT_MISMATCH",
+            "value": 20784,
+            "label": "PVRSS count mismatch"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS_VLOW_HIGH",
+            "value": 20800,
+            "label": "PVRSS fail: hi input"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS_VLOW_TIMEOUT",
+            "value": 20816,
+            "label": "PVRSS fail: timeout"
+          },
+          {
+            "name": "TEST_FAIL_AFD",
+            "value": 20832,
+            "label": "AFD selftest failed"
+          },
+          {
+            "name": "TEST_FAIL_GFD",
+            "value": 20848,
+            "label": "GFD selftest failed"
+          },
+          {
+            "name": "TEST_FAIL_PVRSS_NOT_CONFIGURED",
+            "value": 20864,
+            "label": "PVRSS not configured"
+          },
+          {
+            "name": "UPDATING_FIRMWARE",
+            "value": 20992,
+            "label": "updating firmware"
+          },
+          {
+            "name": "CHARGING_BATTERY",
+            "value": 24576,
+            "label": "charging"
+          },
+          {
+            "name": "FLOAT_CHARGING_BATTERY",
+            "value": 24592,
+            "label": "float charging"
+          },
+          {
+            "name": "BULK_CHARGING_BATTERY",
+            "value": 24608,
+            "label": "bulk charging"
+          },
+          {
+            "name": "ABSORPTION_CHARGING_BATTERY",
+            "value": 24624,
+            "label": "absorption charging"
+          },
+          {
+            "name": "EQUALIZE_CHARGING_BATTERY",
+            "value": 24640,
+            "label": "equalizing"
+          },
+          {
+            "name": "DISCHARGING_BATTERY",
+            "value": 24832,
+            "label": "discharging"
+          },
+          {
+            "name": "LOW_BATTERY_VOLTAGE",
+            "value": 24848,
+            "label": "low battery voltage"
+          },
+          {
+            "name": "CELL_IMBALANCE",
+            "value": 25344,
+            "label": "cell imbalance"
+          },
+          {
+            "name": "ERROR_GENERIC",
+            "value": 28672,
+            "label": "error"
+          },
+          {
+            "name": "OVER_VOLTAGE_INPUT",
+            "value": 28688,
+            "label": "input over voltage"
+          },
+          {
+            "name": "OVER_VOLTAGE_OUTPUT",
+            "value": 28704,
+            "label": "output over voltage"
+          },
+          {
+            "name": "OVER_CURRENT_INPUT",
+            "value": 28720,
+            "label": "input over current"
+          },
+          {
+            "name": "OVER_CURRENT_OUTPUT",
+            "value": 28736,
+            "label": "output over current"
+          },
+          {
+            "name": "ERROR_LOW_BATTERY_VOLTAGE",
+            "value": 28752,
+            "label": "low battery voltage"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 28928,
+            "label": "over temperature"
+          },
+          {
+            "name": "GROUND_FAULT_LOCKOUT_DEFUNCT",
+            "value": 29184,
+            "label": "ground fault lockout"
+          },
+          {
+            "name": "INSULATION_FAULT_LOCKOUT",
+            "value": 29200,
+            "label": "insulation fault lockout"
+          },
+          {
+            "name": "ARC_FAULT_LOCKOUT",
+            "value": 29440,
+            "label": "arc fault lockout"
+          },
+          {
+            "name": "PVRSS_LOCKOUT",
+            "value": 29456,
+            "label": "PVRSS lockout error"
+          },
+          {
+            "name": "INPUT_REVERSED",
+            "value": 29696,
+            "label": "input reversed"
+          },
+          {
+            "name": "ERROR_REBUS_FAULT",
+            "value": 29968,
+            "label": "error: REbus fault"
+          },
+          {
+            "name": "ERROR_INTERNAL_BUS_FAULT",
+            "value": 29984,
+            "label": "error: int DC fault"
+          },
+          {
+            "name": "CONFIGURATION_ERROR",
+            "value": 30464,
+            "label": "config error"
+          },
+          {
+            "name": "BAD_RESET_ERROR",
+            "value": 30480,
+            "label": "bad reset error"
+          },
+          {
+            "name": "WIRING_ERROR",
+            "value": 30496,
+            "label": "wiring error"
+          },
+          {
+            "name": "ERROR_FUSE_BLOWN",
+            "value": 30512,
+            "label": "fuse blown error"
+          },
+          {
+            "name": "CALIBRATION_0",
+            "value": 32256,
+            "label": "calibration mode"
+          },
+          {
+            "name": "CALIBRATION_1",
+            "value": 32272,
+            "label": "calibration mode"
+          },
+          {
+            "name": "CALIBRATION_2",
+            "value": 32288,
+            "label": "calibration mode"
+          },
+          {
+            "name": "CALIBRATION_3",
+            "value": 32304,
+            "label": "calibration mode"
+          }
+        ]
+      },
+      {
+        "name": "Ev",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Last Event",
+        "symbols": [
+          {
+            "name": "GENERIC",
+            "value": 32768,
+            "label": "generic event"
+          },
+          {
+            "name": "POWERUP",
+            "value": 32784,
+            "label": "power up"
+          },
+          {
+            "name": "SUPPLY_UNDERVOLTAGE",
+            "value": 32800,
+            "label": "supply under voltage"
+          },
+          {
+            "name": "DAILY_EVENT",
+            "value": 32816,
+            "label": "daily event"
+          },
+          {
+            "name": "FIRMWARE_RECEIVED",
+            "value": 32832,
+            "label": "firmware received"
+          },
+          {
+            "name": "SUPPLY_OVERVOLTAGE",
+            "value": 32848,
+            "label": "supply over voltage"
+          },
+          {
+            "name": "CT_CALIBRATION_NIBBLED",
+            "value": 32864,
+            "label": "ct cal = "
+          },
+          {
+            "name": "CT_CALIBRATION_SUCCESS",
+            "value": 32880,
+            "label": "ct cal success"
+          },
+          {
+            "name": "CT_CALIBRATION_FAULT",
+            "value": 32896,
+            "label": "ct cal fault"
+          },
+          {
+            "name": "FIRMWARE_REJECTED",
+            "value": 32912,
+            "label": "firmware rejected"
+          },
+          {
+            "name": "ENABLE",
+            "value": 33024,
+            "label": "enable"
+          },
+          {
+            "name": "DISABLE",
+            "value": 33280,
+            "label": "disable"
+          },
+          {
+            "name": "MANUAL_DISABLE",
+            "value": 33296,
+            "label": "manual disable"
+          },
+          {
+            "name": "EXTERNAL_ESTOP",
+            "value": 33312,
+            "label": "external estop"
+          },
+          {
+            "name": "ENTERING_ISLANDED",
+            "value": 33328,
+            "label": "entering islanded"
+          },
+          {
+            "name": "SYSMODE_CHANGE",
+            "value": 33536,
+            "label": "sysmode change"
+          },
+          {
+            "name": "HEARTBEAT_LOST",
+            "value": 33584,
+            "label": "heartbeat lost"
+          },
+          {
+            "name": "SYSMODE_BAD",
+            "value": 33792,
+            "label": "unauthorized sysmode"
+          },
+          {
+            "name": "DEBUG_TRACE",
+            "value": 34048,
+            "label": "debug trace recorded"
+          },
+          {
+            "name": "TOU_ENTRY_ACTIVATED",
+            "value": 34304,
+            "label": "TOU entry activated"
+          },
+          {
+            "name": "PVRSS_INSTALLED_COUNT_CHANGED",
+            "value": 34560,
+            "label": "PVRSS count changed"
+          },
+          {
+            "name": "PVRSS_LOCKOUT_CLEARED",
+            "value": 34576,
+            "label": "PVRSS lockout cleared"
+          },
+          {
+            "name": "PVRSS_LOCKOUT_SET",
+            "value": 34592,
+            "label": "PVRSS lockout set"
+          },
+          {
+            "name": "SOFTWARE_VERSION",
+            "value": 36832,
+            "label": "software version mismatch"
+          },
+          {
+            "name": "HARDWARE_VERSION",
+            "value": 36848,
+            "label": "hardware version mismatch"
+          },
+          {
+            "name": "INTERRUPT_FAULT",
+            "value": 36864,
+            "label": "interrupt fault"
+          },
+          {
+            "name": "GATEDRIVE_FAULT",
+            "value": 37120,
+            "label": "gate drive fault"
+          },
+          {
+            "name": "TIMER_FAULT",
+            "value": 37376,
+            "label": "int. timer fault"
+          },
+          {
+            "name": "MUX_STUCK",
+            "value": 37632,
+            "label": "mux stuck"
+          },
+          {
+            "name": "RELAY_FAULT",
+            "value": 37664,
+            "label": "relay fault"
+          },
+          {
+            "name": "TRANSISTOR_FAILURE",
+            "value": 39168,
+            "label": "transistor failure"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 41216,
+            "label": "over temp shutdown"
+          },
+          {
+            "name": "FAN_FAILURE",
+            "value": 41232,
+            "label": "fan failure"
+          },
+          {
+            "name": "FUSE_BLOWN",
+            "value": 41248,
+            "label": "fuse blown"
+          },
+          {
+            "name": "MISWIRING",
+            "value": 41472,
+            "label": "miswiring"
+          },
+          {
+            "name": "ALTERNATOR_BAD",
+            "value": 42496,
+            "label": "bad alternator"
+          },
+          {
+            "name": "REVERSE_ROTATION",
+            "value": 42752,
+            "label": "reverse rotation"
+          },
+          {
+            "name": "BUS_FAULT",
+            "value": 45056,
+            "label": "REbus fault"
+          },
+          {
+            "name": "BUS_NO_LOAD",
+            "value": 45072,
+            "label": "REbus no load"
+          },
+          {
+            "name": "BUS_PRECHARGE_FAIL",
+            "value": 45088,
+            "label": "precharge fail"
+          },
+          {
+            "name": "BUS_OVER_VOLTAGE",
+            "value": 45312,
+            "label": "REbus over voltage"
+          },
+          {
+            "name": "BUS_UNDER_VOLTAGE",
+            "value": 45328,
+            "label": "REbus under voltage"
+          },
+          {
+            "name": "BUS_OVER_CURRENT",
+            "value": 45568,
+            "label": "REbus over current"
+          },
+          {
+            "name": "INTERNAL_OVERVOLTAGE",
+            "value": 45824,
+            "label": "internal over voltage"
+          },
+          {
+            "name": "RAPID_SHUTDOWN_FAULT",
+            "value": 46096,
+            "label": "PVRSS selftest failed"
+          },
+          {
+            "name": "BATTERY_GENERIC",
+            "value": 47104,
+            "label": "battery issue"
+          },
+          {
+            "name": "BATTERY_READY",
+            "value": 47120,
+            "label": "battery ready"
+          },
+          {
+            "name": "BATTERY_NOT_READY",
+            "value": 47136,
+            "label": "battery not ready"
+          },
+          {
+            "name": "BATTERY_CONNECTED",
+            "value": 47152,
+            "label": "battery connected"
+          },
+          {
+            "name": "BATTERY_DISCONNECTED",
+            "value": 47168,
+            "label": "battery disconnected"
+          },
+          {
+            "name": "BATTERY_UNDER_CHARGE",
+            "value": 47184,
+            "label": "battery under charge"
+          },
+          {
+            "name": "BATTERY_OVER_CHARGE",
+            "value": 47200,
+            "label": "battery over charge"
+          },
+          {
+            "name": "BATTERY_BAD_MODULE",
+            "value": 47216,
+            "label": "battery over charge"
+          },
+          {
+            "name": "BMS_GENERIC",
+            "value": 47360,
+            "label": "BMS generic"
+          },
+          {
+            "name": "BMS_ALARM",
+            "value": 47376,
+            "label": "BMS alarm"
+          },
+          {
+            "name": "BMS_WARNING",
+            "value": 47392,
+            "label": "BMS warning"
+          },
+          {
+            "name": "BMS_ERROR",
+            "value": 47408,
+            "label": "BMS error"
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 49152,
+            "label": "ground fault"
+          },
+          {
+            "name": "GROUND_FAULT_LOCKOUT",
+            "value": 49168,
+            "label": "ground fault lockout"
+          },
+          {
+            "name": "INSULATION_FAULT",
+            "value": 49184,
+            "label": "insulation fault"
+          },
+          {
+            "name": "INPUT_LOW",
+            "value": 49408,
+            "label": "input low"
+          },
+          {
+            "name": "INPUT_SENSOR_FAULT",
+            "value": 49664,
+            "label": "input sensor fault"
+          },
+          {
+            "name": "INPUT_OVER_CURRENT",
+            "value": 49920,
+            "label": "input over current"
+          },
+          {
+            "name": "INPUT_OVERSPEED",
+            "value": 50176,
+            "label": "input over speed"
+          },
+          {
+            "name": "INPUT_HIGH",
+            "value": 50432,
+            "label": "input high"
+          },
+          {
+            "name": "ARC_FAULT",
+            "value": 50688,
+            "label": "arc fault"
+          },
+          {
+            "name": "ARC_FAULT_LOCKOUT",
+            "value": 50704,
+            "label": "arc fault lockout"
+          },
+          {
+            "name": "INPUT_READY",
+            "value": 50944,
+            "label": "input ready"
+          },
+          {
+            "name": "INPUT_REVERSED",
+            "value": 51200,
+            "label": "input reversed"
+          },
+          {
+            "name": "INPUT_OVER_VOLTAGE",
+            "value": 51456,
+            "label": "input over voltage"
+          },
+          {
+            "name": "GRID_FAULT",
+            "value": 53248,
+            "label": "grid fault"
+          },
+          {
+            "name": "GRID_OVER_VOLTAGE",
+            "value": 53264,
+            "label": "grid over voltage"
+          },
+          {
+            "name": "GRID_OVER_CURRENT",
+            "value": 53280,
+            "label": "grid over current"
+          },
+          {
+            "name": "GRID_OVER_FREQUENCY",
+            "value": 53296,
+            "label": "grid over frequency"
+          },
+          {
+            "name": "GRID_UNDER_VOLTAGE",
+            "value": 53312,
+            "label": "grid under voltage"
+          },
+          {
+            "name": "GRID_UNDER_FREQUENCY",
+            "value": 53328,
+            "label": "grid under frequency"
+          },
+          {
+            "name": "GRID_OVER_VOLTAGE_FAST",
+            "value": 53344,
+            "label": "grid overvoltage fast"
+          },
+          {
+            "name": "GRID_HIGH_IMPEDANCE",
+            "value": 53360,
+            "label": "grid high impedance"
+          },
+          {
+            "name": "TRANSFER_FAIL",
+            "value": 53504,
+            "label": "transfer sw fail"
+          },
+          {
+            "name": "ISLAND_OVERLOAD",
+            "value": 53520,
+            "label": "island overload"
+          },
+          {
+            "name": "SETPOINT_CRC_FAULT",
+            "value": 57344,
+            "label": "bad spt crc"
+          },
+          {
+            "name": "EEPROM_FAULT",
+            "value": 57600,
+            "label": "EEPROM failure"
+          },
+          {
+            "name": "FLASH_FAULT",
+            "value": 57856,
+            "label": "FLASH fault"
+          },
+          {
+            "name": "PLM_RESTART",
+            "value": 58112,
+            "label": "PLM restart"
+          },
+          {
+            "name": "DEBUG_DATA_COLLECTION",
+            "value": 58368,
+            "label": "debug data collected"
+          },
+          {
+            "name": "EVPATTERN_LOCKOUT",
+            "value": 58624,
+            "label": "event pattern lockout"
+          },
+          {
+            "name": "BAD_RESET_ERROR",
+            "value": 58880,
+            "label": "bad reset error"
+          },
+          {
+            "name": "PLM_FAULT",
+            "value": 59136,
+            "label": "PLM fault"
+          },
+          {
+            "name": "DEFAULT_TRAP",
+            "value": 61440,
+            "label": "default trap"
+          },
+          {
+            "name": "ADDRESS_ERROR",
+            "value": 61456,
+            "label": "address error trap"
+          },
+          {
+            "name": "STACK_ERROR",
+            "value": 61472,
+            "label": "stack error trap"
+          },
+          {
+            "name": "OSCILLATOR_FAIL",
+            "value": 61488,
+            "label": "osc. fail trap"
+          },
+          {
+            "name": "MATH_ERROR",
+            "value": 61504,
+            "label": "math error trap"
+          },
+          {
+            "name": "DMAC_ERROR",
+            "value": 61520,
+            "label": "dmac error trap"
+          }
+        ]
+      },
+      {
+        "name": "RB",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "REbusBits",
+        "desc": "REbus status register",
+        "symbols": [
+          {
+            "name": "ENABLE_MASTER",
+            "value": 0
+          },
+          {
+            "name": "ENABLE_SOURCE",
+            "value": 1
+          },
+          {
+            "name": "ENABLE_SINK",
+            "value": 2
+          },
+          {
+            "name": "RESERVED3",
+            "value": 3
+          },
+          {
+            "name": "BUS_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "BUS_DISCONNECTED",
+            "value": 5
+          },
+          {
+            "name": "SOURCING",
+            "value": 6
+          },
+          {
+            "name": "SINKING",
+            "value": 7
+          },
+          {
+            "name": "BUS_VOLTAGE_LOW",
+            "value": 8
+          },
+          {
+            "name": "BUS_VOLTAGE_HIGH",
+            "value": 9
+          },
+          {
+            "name": "BUS_IMBALANCE",
+            "value": 10
+          },
+          {
+            "name": "RESERVED11",
+            "value": 11
+          },
+          {
+            "name": "PLC_GOOD",
+            "value": 12
+          },
+          {
+            "name": "HEARTBEAT_GOOD",
+            "value": 13
+          },
+          {
+            "name": "ADAPTIVE_VREBUS_ACTIVE",
+            "value": 14
+          },
+          {
+            "name": "RESERVED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "VT_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VT_sf",
+        "desc": "Scale factor for V and T"
+      },
+      {
+        "name": "I_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "I_sf",
+        "desc": "Scale factor for I"
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64207
+}

--- a/models/model_64208.json
+++ b/models/model_64208.json
@@ -1,0 +1,528 @@
+{
+  "group": {
+    "name": "inverter_status",
+    "type": "group",
+    "label": "Inverter Status",
+    "desc": "Miscellaneous Generac inverter status registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64208
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "SysMd",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "System Operating Mode",
+        "symbols": [
+          {
+            "name": "SAFETY_SHUTDOWN",
+            "value": 0,
+            "label": "Saftey Shutdown",
+            "desc": "All devices disabled and DC bus de-energized."
+          },
+          {
+            "name": "GRID_TIE",
+            "value": 1,
+            "label": "Grid Tie",
+            "desc": "Support local loads and export solar power to the utility grid."
+          },
+          {
+            "name": "SELF_SUPPLY",
+            "value": 2,
+            "label": "Self Supply",
+            "desc": "Utilize both solar power and battery power to support local loads before exporting surplus solar to utility grid."
+          },
+          {
+            "name": "CLEAN_BACKUP",
+            "value": 3,
+            "label": "Clean Backup",
+            "desc": "Charge batteries from solar only before supporting local loads and exporting to utility grid."
+          },
+          {
+            "name": "PRIORITY_BACKUP",
+            "value": 4,
+            "label": "Priority Backup",
+            "desc": "Charge batteries with both solar and the utility grid"
+          },
+          {
+            "name": "REMOTE_ARBITRAGE",
+            "value": 5
+          },
+          {
+            "name": "SELL",
+            "value": 6,
+            "label": "Sell",
+            "desc": "Export full capacity, including battery power, to utility grid."
+          }
+        ]
+      },
+      {
+        "name": "CTPow",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "External CT Power measurement",
+        "desc": "Positive is exporting, negative is importing. Reads 0x8000 when CTs are not connected."
+      },
+      {
+        "name": "WhIn",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total AC Energy Imported",
+        "desc": "As measured from CTs"
+      },
+      {
+        "name": "WhOut",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total AC Energy Exported",
+        "desc": "As measured from CTs"
+      },
+      {
+        "name": "ErrorWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Error status",
+        "desc": "Error status bitfield",
+        "symbols": [
+          {
+            "name": "LINE1_OVERCURRENT",
+            "value": 0
+          },
+          {
+            "name": "AC_PRECHARGE_FAIL",
+            "value": 1
+          },
+          {
+            "name": "DC_OVERCURRENT",
+            "value": 2
+          },
+          {
+            "name": "DC_UNBALANCED_CURRENT",
+            "value": 3
+          },
+          {
+            "name": "GATEDRIVE_FAULT",
+            "value": 4
+          },
+          {
+            "name": "BAD_THERMISTER",
+            "value": 5
+          },
+          {
+            "name": "OVERTEMP_COMP",
+            "value": 6
+          },
+          {
+            "name": "DC_PRECHARGE_FAIL",
+            "value": 7
+          },
+          {
+            "name": "XFR_SWITCH_FAIL",
+            "value": 8
+          },
+          {
+            "name": "FLASH_FAIL",
+            "value": 9
+          },
+          {
+            "name": "EEPROM_FAIL",
+            "value": 10
+          },
+          {
+            "name": "AINV_INVALID",
+            "value": 11
+          }
+        ]
+      },
+      {
+        "name": "EnableBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable bits",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "DEADMAN",
+            "value": 0
+          },
+          {
+            "name": "DEADMAN_UP",
+            "value": 1
+          },
+          {
+            "name": "UNLOCK_GRIDSYNC",
+            "value": 2
+          },
+          {
+            "name": "CTCAL",
+            "value": 3
+          },
+          {
+            "name": "REBUS_CONNECT",
+            "value": 4
+          },
+          {
+            "name": "GRID_DISCONNECT",
+            "value": 5
+          },
+          {
+            "name": "OUTPUT_CONNECT",
+            "value": 6
+          },
+          {
+            "name": "LINE3_CONNECT",
+            "value": 7
+          },
+          {
+            "name": "VOLTAGE_MODE",
+            "value": 8
+          },
+          {
+            "name": "CURRENT_MODE",
+            "value": 9
+          },
+          {
+            "name": "BRIDGE",
+            "value": 10
+          },
+          {
+            "name": "NEUT_BRIDGE",
+            "value": 11
+          },
+          {
+            "name": "UNUSED12",
+            "value": 12
+          },
+          {
+            "name": "AUTOFAN_ON",
+            "value": 13
+          },
+          {
+            "name": "LCM_RCP",
+            "value": 14
+          },
+          {
+            "name": "USB_RCP",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "RelayStatus",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Relay status",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "AC_PRECHARGE",
+            "value": 0
+          },
+          {
+            "name": "DC_PRECHARGE",
+            "value": 1
+          },
+          {
+            "name": "REBUS_CONNECTED",
+            "value": 2
+          },
+          {
+            "name": "REBUS_DISCONNETED",
+            "value": 3
+          },
+          {
+            "name": "GRID_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "GRID_DISCONNECTED",
+            "value": 5
+          },
+          {
+            "name": "OUTPUT_CONNECTED",
+            "value": 6
+          },
+          {
+            "name": "OUTPUT_DISCONNECTED",
+            "value": 7
+          },
+          {
+            "name": "LINE3_CONNECTED",
+            "value": 8
+          },
+          {
+            "name": "LINE3_DISCONNECTED",
+            "value": 9
+          },
+          {
+            "name": "LINE3_RETURNING",
+            "value": 10
+          },
+          {
+            "name": "UNUSED11",
+            "value": 11
+          },
+          {
+            "name": "UNUSED12",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "StatusWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "General status",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "V1_LOCKED",
+            "value": 0
+          },
+          {
+            "name": "V2_LOCKED",
+            "value": 1
+          },
+          {
+            "name": "FREQ_LOCKED",
+            "value": 2
+          },
+          {
+            "name": "PHASE_LOCKED",
+            "value": 3
+          },
+          {
+            "name": "LOCKED_TO_GRID",
+            "value": 4
+          },
+          {
+            "name": "PRERES_OVERTEMP",
+            "value": 5
+          },
+          {
+            "name": "QPRIORITY",
+            "value": 6
+          },
+          {
+            "name": "EXT_TRANSFERRED",
+            "value": 7
+          },
+          {
+            "name": "MFLT_ACTIVE",
+            "value": 8
+          },
+          {
+            "name": "ESTOP_ACTIVE",
+            "value": 9
+          },
+          {
+            "name": "GF_ACTIVE",
+            "value": 10
+          },
+          {
+            "name": "AF_ACTIVE",
+            "value": 11
+          },
+          {
+            "name": "PLM_READY",
+            "value": 12
+          },
+          {
+            "name": "INST_IFACE",
+            "value": 13
+          },
+          {
+            "name": "XESTOP_ACTIVE",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "LineStatus",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "AC Line Status",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "V1_LOW",
+            "value": 0
+          },
+          {
+            "name": "V1_HIGH",
+            "value": 1
+          },
+          {
+            "name": "V2_LOW",
+            "value": 2
+          },
+          {
+            "name": "V2_HIGH",
+            "value": 3
+          },
+          {
+            "name": "V3_LOW",
+            "value": 4
+          },
+          {
+            "name": "V3_HIGH",
+            "value": 5
+          },
+          {
+            "name": "FREQ_LOW",
+            "value": 6
+          },
+          {
+            "name": "FREQ_HIGH",
+            "value": 7
+          },
+          {
+            "name": "UNLOCK",
+            "value": 8
+          },
+          {
+            "name": "NO_ZCROSS",
+            "value": 9
+          },
+          {
+            "name": "HIGH_IMP",
+            "value": 10
+          },
+          {
+            "name": "GRIDFAULT",
+            "value": 11
+          },
+          {
+            "name": "GT_SPLIT_OR_REVERSE",
+            "value": 12
+          },
+          {
+            "name": "GT_3PHASE",
+            "value": 13
+          },
+          {
+            "name": "CESSATION",
+            "value": 14
+          },
+          {
+            "name": "GENMODE",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Large pad for future model expansion"
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad9",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad10",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64208
+}

--- a/models/model_64209.json
+++ b/models/model_64209.json
@@ -1,0 +1,498 @@
+{
+  "group": {
+    "name": "battery_status",
+    "type": "group",
+    "label": "Generac B-Link Status",
+    "desc": "Miscellaneous battery status registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64209
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "WhIn",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Energy In",
+        "desc": "Energy absorbed by battery"
+      },
+      {
+        "name": "WhOut",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Total Energy Out",
+        "desc": "Energy supplied by battery"
+      },
+      {
+        "name": "ErrorWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Error status",
+        "desc": "Error status bitfield",
+        "symbols": [
+          {
+            "name": "CS_ZERO_ERR",
+            "value": 0
+          },
+          {
+            "name": "REF_FAIL",
+            "value": 1
+          },
+          {
+            "name": "THERM_FAIL",
+            "value": 2
+          },
+          {
+            "name": "UNUSED",
+            "value": 3
+          },
+          {
+            "name": "EEPROM_FAIL",
+            "value": 4
+          },
+          {
+            "name": "SPT_ERROR",
+            "value": 5
+          },
+          {
+            "name": "HWV_MISMATCH",
+            "value": 6
+          },
+          {
+            "name": "SPTV_MISMATCH",
+            "value": 7
+          },
+          {
+            "name": "BATT_OVERTEMP",
+            "value": 8
+          },
+          {
+            "name": "REPEAT_OVERCURRENT",
+            "value": 9
+          },
+          {
+            "name": "FAN_FAIL",
+            "value": 10
+          },
+          {
+            "name": "CURRENT_CTRL_FAIL",
+            "value": 11
+          },
+          {
+            "name": "BMS_ERROR",
+            "value": 12
+          },
+          {
+            "name": "REPEAT_CONTACT",
+            "value": 13
+          },
+          {
+            "name": "EXTERNAL_STOP",
+            "value": 14
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "EnableBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable bits",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "DEADMAN",
+            "value": 0
+          },
+          {
+            "name": "GATEDRIVE",
+            "value": 1
+          },
+          {
+            "name": "REBUS_CONNECT",
+            "value": 2
+          },
+          {
+            "name": "BATT_CONNECT",
+            "value": 3
+          },
+          {
+            "name": "INT_FAN",
+            "value": 4
+          },
+          {
+            "name": "EXT_FAN",
+            "value": 5
+          },
+          {
+            "name": "FAN_OVERRIDE",
+            "value": 6
+          },
+          {
+            "name": "BLKSTART_BATT_CHG",
+            "value": 7
+          },
+          {
+            "name": "CONV1",
+            "value": 8
+          },
+          {
+            "name": "CONV2",
+            "value": 9
+          },
+          {
+            "name": "AUTOMODE",
+            "value": 10
+          },
+          {
+            "name": "120HZ_FILTER",
+            "value": 11
+          },
+          {
+            "name": "BMS",
+            "value": 12
+          },
+          {
+            "name": "INHIBIT_CSZ",
+            "value": 13
+          },
+          {
+            "name": "CSZERO",
+            "value": 14
+          },
+          {
+            "name": "USB_RCP",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "InhibitBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "InhibitBits",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "PRECHARGE_FAIL",
+            "value": 0
+          },
+          {
+            "name": "IBAT_INTEGRAL",
+            "value": 1
+          },
+          {
+            "name": "NO_REBUS_ENABLES",
+            "value": 2
+          },
+          {
+            "name": "BATTERY_BMS",
+            "value": 3
+          },
+          {
+            "name": "VBUS_OV",
+            "value": 4
+          },
+          {
+            "name": "VDC_OV",
+            "value": 5
+          },
+          {
+            "name": "VBAT_OV",
+            "value": 6
+          },
+          {
+            "name": "IBAT_OV",
+            "value": 7
+          },
+          {
+            "name": "NO_INPUT",
+            "value": 8
+          },
+          {
+            "name": "BATT_VERYLOW_TIMEOUT",
+            "value": 9
+          },
+          {
+            "name": "BATT_CRIT_LOW",
+            "value": 10
+          },
+          {
+            "name": "BATT_CRIT_HIGH",
+            "value": 11
+          },
+          {
+            "name": "UNUSED12",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "StatusBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "General Status",
+        "desc": "General system status",
+        "symbols": [
+          {
+            "name": "DEADMAN_UP",
+            "value": 0
+          },
+          {
+            "name": "REBUS_PRECHARGING",
+            "value": 1
+          },
+          {
+            "name": "REBUS_CONNECTED",
+            "value": 2
+          },
+          {
+            "name": "BATT_CONNECTED",
+            "value": 3
+          },
+          {
+            "name": "CHARGING",
+            "value": 4
+          },
+          {
+            "name": "DISCHARGING",
+            "value": 5
+          },
+          {
+            "name": "COULD_CHARGE",
+            "value": 6
+          },
+          {
+            "name": "COULD_DISCHARGE",
+            "value": 7
+          },
+          {
+            "name": "UNUSED8",
+            "value": 8
+          },
+          {
+            "name": "UNUSED9",
+            "value": 9
+          },
+          {
+            "name": "UNUSED10",
+            "value": 10
+          },
+          {
+            "name": "UNUSED11",
+            "value": 11
+          },
+          {
+            "name": "GFD_READY",
+            "value": 12
+          },
+          {
+            "name": "PLM_READY",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "BMSStatus",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "BMS Status",
+        "desc": "Battery Management System flags",
+        "symbols": [
+          {
+            "name": "ENABLE_DISCHARGE",
+            "value": 0
+          },
+          {
+            "name": "LOW_SOC",
+            "value": 1
+          },
+          {
+            "name": "VERYLOW_SOC",
+            "value": 2
+          },
+          {
+            "name": "CRITLOW_SOC",
+            "value": 3
+          },
+          {
+            "name": "ENABLE_CHARGE",
+            "value": 4
+          },
+          {
+            "name": "HIGH_SOC",
+            "value": 5
+          },
+          {
+            "name": "VERYHIGH_SOC",
+            "value": 6
+          },
+          {
+            "name": "CRITHIGH_SOC",
+            "value": 7
+          },
+          {
+            "name": "BMS_UP",
+            "value": 8
+          },
+          {
+            "name": "COMM_OK",
+            "value": 9
+          },
+          {
+            "name": "BATT_READY",
+            "value": 10
+          },
+          {
+            "name": "UNUSED",
+            "value": 11
+          },
+          {
+            "name": "CHARGE_WARNING",
+            "value": 12
+          },
+          {
+            "name": "DISCHARGE_WARNING",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "FLOAT",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Large pad for future model expansion"
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad9",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad10",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad11",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad12",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64209
+}

--- a/models/model_64210.json
+++ b/models/model_64210.json
@@ -1,0 +1,150 @@
+{
+  "group": {
+    "name": "owner_info",
+    "type": "group",
+    "label": "Device Registration",
+    "desc": "Owner and Installer information",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64210
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "FNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Owner's First Name",
+        "desc": "End user's first name"
+      },
+      {
+        "name": "LNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Owner's Last Name",
+        "desc": "End user's last name"
+      },
+      {
+        "name": "Em",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Owner's Email",
+        "desc": "End user's email address"
+      },
+      {
+        "name": "Adr1",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Address Line 1",
+        "desc": "Address Line 1"
+      },
+      {
+        "name": "Adr2",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Address Line 2",
+        "desc": "Address Line 2"
+      },
+      {
+        "name": "Cty",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "City",
+        "desc": "City"
+      },
+      {
+        "name": "St",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "State/Province",
+        "desc": "State/Province"
+      },
+      {
+        "name": "Zp",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Zip/Postal Code",
+        "desc": "Zip/Postal Code"
+      },
+      {
+        "name": "Cntr",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Country",
+        "desc": "Country"
+      },
+      {
+        "name": "Phn",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Phone",
+        "desc": "Customer's phone number"
+      },
+      {
+        "name": "IFNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's first name",
+        "desc": "Installer's first name"
+      },
+      {
+        "name": "ILNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's last name",
+        "desc": "Installer's last name"
+      },
+      {
+        "name": "IEm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's email",
+        "desc": "Installer's email address"
+      },
+      {
+        "name": "ICo",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Installer Company",
+        "desc": "Installer Company"
+      },
+      {
+        "name": "IPhn",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Installer's phone",
+        "desc": "Installer's phone"
+      }
+    ]
+  },
+  "id": 64210
+}

--- a/models/model_64211.json
+++ b/models/model_64211.json
@@ -1,0 +1,390 @@
+{
+  "group": {
+    "name": "pvlink_status",
+    "type": "group",
+    "label": "Generac PV Link Status",
+    "desc": "Miscellaneous PV Link status registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64211
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ErrorWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Error status",
+        "desc": "Error status bitfield",
+        "symbols": [
+          {
+            "name": "UNUSED0",
+            "value": 0
+          },
+          {
+            "name": "HW_ARC_FAULT",
+            "value": 1
+          },
+          {
+            "name": "HW_REVERSE_CURRENT",
+            "value": 2
+          },
+          {
+            "name": "OVER_CURRENT",
+            "value": 3
+          },
+          {
+            "name": "INPUT_OVERVOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "GFTEST_FAIL",
+            "value": 5
+          },
+          {
+            "name": "LOW_INPUT_IMPEDANCE",
+            "value": 6
+          },
+          {
+            "name": "UNUSED7",
+            "value": 7
+          },
+          {
+            "name": "UNUSED8",
+            "value": 8
+          },
+          {
+            "name": "FLASH_FAILURE",
+            "value": 9
+          },
+          {
+            "name": "EEPROM_FAILURE",
+            "value": 10
+          },
+          {
+            "name": "SPT_CRC_FAIL",
+            "value": 11
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "DEAD_FET",
+            "value": 14
+          },
+          {
+            "name": "HWV_MISMATCH",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "EnableBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable bits",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "DEADMAN",
+            "value": 0
+          },
+          {
+            "name": "UNUSED1",
+            "value": 1
+          },
+          {
+            "name": "UNUSED2",
+            "value": 2
+          },
+          {
+            "name": "UNUSED3",
+            "value": 3
+          },
+          {
+            "name": "CONNECT_INPUT",
+            "value": 4
+          },
+          {
+            "name": "CONNECT_OUTPUT",
+            "value": 5
+          },
+          {
+            "name": "UNUSED6",
+            "value": 6
+          },
+          {
+            "name": "UNUSED7",
+            "value": 7
+          },
+          {
+            "name": "UNUSED8",
+            "value": 8
+          },
+          {
+            "name": "GF_STARTTEST",
+            "value": 9
+          },
+          {
+            "name": "INPUT_IMPED_STARTTEST",
+            "value": 11
+          },
+          {
+            "name": "UNUSED11",
+            "value": 11
+          },
+          {
+            "name": "PHASE2",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "StatusWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "General status",
+        "desc": "General system status",
+        "symbols": [
+          {
+            "name": "DEADMAN_UP",
+            "value": 0
+          },
+          {
+            "name": "LOW_SUPPLY_VOLTAGE",
+            "value": 1
+          },
+          {
+            "name": "GF_TESTED",
+            "value": 2
+          },
+          {
+            "name": "INPUT_IMPED_TESTED",
+            "value": 3
+          },
+          {
+            "name": "INPUT_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "OUTPUT_CONNECTED",
+            "value": 5
+          },
+          {
+            "name": "INPUT_DISCONNETED",
+            "value": 6
+          },
+          {
+            "name": "OUTPUT_DISCONNETED",
+            "value": 7
+          },
+          {
+            "name": "GF_SW_ACTIVE",
+            "value": 8
+          },
+          {
+            "name": "MASTER_FAULT_ACTIVE",
+            "value": 9
+          },
+          {
+            "name": "GF_ACTIVE",
+            "value": 10
+          },
+          {
+            "name": "ARC_FAULT_ACTIVE",
+            "value": 11
+          },
+          {
+            "name": "PBUS_LOW",
+            "value": 12
+          },
+          {
+            "name": "UNBAL_INPUT_FAULT_ACTIVE",
+            "value": 13
+          },
+          {
+            "name": "PH2_ON",
+            "value": 14
+          },
+          {
+            "name": "PH2_OFF",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "I_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Vin",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "mandatory": "M",
+        "label": "PV String Voltage",
+        "desc": "Input voltage of PV string"
+      },
+      {
+        "name": "Iin",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_SF",
+        "mandatory": "M",
+        "label": "PV String Current",
+        "desc": "Input current of PV string"
+      },
+      {
+        "name": "AMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Maximum Input Current",
+        "desc": "Maximum permitted input current from PV string"
+      },
+      {
+        "name": "Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable or Disable PV Link",
+        "symbols": [
+          {
+            "name": "DISABLE",
+            "value": 0
+          },
+          {
+            "name": "ENABLE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Large pad for future model expansion"
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad9",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad10",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad11",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad12",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64211
+}

--- a/models/model_64212.json
+++ b/models/model_64212.json
@@ -1,0 +1,280 @@
+{
+  "group": {
+    "name": "DCB105_warranty",
+    "type": "group",
+    "label": "Panasonic DCB105 Module Warranty Data",
+    "desc": "Data from DCB105 modules required for Panasonic warranty",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64212
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "sf_10",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "sf_100",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "sf_1000",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "NMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Count",
+        "desc": "Number of DCB modules that the system is configured for"
+      },
+      {
+        "name": "WhIn",
+        "type": "int32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WhIn",
+        "desc": "Cummulative energy into battery string"
+      },
+      {
+        "name": "WhOut",
+        "type": "int32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WhOut",
+        "desc": "Cummulative energy out of battery string"
+      },
+      {
+        "name": "AhIn",
+        "type": "int32",
+        "size": 2,
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "AhIn",
+        "desc": "Cummulative charge into battery string"
+      },
+      {
+        "name": "AhOut",
+        "type": "int32",
+        "size": 2,
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "AhOut",
+        "desc": "Cummulative charge out of battery string"
+      },
+      {
+        "name": "THSin",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_10",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Heat Sink Temp",
+        "desc": "Temperature of heat sink input"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power",
+        "desc": "Battery power right now"
+      },
+      {
+        "name": "I",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_100",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Current",
+        "desc": "Instantaneous current measurement"
+      },
+      {
+        "name": "V",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_10",
+        "units": "V",
+        "mandatory": "M",
+        "label": "String Voltage",
+        "desc": "Voltage of whole string of batteries"
+      }
+    ],
+    "groups": [
+      {
+        "name": "DCB105_module",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "SN",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Serial Number",
+            "desc": "Serial Number"
+          },
+          {
+            "name": "ManDt",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Product Date Code",
+            "desc": "Manufacture date"
+          },
+          {
+            "name": "ProgVer",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Program Version",
+            "desc": "Program version"
+          },
+          {
+            "name": "DataVer",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Data Version",
+            "desc": "Data version"
+          },
+          {
+            "name": "StatusFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Status Flags",
+            "desc": "Status"
+          },
+          {
+            "name": "WarningFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Warning Flags",
+            "desc": "Warnings"
+          },
+          {
+            "name": "AlarmFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Alarm Flags",
+            "desc": "Alarms"
+          },
+          {
+            "name": "ErrorFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Error Flags",
+            "desc": "Errors"
+          },
+          {
+            "name": "ModuleIOFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Module IO Flags",
+            "desc": "IO flags"
+          },
+          {
+            "name": "SOC",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_10",
+            "mandatory": "M",
+            "label": "State of Charge",
+            "desc": "State of Charge"
+          },
+          {
+            "name": "SOH",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_10",
+            "mandatory": "M",
+            "label": "State of Health",
+            "desc": "State of Health"
+          },
+          {
+            "name": "MaxCellV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_1000",
+            "units": "V",
+            "mandatory": "M",
+            "label": "MaxCellV",
+            "desc": "Maximum cell voltage"
+          },
+          {
+            "name": "MinCellV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_1000",
+            "units": "V",
+            "mandatory": "M",
+            "label": "MinCellV",
+            "desc": "Minimum cell voltage"
+          },
+          {
+            "name": "PackV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_100",
+            "units": "V",
+            "mandatory": "M",
+            "label": "PackV",
+            "desc": "Module voltage"
+          },
+          {
+            "name": "MaxCellT",
+            "type": "int16",
+            "size": 1,
+            "sf": "sf_10",
+            "units": "C",
+            "mandatory": "M",
+            "label": "MaxCellT",
+            "desc": "Maximum cell temperature"
+          },
+          {
+            "name": "MinCellT",
+            "type": "int16",
+            "size": 1,
+            "sf": "sf_10",
+            "units": "C",
+            "mandatory": "M",
+            "label": "MinCellT",
+            "desc": "Minimum cell temperature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64212
+}

--- a/models/model_64213.json
+++ b/models/model_64213.json
@@ -1,0 +1,590 @@
+{
+  "group": {
+    "name": "legacy_status",
+    "type": "group",
+    "label": "RCP Legacy Status Update",
+    "desc": "Status update data",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64213
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "VT_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VT_sf",
+        "desc": "Scale factor for V and T"
+      },
+      {
+        "name": "I_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "I_sf",
+        "desc": "Scale factor for I"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "State",
+        "desc": "RCP state code",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "device offline"
+          },
+          {
+            "name": "DISABLED",
+            "value": 16,
+            "label": "disabled"
+          },
+          {
+            "name": "INITIALIZING",
+            "value": 256,
+            "label": "initializing"
+          },
+          {
+            "name": "POWERING_UP",
+            "value": 272,
+            "label": "powering up"
+          },
+          {
+            "name": "CONNECTING_BUS",
+            "value": 288,
+            "label": "connecting to REbus"
+          },
+          {
+            "name": "DISCONNECTING_BUS",
+            "value": 304,
+            "label": "disconnecting REbus"
+          },
+          {
+            "name": "TESTING_BUS",
+            "value": 320,
+            "label": "testing REbus..."
+          },
+          {
+            "name": "LOW_BUS_VOLTAGE",
+            "value": 512,
+            "label": "low REbus voltage"
+          },
+          {
+            "name": "STANDBY",
+            "value": 768,
+            "label": "standby"
+          },
+          {
+            "name": "WAITING",
+            "value": 784,
+            "label": "waiting"
+          },
+          {
+            "name": "WAITING_NO_INPUT",
+            "value": 800,
+            "label": "waiting - no input"
+          },
+          {
+            "name": "CONNECTING_GRID",
+            "value": 2048,
+            "label": "connecting grid"
+          },
+          {
+            "name": "DISCONNECTING_GRID",
+            "value": 2064,
+            "label": "disconnecting grid"
+          },
+          {
+            "name": "GRID_CONNECTED",
+            "value": 2080,
+            "label": "grid connected"
+          },
+          {
+            "name": "ISLANDED",
+            "value": 2096,
+            "label": "islanded"
+          },
+          {
+            "name": "CONNECTING_GENERATOR",
+            "value": 2112,
+            "label": "connecting generator"
+          },
+          {
+            "name": "GENERATOR_PARALLEL",
+            "value": 2128,
+            "label": "generator parallel"
+          },
+          {
+            "name": "LOW_INPUT_VOLTAGE",
+            "value": 4096,
+            "label": "low input voltage"
+          },
+          {
+            "name": "TESTING_DEVICE_INPUT",
+            "value": 4112,
+            "label": "testing input..."
+          },
+          {
+            "name": "CONNECTING_INPUT",
+            "value": 4352,
+            "label": "connecting input"
+          },
+          {
+            "name": "DISCONNECTING_INPUT",
+            "value": 4368,
+            "label": "disconnecting input"
+          },
+          {
+            "name": "CALIBRATING",
+            "value": 4608,
+            "label": "calibrating"
+          },
+          {
+            "name": "CALIBRATION_SUCCESS",
+            "value": 4624,
+            "label": "calibration success!"
+          },
+          {
+            "name": "CALIBRATION_NEEDED",
+            "value": 4640,
+            "label": "calibration required"
+          },
+          {
+            "name": "BURN_IN",
+            "value": 4656,
+            "label": "burning in"
+          },
+          {
+            "name": "BURN_IN_DONE",
+            "value": 4672,
+            "label": "burn in done"
+          },
+          {
+            "name": "SCHEDULER_OVERRIDDEN",
+            "value": 4864,
+            "label": "running, overridden"
+          },
+          {
+            "name": "SCHEDULER_DISABLED",
+            "value": 4880,
+            "label": "scheduler disabled"
+          },
+          {
+            "name": "RUNNING",
+            "value": 8192,
+            "label": "running"
+          },
+          {
+            "name": "MAKING_POWER",
+            "value": 8208,
+            "label": "making power"
+          },
+          {
+            "name": "LIMITING_POWER",
+            "value": 8224,
+            "label": "limiting power"
+          },
+          {
+            "name": "LOW_WIND",
+            "value": 12288,
+            "label": "low wind"
+          },
+          {
+            "name": "HIGH_WIND",
+            "value": 12304,
+            "label": "high wind"
+          },
+          {
+            "name": "LOW_SUN",
+            "value": 12544,
+            "label": "low sun"
+          },
+          {
+            "name": "CHARGING_BATTERY",
+            "value": 24576,
+            "label": "charging"
+          },
+          {
+            "name": "FLOAT_CHARGING_BATTERY",
+            "value": 24592,
+            "label": "float charging"
+          },
+          {
+            "name": "BULK_CHARGING_BATTERY",
+            "value": 24608,
+            "label": "bulk charging"
+          },
+          {
+            "name": "ABSORPTION_CHARGING_BATTERY",
+            "value": 24624,
+            "label": "absorption charging"
+          },
+          {
+            "name": "EQUALIZE_CHARGING_BATTERY",
+            "value": 24640,
+            "label": "equalizing"
+          },
+          {
+            "name": "DISCHARGING_BATTERY",
+            "value": 24832,
+            "label": "discharging"
+          },
+          {
+            "name": "LOW_BATTERY_VOLTAGE",
+            "value": 24848,
+            "label": "low battery voltage"
+          },
+          {
+            "name": "ERROR_GENERIC",
+            "value": 28672,
+            "label": "error"
+          },
+          {
+            "name": "OVER_VOLTAGE_INPUT",
+            "value": 28688,
+            "label": "over voltage input"
+          },
+          {
+            "name": "OVER_VOLTAGE_OUTPUT",
+            "value": 28704,
+            "label": "over voltage output"
+          },
+          {
+            "name": "OVER_CURRENT_INPUT",
+            "value": 28720,
+            "label": "over current input"
+          },
+          {
+            "name": "OVER_CURRENT_OUTPUT",
+            "value": 28736,
+            "label": "over current output"
+          },
+          {
+            "name": "ERROR_LOW_BATTERY_VOLTAGE",
+            "value": 28752,
+            "label": "error: low batt volts"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 28928,
+            "label": "over temperature"
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 29184,
+            "label": "err: ground fault"
+          },
+          {
+            "name": "INSULATION_FAULT",
+            "value": 29200,
+            "label": "err: insulation fault"
+          },
+          {
+            "name": "CALIBRATION_0",
+            "value": 32256,
+            "label": "calibration mode"
+          },
+          {
+            "name": "CALIBRATION_1",
+            "value": 32272,
+            "label": "calibration 1"
+          },
+          {
+            "name": "CALIBRATION_2",
+            "value": 32288,
+            "label": "calibration 2"
+          },
+          {
+            "name": "CALIBRATION_3",
+            "value": 32304,
+            "label": "calibration 3"
+          }
+        ]
+      },
+      {
+        "name": "P",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "REbus Power",
+        "desc": "REbus power (positive means the device is sourcing power onto REbus, negative means the device is sinking power from REbus) "
+      },
+      {
+        "name": "E",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Accumulated Energy",
+        "desc": "Total accumulated energy (exact definition differs by device)"
+      },
+      {
+        "name": "Rb",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "REbus Bits",
+        "desc": "Status flags",
+        "symbols": [
+          {
+            "name": "ENABLE_MASTER",
+            "value": 0
+          },
+          {
+            "name": "ENABLE_SOURCE",
+            "value": 1
+          },
+          {
+            "name": "ENABLE_SINK",
+            "value": 2
+          },
+          {
+            "name": "RESERVED3",
+            "value": 3
+          },
+          {
+            "name": "BUS_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "BUS_DISCONNECTED",
+            "value": 5
+          },
+          {
+            "name": "SOURCING",
+            "value": 6
+          },
+          {
+            "name": "SINKING",
+            "value": 7
+          },
+          {
+            "name": "BUS_VOLTAGE_LOW",
+            "value": 8
+          },
+          {
+            "name": "BUS_VOLTAGE_HIGH",
+            "value": 9
+          },
+          {
+            "name": "BUS_IMBALANCE",
+            "value": 10
+          },
+          {
+            "name": "RESERVED11",
+            "value": 11
+          },
+          {
+            "name": "PLC_GOOD",
+            "value": 12
+          },
+          {
+            "name": "HEARTBEAT_GOOD",
+            "value": 13
+          },
+          {
+            "name": "ADAPTIVE_VREBUS_ACTIVE",
+            "value": 14
+          },
+          {
+            "name": "RESERVED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "V",
+        "type": "int16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "V",
+        "mandatory": "M",
+        "label": "REbus Voltage ",
+        "desc": "REbus voltage"
+      },
+      {
+        "name": "I",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_sf",
+        "units": "A",
+        "mandatory": "M",
+        "label": "REbus Current",
+        "desc": "REbus current"
+      },
+      {
+        "name": "T",
+        "type": "int16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Device Temperature",
+        "desc": "Device temperature"
+      },
+      {
+        "name": "O0",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 0",
+        "desc": "Otherdata 0"
+      },
+      {
+        "name": "O1",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 1",
+        "desc": "Otherdata 1"
+      },
+      {
+        "name": "O2",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 2",
+        "desc": "Otherdata 2"
+      },
+      {
+        "name": "O3",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 3",
+        "desc": "Otherdata 3"
+      },
+      {
+        "name": "O4",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 4",
+        "desc": "Otherdata 4"
+      },
+      {
+        "name": "O5",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 5",
+        "desc": "Otherdata 5"
+      },
+      {
+        "name": "O6",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 6",
+        "desc": "Otherdata 6"
+      },
+      {
+        "name": "O7",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 7",
+        "desc": "Otherdata 7"
+      },
+      {
+        "name": "O8",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 8",
+        "desc": "Otherdata 8"
+      },
+      {
+        "name": "O9",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 9",
+        "desc": "Otherdata 9"
+      },
+      {
+        "name": "OA",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata A",
+        "desc": "Otherdata 10"
+      },
+      {
+        "name": "OB",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata B",
+        "desc": "Otherdata 11"
+      },
+      {
+        "name": "OC",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata C",
+        "desc": "Otherdata 12"
+      },
+      {
+        "name": "OD",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata D",
+        "desc": "Otherdata 13"
+      },
+      {
+        "name": "OE",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata E",
+        "desc": "Otherdata 14"
+      },
+      {
+        "name": "OF",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata F",
+        "desc": "Otherdata 15"
+      },
+      {
+        "name": "OG",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata G",
+        "desc": "Otherdata 16"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64213
+}

--- a/models/model_64229.json
+++ b/models/model_64229.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "lvrt_pika",
+    "type": "group",
+    "label": "LVRTD",
+    "desc": "LVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64229
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64229
+}

--- a/models/model_64230.json
+++ b/models/model_64230.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "hvrt_pika",
+    "type": "group",
+    "label": "HVRTD",
+    "desc": "HVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64230
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HVRT control mode. Enable active curve. Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HVRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HVRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64230
+}

--- a/models/model_64235.json
+++ b/models/model_64235.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "lfrt_pika",
+    "type": "group",
+    "label": "LFRT",
+    "desc": "Low Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64235
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve. Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64235
+}

--- a/models/model_64236.json
+++ b/models/model_64236.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "hfrt_pika",
+    "type": "group",
+    "label": "HFRT",
+    "desc": "High Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64236
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HFRT control mode. Enable active curve. Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HFRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HFRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64236
+}

--- a/models/model_64250.json
+++ b/models/model_64250.json
@@ -1,0 +1,150 @@
+{
+  "group": {
+    "name": "owner_info",
+    "type": "group",
+    "label": "Device Registration",
+    "desc": "Owner and Installer information",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64250
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "FNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Owner's First Name",
+        "desc": "End user's first name"
+      },
+      {
+        "name": "LNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Owner's Last Name",
+        "desc": "End user's last name"
+      },
+      {
+        "name": "Em",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Owner's Email",
+        "desc": "End user's email address"
+      },
+      {
+        "name": "Adr1",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Address Line 1",
+        "desc": "Address Line 1"
+      },
+      {
+        "name": "Adr2",
+        "type": "string",
+        "size": 20,
+        "access": "RW",
+        "label": "Address Line 2",
+        "desc": "Address Line 2"
+      },
+      {
+        "name": "Cty",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "City",
+        "desc": "City"
+      },
+      {
+        "name": "St",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "State/Province",
+        "desc": "State/Province"
+      },
+      {
+        "name": "Zp",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Zip/Postal Code",
+        "desc": "Zip/Postal Code"
+      },
+      {
+        "name": "Cntr",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Country",
+        "desc": "Country"
+      },
+      {
+        "name": "Phn",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Phone",
+        "desc": "Customer's phone number"
+      },
+      {
+        "name": "IFNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's first name",
+        "desc": "Installer's first name"
+      },
+      {
+        "name": "ILNm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's last name",
+        "desc": "Installer's last name"
+      },
+      {
+        "name": "IEm",
+        "type": "string",
+        "size": 16,
+        "access": "RW",
+        "label": "Installer's email",
+        "desc": "Installer's email address"
+      },
+      {
+        "name": "ICo",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Installer Company",
+        "desc": "Installer Company"
+      },
+      {
+        "name": "IPhn",
+        "type": "string",
+        "size": 8,
+        "access": "RW",
+        "label": "Installer's phone",
+        "desc": "Installer's phone"
+      }
+    ]
+  },
+  "id": 64250
+}

--- a/models/model_64251.json
+++ b/models/model_64251.json
@@ -1,0 +1,390 @@
+{
+  "group": {
+    "name": "pvlink_status",
+    "type": "group",
+    "label": "Generac PV Link Status",
+    "desc": "Miscellaneous PV Link status registers",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64251
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ErrorWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Error status",
+        "desc": "Error status bitfield",
+        "symbols": [
+          {
+            "name": "UNUSED0",
+            "value": 0
+          },
+          {
+            "name": "HW_ARC_FAULT",
+            "value": 1
+          },
+          {
+            "name": "HW_REVERSE_CURRENT",
+            "value": 2
+          },
+          {
+            "name": "OVER_CURRENT",
+            "value": 3
+          },
+          {
+            "name": "INPUT_OVERVOLTAGE",
+            "value": 4
+          },
+          {
+            "name": "GFTEST_FAIL",
+            "value": 5
+          },
+          {
+            "name": "LOW_INPUT_IMPEDANCE",
+            "value": 6
+          },
+          {
+            "name": "UNUSED7",
+            "value": 7
+          },
+          {
+            "name": "UNUSED8",
+            "value": 8
+          },
+          {
+            "name": "FLASH_FAILURE",
+            "value": 9
+          },
+          {
+            "name": "EEPROM_FAILURE",
+            "value": 10
+          },
+          {
+            "name": "SPT_CRC_FAIL",
+            "value": 11
+          },
+          {
+            "name": "OVER_TEMP",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "DEAD_FET",
+            "value": 14
+          },
+          {
+            "name": "HWV_MISMATCH",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "EnableBits",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Enable bits",
+        "desc": "Internal status register",
+        "symbols": [
+          {
+            "name": "DEADMAN",
+            "value": 0
+          },
+          {
+            "name": "UNUSED1",
+            "value": 1
+          },
+          {
+            "name": "UNUSED2",
+            "value": 2
+          },
+          {
+            "name": "UNUSED3",
+            "value": 3
+          },
+          {
+            "name": "CONNECT_INPUT",
+            "value": 4
+          },
+          {
+            "name": "CONNECT_OUTPUT",
+            "value": 5
+          },
+          {
+            "name": "UNUSED6",
+            "value": 6
+          },
+          {
+            "name": "UNUSED7",
+            "value": 7
+          },
+          {
+            "name": "UNUSED8",
+            "value": 8
+          },
+          {
+            "name": "GF_STARTTEST",
+            "value": 9
+          },
+          {
+            "name": "INPUT_IMPED_STARTTEST",
+            "value": 11
+          },
+          {
+            "name": "UNUSED11",
+            "value": 11
+          },
+          {
+            "name": "PHASE2",
+            "value": 12
+          },
+          {
+            "name": "UNUSED13",
+            "value": 13
+          },
+          {
+            "name": "UNUSED14",
+            "value": 14
+          },
+          {
+            "name": "UNUSED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "StatusWord",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "General status",
+        "desc": "General system status",
+        "symbols": [
+          {
+            "name": "DEADMAN_UP",
+            "value": 0
+          },
+          {
+            "name": "LOW_SUPPLY_VOLTAGE",
+            "value": 1
+          },
+          {
+            "name": "GF_TESTED",
+            "value": 2
+          },
+          {
+            "name": "INPUT_IMPED_TESTED",
+            "value": 3
+          },
+          {
+            "name": "INPUT_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "OUTPUT_CONNECTED",
+            "value": 5
+          },
+          {
+            "name": "INPUT_DISCONNETED",
+            "value": 6
+          },
+          {
+            "name": "OUTPUT_DISCONNETED",
+            "value": 7
+          },
+          {
+            "name": "GF_SW_ACTIVE",
+            "value": 8
+          },
+          {
+            "name": "MASTER_FAULT_ACTIVE",
+            "value": 9
+          },
+          {
+            "name": "GF_ACTIVE",
+            "value": 10
+          },
+          {
+            "name": "ARC_FAULT_ACTIVE",
+            "value": 11
+          },
+          {
+            "name": "PBUS_LOW",
+            "value": 12
+          },
+          {
+            "name": "UNBAL_INPUT_FAULT_ACTIVE",
+            "value": 13
+          },
+          {
+            "name": "PH2_ON",
+            "value": 14
+          },
+          {
+            "name": "PH2_OFF",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "I_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Vin",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "mandatory": "M",
+        "label": "PV String Voltage",
+        "desc": "Input voltage of PV string"
+      },
+      {
+        "name": "Iin",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_SF",
+        "mandatory": "M",
+        "label": "PV String Current",
+        "desc": "Input current of PV string"
+      },
+      {
+        "name": "AMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_SF",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Maximum Input Current",
+        "desc": "Maximum permitted input current from PV string"
+      },
+      {
+        "name": "Ena",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable or Disable PV Link",
+        "symbols": [
+          {
+            "name": "DISABLE",
+            "value": 0
+          },
+          {
+            "name": "ENABLE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Large pad for future model expansion"
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad9",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad10",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad11",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad12",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64251
+}

--- a/models/model_64252.json
+++ b/models/model_64252.json
@@ -1,0 +1,280 @@
+{
+  "group": {
+    "name": "DCB105_warranty",
+    "type": "group",
+    "label": "Panasonic DCB105 Module Warranty Data",
+    "desc": "Data from DCB105 modules required for Panasonic warranty",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64252
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "sf_10",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "sf_100",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "sf_1000",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "NMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Count",
+        "desc": "Number of DCB modules that the system is configured for"
+      },
+      {
+        "name": "WhIn",
+        "type": "int32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WhIn",
+        "desc": "Cummulative energy into battery string"
+      },
+      {
+        "name": "WhOut",
+        "type": "int32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "WhOut",
+        "desc": "Cummulative energy out of battery string"
+      },
+      {
+        "name": "AhIn",
+        "type": "int32",
+        "size": 2,
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "AhIn",
+        "desc": "Cummulative charge into battery string"
+      },
+      {
+        "name": "AhOut",
+        "type": "int32",
+        "size": 2,
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "AhOut",
+        "desc": "Cummulative charge out of battery string"
+      },
+      {
+        "name": "THSin",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_10",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Heat Sink Temp",
+        "desc": "Temperature of heat sink input"
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Power",
+        "desc": "Battery power right now"
+      },
+      {
+        "name": "I",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_100",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Current",
+        "desc": "Instantaneous current measurement"
+      },
+      {
+        "name": "V",
+        "type": "int16",
+        "size": 1,
+        "sf": "sf_10",
+        "units": "V",
+        "mandatory": "M",
+        "label": "String Voltage",
+        "desc": "Voltage of whole string of batteries"
+      }
+    ],
+    "groups": [
+      {
+        "name": "DCB105_module",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "SN",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Serial Number",
+            "desc": "Serial Number"
+          },
+          {
+            "name": "ManDt",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Product Date Code",
+            "desc": "Manufacture date"
+          },
+          {
+            "name": "ProgVer",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Program Version",
+            "desc": "Program version"
+          },
+          {
+            "name": "DataVer",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Data Version",
+            "desc": "Data version"
+          },
+          {
+            "name": "StatusFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Status Flags",
+            "desc": "Status"
+          },
+          {
+            "name": "WarningFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Warning Flags",
+            "desc": "Warnings"
+          },
+          {
+            "name": "AlarmFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Alarm Flags",
+            "desc": "Alarms"
+          },
+          {
+            "name": "ErrorFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Error Flags",
+            "desc": "Errors"
+          },
+          {
+            "name": "ModuleIOFlags",
+            "type": "bitfield16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Module IO Flags",
+            "desc": "IO flags"
+          },
+          {
+            "name": "SOC",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_10",
+            "mandatory": "M",
+            "label": "State of Charge",
+            "desc": "State of Charge"
+          },
+          {
+            "name": "SOH",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_10",
+            "mandatory": "M",
+            "label": "State of Health",
+            "desc": "State of Health"
+          },
+          {
+            "name": "MaxCellV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_1000",
+            "units": "V",
+            "mandatory": "M",
+            "label": "MaxCellV",
+            "desc": "Maximum cell voltage"
+          },
+          {
+            "name": "MinCellV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_1000",
+            "units": "V",
+            "mandatory": "M",
+            "label": "MinCellV",
+            "desc": "Minimum cell voltage"
+          },
+          {
+            "name": "PackV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "sf_100",
+            "units": "V",
+            "mandatory": "M",
+            "label": "PackV",
+            "desc": "Module voltage"
+          },
+          {
+            "name": "MaxCellT",
+            "type": "int16",
+            "size": 1,
+            "sf": "sf_10",
+            "units": "C",
+            "mandatory": "M",
+            "label": "MaxCellT",
+            "desc": "Maximum cell temperature"
+          },
+          {
+            "name": "MinCellT",
+            "type": "int16",
+            "size": 1,
+            "sf": "sf_10",
+            "units": "C",
+            "mandatory": "M",
+            "label": "MinCellT",
+            "desc": "Minimum cell temperature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64252
+}

--- a/models/model_64253.json
+++ b/models/model_64253.json
@@ -1,0 +1,590 @@
+{
+  "group": {
+    "name": "legacy_status",
+    "type": "group",
+    "label": "RCP Legacy Status Update",
+    "desc": "Status update data",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64253
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "VT_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "VT_sf",
+        "desc": "Scale factor for V and T"
+      },
+      {
+        "name": "I_sf",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "I_sf",
+        "desc": "Scale factor for I"
+      },
+      {
+        "name": "St",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "State",
+        "desc": "RCP state code",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "device offline"
+          },
+          {
+            "name": "DISABLED",
+            "value": 16,
+            "label": "disabled"
+          },
+          {
+            "name": "INITIALIZING",
+            "value": 256,
+            "label": "initializing"
+          },
+          {
+            "name": "POWERING_UP",
+            "value": 272,
+            "label": "powering up"
+          },
+          {
+            "name": "CONNECTING_BUS",
+            "value": 288,
+            "label": "connecting to REbus"
+          },
+          {
+            "name": "DISCONNECTING_BUS",
+            "value": 304,
+            "label": "disconnecting REbus"
+          },
+          {
+            "name": "TESTING_BUS",
+            "value": 320,
+            "label": "testing REbus..."
+          },
+          {
+            "name": "LOW_BUS_VOLTAGE",
+            "value": 512,
+            "label": "low REbus voltage"
+          },
+          {
+            "name": "STANDBY",
+            "value": 768,
+            "label": "standby"
+          },
+          {
+            "name": "WAITING",
+            "value": 784,
+            "label": "waiting"
+          },
+          {
+            "name": "WAITING_NO_INPUT",
+            "value": 800,
+            "label": "waiting - no input"
+          },
+          {
+            "name": "CONNECTING_GRID",
+            "value": 2048,
+            "label": "connecting grid"
+          },
+          {
+            "name": "DISCONNECTING_GRID",
+            "value": 2064,
+            "label": "disconnecting grid"
+          },
+          {
+            "name": "GRID_CONNECTED",
+            "value": 2080,
+            "label": "grid connected"
+          },
+          {
+            "name": "ISLANDED",
+            "value": 2096,
+            "label": "islanded"
+          },
+          {
+            "name": "CONNECTING_GENERATOR",
+            "value": 2112,
+            "label": "connecting generator"
+          },
+          {
+            "name": "GENERATOR_PARALLEL",
+            "value": 2128,
+            "label": "generator parallel"
+          },
+          {
+            "name": "LOW_INPUT_VOLTAGE",
+            "value": 4096,
+            "label": "low input voltage"
+          },
+          {
+            "name": "TESTING_DEVICE_INPUT",
+            "value": 4112,
+            "label": "testing input..."
+          },
+          {
+            "name": "CONNECTING_INPUT",
+            "value": 4352,
+            "label": "connecting input"
+          },
+          {
+            "name": "DISCONNECTING_INPUT",
+            "value": 4368,
+            "label": "disconnecting input"
+          },
+          {
+            "name": "CALIBRATING",
+            "value": 4608,
+            "label": "calibrating"
+          },
+          {
+            "name": "CALIBRATION_SUCCESS",
+            "value": 4624,
+            "label": "calibration success!"
+          },
+          {
+            "name": "CALIBRATION_NEEDED",
+            "value": 4640,
+            "label": "calibration required"
+          },
+          {
+            "name": "BURN_IN",
+            "value": 4656,
+            "label": "burning in"
+          },
+          {
+            "name": "BURN_IN_DONE",
+            "value": 4672,
+            "label": "burn in done"
+          },
+          {
+            "name": "SCHEDULER_OVERRIDDEN",
+            "value": 4864,
+            "label": "running, overridden"
+          },
+          {
+            "name": "SCHEDULER_DISABLED",
+            "value": 4880,
+            "label": "scheduler disabled"
+          },
+          {
+            "name": "RUNNING",
+            "value": 8192,
+            "label": "running"
+          },
+          {
+            "name": "MAKING_POWER",
+            "value": 8208,
+            "label": "making power"
+          },
+          {
+            "name": "LIMITING_POWER",
+            "value": 8224,
+            "label": "limiting power"
+          },
+          {
+            "name": "LOW_WIND",
+            "value": 12288,
+            "label": "low wind"
+          },
+          {
+            "name": "HIGH_WIND",
+            "value": 12304,
+            "label": "high wind"
+          },
+          {
+            "name": "LOW_SUN",
+            "value": 12544,
+            "label": "low sun"
+          },
+          {
+            "name": "CHARGING_BATTERY",
+            "value": 24576,
+            "label": "charging"
+          },
+          {
+            "name": "FLOAT_CHARGING_BATTERY",
+            "value": 24592,
+            "label": "float charging"
+          },
+          {
+            "name": "BULK_CHARGING_BATTERY",
+            "value": 24608,
+            "label": "bulk charging"
+          },
+          {
+            "name": "ABSORPTION_CHARGING_BATTERY",
+            "value": 24624,
+            "label": "absorption charging"
+          },
+          {
+            "name": "EQUALIZE_CHARGING_BATTERY",
+            "value": 24640,
+            "label": "equalizing"
+          },
+          {
+            "name": "DISCHARGING_BATTERY",
+            "value": 24832,
+            "label": "discharging"
+          },
+          {
+            "name": "LOW_BATTERY_VOLTAGE",
+            "value": 24848,
+            "label": "low battery voltage"
+          },
+          {
+            "name": "ERROR_GENERIC",
+            "value": 28672,
+            "label": "error"
+          },
+          {
+            "name": "OVER_VOLTAGE_INPUT",
+            "value": 28688,
+            "label": "over voltage input"
+          },
+          {
+            "name": "OVER_VOLTAGE_OUTPUT",
+            "value": 28704,
+            "label": "over voltage output"
+          },
+          {
+            "name": "OVER_CURRENT_INPUT",
+            "value": 28720,
+            "label": "over current input"
+          },
+          {
+            "name": "OVER_CURRENT_OUTPUT",
+            "value": 28736,
+            "label": "over current output"
+          },
+          {
+            "name": "ERROR_LOW_BATTERY_VOLTAGE",
+            "value": 28752,
+            "label": "error: low batt volts"
+          },
+          {
+            "name": "OVER_TEMPERATURE",
+            "value": 28928,
+            "label": "over temperature"
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 29184,
+            "label": "err: ground fault"
+          },
+          {
+            "name": "INSULATION_FAULT",
+            "value": 29200,
+            "label": "err: insulation fault"
+          },
+          {
+            "name": "CALIBRATION_0",
+            "value": 32256,
+            "label": "calibration mode"
+          },
+          {
+            "name": "CALIBRATION_1",
+            "value": 32272,
+            "label": "calibration 1"
+          },
+          {
+            "name": "CALIBRATION_2",
+            "value": 32288,
+            "label": "calibration 2"
+          },
+          {
+            "name": "CALIBRATION_3",
+            "value": 32304,
+            "label": "calibration 3"
+          }
+        ]
+      },
+      {
+        "name": "P",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "REbus Power",
+        "desc": "REbus power (positive means the device is sourcing power onto REbus, negative means the device is sinking power from REbus) "
+      },
+      {
+        "name": "E",
+        "type": "uint32",
+        "size": 2,
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Accumulated Energy",
+        "desc": "Total accumulated energy (exact definition differs by device)"
+      },
+      {
+        "name": "Rb",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "REbus Bits",
+        "desc": "Status flags",
+        "symbols": [
+          {
+            "name": "ENABLE_MASTER",
+            "value": 0
+          },
+          {
+            "name": "ENABLE_SOURCE",
+            "value": 1
+          },
+          {
+            "name": "ENABLE_SINK",
+            "value": 2
+          },
+          {
+            "name": "RESERVED3",
+            "value": 3
+          },
+          {
+            "name": "BUS_CONNECTED",
+            "value": 4
+          },
+          {
+            "name": "BUS_DISCONNECTED",
+            "value": 5
+          },
+          {
+            "name": "SOURCING",
+            "value": 6
+          },
+          {
+            "name": "SINKING",
+            "value": 7
+          },
+          {
+            "name": "BUS_VOLTAGE_LOW",
+            "value": 8
+          },
+          {
+            "name": "BUS_VOLTAGE_HIGH",
+            "value": 9
+          },
+          {
+            "name": "BUS_IMBALANCE",
+            "value": 10
+          },
+          {
+            "name": "RESERVED11",
+            "value": 11
+          },
+          {
+            "name": "PLC_GOOD",
+            "value": 12
+          },
+          {
+            "name": "HEARTBEAT_GOOD",
+            "value": 13
+          },
+          {
+            "name": "ADAPTIVE_VREBUS_ACTIVE",
+            "value": 14
+          },
+          {
+            "name": "RESERVED15",
+            "value": 15
+          }
+        ]
+      },
+      {
+        "name": "V",
+        "type": "int16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "V",
+        "mandatory": "M",
+        "label": "REbus Voltage ",
+        "desc": "REbus voltage"
+      },
+      {
+        "name": "I",
+        "type": "int16",
+        "size": 1,
+        "sf": "I_sf",
+        "units": "A",
+        "mandatory": "M",
+        "label": "REbus Current",
+        "desc": "REbus current"
+      },
+      {
+        "name": "T",
+        "type": "int16",
+        "size": 1,
+        "sf": "VT_sf",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Device Temperature",
+        "desc": "Device temperature"
+      },
+      {
+        "name": "O0",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 0",
+        "desc": "Otherdata 0"
+      },
+      {
+        "name": "O1",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 1",
+        "desc": "Otherdata 1"
+      },
+      {
+        "name": "O2",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 2",
+        "desc": "Otherdata 2"
+      },
+      {
+        "name": "O3",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 3",
+        "desc": "Otherdata 3"
+      },
+      {
+        "name": "O4",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 4",
+        "desc": "Otherdata 4"
+      },
+      {
+        "name": "O5",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 5",
+        "desc": "Otherdata 5"
+      },
+      {
+        "name": "O6",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 6",
+        "desc": "Otherdata 6"
+      },
+      {
+        "name": "O7",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 7",
+        "desc": "Otherdata 7"
+      },
+      {
+        "name": "O8",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 8",
+        "desc": "Otherdata 8"
+      },
+      {
+        "name": "O9",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata 9",
+        "desc": "Otherdata 9"
+      },
+      {
+        "name": "OA",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata A",
+        "desc": "Otherdata 10"
+      },
+      {
+        "name": "OB",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata B",
+        "desc": "Otherdata 11"
+      },
+      {
+        "name": "OC",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata C",
+        "desc": "Otherdata 12"
+      },
+      {
+        "name": "OD",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata D",
+        "desc": "Otherdata 13"
+      },
+      {
+        "name": "OE",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata E",
+        "desc": "Otherdata 14"
+      },
+      {
+        "name": "OF",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata F",
+        "desc": "Otherdata 15"
+      },
+      {
+        "name": "OG",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Otherdata G",
+        "desc": "Otherdata 16"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64253
+}

--- a/models/model_64254.json
+++ b/models/model_64254.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "lvrt_pika",
+    "type": "group",
+    "label": "LVRTD",
+    "desc": "LVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64254
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0=no active curve."
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LVRT control mode. Enable active curve. Bitfield value.",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LVRT change."
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LVRT curve selection."
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode."
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)."
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximumn of 20)."
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef."
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array."
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration."
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage."
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration."
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage."
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration."
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage."
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration."
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage."
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration."
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage."
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration."
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage."
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration."
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage."
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration."
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage."
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration."
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage."
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration."
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage."
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration."
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage."
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration."
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage."
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration."
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage."
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration."
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage."
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration."
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage."
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration."
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage."
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration."
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage."
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration."
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage."
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration."
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage."
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration."
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage."
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior.",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve."
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64254
+}

--- a/models/model_64255.json
+++ b/models/model_64255.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "hvrt_pika",
+    "type": "group",
+    "label": "HVRTD",
+    "desc": "HVRT Must Disconnect",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64255
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HVRT control mode. Enable active curve. Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HVRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HVRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximumn of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "V_SF",
+        "desc": "Scale factor for percent VRef"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "V1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "V1",
+            "desc": "Point 1 must disconnect voltage"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "V2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V2",
+            "desc": "Point 2 must disconnect voltage"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "V3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V3",
+            "desc": "Point 3 must disconnect voltage"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "V4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V4",
+            "desc": "Point 4 must disconnect voltage"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "V5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V5",
+            "desc": "Point 5 must disconnect voltage"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "V6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V6",
+            "desc": "Point 6 must disconnect voltage"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "V7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V7",
+            "desc": "Point 7 must disconnect voltage"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "V8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V8",
+            "desc": "Point 8 must disconnect voltage"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "V9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V9",
+            "desc": "Point 9 must disconnect voltage"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "V10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V10",
+            "desc": "Point 10 must disconnect voltage"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "V11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V11",
+            "desc": "Point 11 must disconnect voltage"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "V12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V12",
+            "desc": "Point 12 must disconnect voltage"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "V13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V13",
+            "desc": "Point 13 must disconnect voltage"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "V14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V14",
+            "desc": "Point 14 must disconnect voltage"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "V15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V15",
+            "desc": "Point 15 must disconnect voltage"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "V16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V16",
+            "desc": "Point 16 must disconnect voltage"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "V17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V17",
+            "desc": "Point 17 must disconnect voltage"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "V18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V18",
+            "desc": "Point 18 must disconnect voltage"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "V19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V19",
+            "desc": "Point 19 must disconnect voltage"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "V20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "V_SF",
+            "units": "%VRef",
+            "access": "RW",
+            "label": "V20",
+            "desc": "Point 20 must disconnect voltage"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64255
+}

--- a/models/model_64256.json
+++ b/models/model_64256.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "lfrt_pika",
+    "type": "group",
+    "label": "LFRT",
+    "desc": "Low Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64256
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "LHzRT control mode. Enable active curve.  Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for LFRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for LFRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximum of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64256
+}

--- a/models/model_64257.json
+++ b/models/model_64257.json
@@ -1,0 +1,925 @@
+{
+  "group": {
+    "name": "hfrt_pika",
+    "type": "group",
+    "label": "HFRT",
+    "desc": "High Frequency Ride-through",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64257
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ActCrv",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ActCrv",
+        "desc": "Index of active curve. 0 = no active curve"
+      },
+      {
+        "name": "ModEna",
+        "type": "bitfield16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "ModEna",
+        "desc": "HFRT control mode. Enable active curve. Bitfield value",
+        "symbols": [
+          {
+            "name": "ENABLED",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "WinTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "WinTms",
+        "desc": "Time window for HFRT change"
+      },
+      {
+        "name": "RvrtTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RvrtTms",
+        "desc": "Timeout period for HFRT curve selection"
+      },
+      {
+        "name": "RmpTms",
+        "type": "uint16",
+        "size": 1,
+        "units": "Secs",
+        "access": "RW",
+        "label": "RmpTms",
+        "desc": "Ramp time for moving from current mode to new mode"
+      },
+      {
+        "name": "NCrv",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NCrv",
+        "desc": "Number of curves supported (recommend 4)"
+      },
+      {
+        "name": "NPt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "NPt",
+        "desc": "Number of curve points supported (maximumn of 20)"
+      },
+      {
+        "name": "Tms_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Tms_SF",
+        "desc": "Scale factor for duration"
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Hz_SF",
+        "desc": "Scale factor for frequency"
+      },
+      {
+        "name": "Pad",
+        "type": "pad",
+        "size": 1
+      }
+    ],
+    "groups": [
+      {
+        "name": "curve",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ActPt",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "ActPt",
+            "desc": "Number of active points in array"
+          },
+          {
+            "name": "Tms1",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Tms1",
+            "desc": "Point 1 must disconnect duration"
+          },
+          {
+            "name": "Hz1",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Hz1",
+            "desc": "Point 1 must disconnect frequency"
+          },
+          {
+            "name": "Fn1",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "Fn1",
+            "desc": "Point 1 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms2",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms2",
+            "desc": "Point 2 must disconnect duration"
+          },
+          {
+            "name": "Hz2",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz2",
+            "desc": "Point 2 must disconnect frequency"
+          },
+          {
+            "name": "Fn2",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn2",
+            "desc": "Point 2 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms3",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms3",
+            "desc": "Point 3 must disconnect duration"
+          },
+          {
+            "name": "Hz3",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz3",
+            "desc": "Point 3 must disconnect frequency"
+          },
+          {
+            "name": "Fn3",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn3",
+            "desc": "Point 3 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms4",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms4",
+            "desc": "Point 4 must disconnect duration"
+          },
+          {
+            "name": "Hz4",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz4",
+            "desc": "Point 4 must disconnect frequency"
+          },
+          {
+            "name": "Fn4",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn4",
+            "desc": "Point 4 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms5",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms5",
+            "desc": "Point 5 must disconnect duration"
+          },
+          {
+            "name": "Hz5",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz5",
+            "desc": "Point 5 must disconnect frequency"
+          },
+          {
+            "name": "Fn5",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn5",
+            "desc": "Point 5 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms6",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms6",
+            "desc": "Point 6 must disconnect duration"
+          },
+          {
+            "name": "Hz6",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz6",
+            "desc": "Point 6 must disconnect frequency"
+          },
+          {
+            "name": "Fn6",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn6",
+            "desc": "Point 6 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms7",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms7",
+            "desc": "Point 7 must disconnect duration"
+          },
+          {
+            "name": "Hz7",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz7",
+            "desc": "Point 7 must disconnect frequency"
+          },
+          {
+            "name": "Fn7",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn7",
+            "desc": "Point 7 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms8",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms8",
+            "desc": "Point 8 must disconnect duration"
+          },
+          {
+            "name": "Hz8",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz8",
+            "desc": "Point 8 must disconnect frequency"
+          },
+          {
+            "name": "Fn8",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn8",
+            "desc": "Point 8 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms9",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms9",
+            "desc": "Point 9 must disconnect duration"
+          },
+          {
+            "name": "Hz9",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz9",
+            "desc": "Point 9 must disconnect frequency"
+          },
+          {
+            "name": "Fn9",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn9",
+            "desc": "Point 9 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms10",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms10",
+            "desc": "Point 10 must disconnect duration"
+          },
+          {
+            "name": "Hz10",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz10",
+            "desc": "Point 10 must disconnect frequency"
+          },
+          {
+            "name": "Fn10",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn10",
+            "desc": "Point 10 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms11",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms11",
+            "desc": "Point 11 must disconnect duration"
+          },
+          {
+            "name": "Hz11",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz11",
+            "desc": "Point 11 must disconnect frequency"
+          },
+          {
+            "name": "Fn11",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn11",
+            "desc": "Point 11 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms12",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms12",
+            "desc": "Point 12 must disconnect duration"
+          },
+          {
+            "name": "Hz12",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz12",
+            "desc": "Point 12 must disconnect frequency"
+          },
+          {
+            "name": "Fn12",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn12",
+            "desc": "Point 12 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms13",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms13",
+            "desc": "Point 13 must disconnect duration"
+          },
+          {
+            "name": "Hz13",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz13",
+            "desc": "Point 13 must disconnect frequency"
+          },
+          {
+            "name": "Fn13",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn13",
+            "desc": "Point 13 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms14",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms14",
+            "desc": "Point 14 must disconnect duration"
+          },
+          {
+            "name": "Hz14",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz14",
+            "desc": "Point 14 must disconnect frequency"
+          },
+          {
+            "name": "Fn14",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn14",
+            "desc": "Point 14 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms15",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms15",
+            "desc": "Point 15 must disconnect duration"
+          },
+          {
+            "name": "Hz15",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz15",
+            "desc": "Point 15 must disconnect frequency"
+          },
+          {
+            "name": "Fn15",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn15",
+            "desc": "Point 15 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms16",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms16",
+            "desc": "Point 16 must disconnect duration"
+          },
+          {
+            "name": "Hz16",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz16",
+            "desc": "Point 16 must disconnect frequency"
+          },
+          {
+            "name": "Fn16",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn16",
+            "desc": "Point 16 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms17",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms17",
+            "desc": "Point 17 must disconnect duration"
+          },
+          {
+            "name": "Hz17",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz17",
+            "desc": "Point 17 must disconnect frequency"
+          },
+          {
+            "name": "Fn17",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn17",
+            "desc": "Point 17 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms18",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms18",
+            "desc": "Point 18 must disconnect duration"
+          },
+          {
+            "name": "Hz18",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz18",
+            "desc": "Point 18 must disconnect frequency"
+          },
+          {
+            "name": "Fn18",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn18",
+            "desc": "Point 18 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms19",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms19",
+            "desc": "Point 19 must disconnect duration"
+          },
+          {
+            "name": "Hz19",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz19",
+            "desc": "Point 19 must disconnect frequency"
+          },
+          {
+            "name": "Fn19",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn19",
+            "desc": "Point 19 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "Tms20",
+            "type": "uint32",
+            "size": 2,
+            "sf": "Tms_SF",
+            "units": "Secs",
+            "access": "RW",
+            "label": "Tms20",
+            "desc": "Point 20 must disconnect duration"
+          },
+          {
+            "name": "Hz20",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Hz_SF",
+            "units": "Hz",
+            "access": "RW",
+            "label": "Hz20",
+            "desc": "Point 20 must disconnect frequency"
+          },
+          {
+            "name": "Fn20",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Fn20",
+            "desc": "Point 20 special behavior",
+            "symbols": [
+              {
+                "name": "MANDATORY_OPERATION",
+                "value": 0
+              },
+              {
+                "name": "CEASE_TO_ENERGIZE",
+                "value": 1
+              }
+            ]
+          },
+          {
+            "name": "CrvNam",
+            "type": "string",
+            "size": 8,
+            "access": "RW",
+            "label": "CrvNam",
+            "desc": "Optional description for curve"
+          },
+          {
+            "name": "ReadOnly",
+            "type": "enum16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "ReadOnly",
+            "desc": "Enumerated value indicates if curve is read-only or can be modified",
+            "symbols": [
+              {
+                "name": "READWRITE",
+                "value": 0
+              },
+              {
+                "name": "READONLY",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64257
+}

--- a/models/model_64258.json
+++ b/models/model_64258.json
@@ -1,0 +1,851 @@
+{
+  "group": {
+    "name": "flash_reader",
+    "type": "group",
+    "label": "Flash memory reader",
+    "desc": "Read contents of Flash",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64258
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "addr",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "cmd",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "IDLE",
+            "value": 0
+          },
+          {
+            "name": "READ",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "err",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "symbols": [
+          {
+            "name": "NO_ERROR",
+            "value": 0
+          },
+          {
+            "name": "BAD_ADDRESS",
+            "value": 1
+          },
+          {
+            "name": "FLASH_FAULT",
+            "value": 2
+          }
+        ]
+      }
+    ],
+    "groups": [
+      {
+        "name": "sector",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "w0",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w1",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w2",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w3",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w4",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w5",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w6",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w7",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w8",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w9",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w10",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w11",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w12",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w13",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w14",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w15",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w16",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w17",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w18",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w19",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w20",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w21",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w22",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w23",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w24",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w25",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w26",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w27",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w28",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w29",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w30",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w31",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w32",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w33",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w34",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w35",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w36",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w37",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w38",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w39",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w40",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w41",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w42",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w43",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w44",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w45",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w46",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w47",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w48",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w49",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w50",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w51",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w52",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w53",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w54",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w55",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w56",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w57",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w58",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w59",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w60",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w61",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w62",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w63",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w64",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w65",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w66",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w67",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w68",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w69",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w70",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w71",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w72",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w73",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w74",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w75",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w76",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w77",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w78",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w79",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w80",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w81",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w82",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w83",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w84",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w85",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w86",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w87",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w88",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w89",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w90",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w91",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w92",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w93",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w94",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w95",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w96",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w97",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w98",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w99",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w100",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w101",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w102",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w103",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w104",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w105",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w106",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w107",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w108",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w109",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w110",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w111",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w112",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w113",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w114",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w115",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w116",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w117",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w118",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w119",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w120",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w121",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w122",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w123",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w124",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w125",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w126",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          },
+          {
+            "name": "w127",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 64258
+}

--- a/models/model_64259.json
+++ b/models/model_64259.json
@@ -1,0 +1,470 @@
+{
+  "group": {
+    "name": "site_energy",
+    "type": "group",
+    "label": "Site Energy Metrics",
+    "desc": "Lifetime accumulated site-wide energy metrics",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64259
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "time",
+        "type": "uint32",
+        "size": 2,
+        "units": "Unix seconds",
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Unix epoch time when update was created"
+      },
+      {
+        "name": "sysmode",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sysmode",
+        "desc": "System operating mode",
+        "symbols": [
+          {
+            "name": "SAFETY_SHUTDOWN",
+            "value": 0
+          },
+          {
+            "name": "GRID_TIE",
+            "value": 1
+          },
+          {
+            "name": "SELF_SUPPLY",
+            "value": 2
+          },
+          {
+            "name": "CLEAN_BACKUP",
+            "value": 3
+          },
+          {
+            "name": "PRIORITY_BACKUP",
+            "value": 4
+          },
+          {
+            "name": "REMOTE_ARBITRAGE",
+            "value": 5
+          },
+          {
+            "name": "SELL",
+            "value": 6
+          }
+        ]
+      },
+      {
+        "name": "alarms",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Alarms",
+        "desc": "Bitfield of device types reporting errors",
+        "symbols": [
+          {
+            "name": "UNKNOWN_ERROR",
+            "value": 0
+          },
+          {
+            "name": "PVLINK_ERROR",
+            "value": 1
+          },
+          {
+            "name": "INVERTER_ERROR",
+            "value": 2
+          },
+          {
+            "name": "BATTERY_ERROR",
+            "value": 3
+          },
+          {
+            "name": "DC_GENERATOR_ERROR",
+            "value": 4
+          }
+        ]
+      },
+      {
+        "name": "bat_soc",
+        "type": "uint16",
+        "size": 1,
+        "sf": "sf_10",
+        "units": "%SoC",
+        "mandatory": "M",
+        "label": "Battery SoC",
+        "desc": "Weighted average state of charge of all connected batteries"
+      },
+      {
+        "name": "sf_10",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "inv_state",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Inverter State",
+        "desc": "State of the inverter",
+        "symbols": [
+          {
+            "name": "UNKNOWN",
+            "value": 0,
+            "label": "unknown"
+          },
+          {
+            "name": "DISABLED",
+            "value": 16,
+            "label": "disabled"
+          },
+          {
+            "name": "INITIALIZING",
+            "value": 256,
+            "label": "initializing"
+          },
+          {
+            "name": "POWERING_UP",
+            "value": 272,
+            "label": "powering up"
+          },
+          {
+            "name": "CONNECTING_BUS",
+            "value": 288,
+            "label": "connecting to REbus"
+          },
+          {
+            "name": "TESTING_BUS",
+            "value": 320,
+            "label": "testing REbus"
+          },
+          {
+            "name": "LOW_BUS_VOLTAGE",
+            "value": 512,
+            "label": "low REbus voltage"
+          },
+          {
+            "name": "WAITING",
+            "value": 784,
+            "label": "waiting"
+          },
+          {
+            "name": "CONNECTING_GRID",
+            "value": 2048,
+            "label": "connecting grid"
+          },
+          {
+            "name": "DISCONNECTING_GRID",
+            "value": 2064,
+            "label": "disconnecting grid"
+          },
+          {
+            "name": "GRID_CONNECTED",
+            "value": 2080,
+            "label": "grid connected"
+          },
+          {
+            "name": "ISLANDED",
+            "value": 2096,
+            "label": "islanded"
+          },
+          {
+            "name": "GENERATOR_PARALLEL",
+            "value": 2112,
+            "label": "generator parallel"
+          },
+          {
+            "name": "ERROR_GENERIC",
+            "value": 28672,
+            "label": "error"
+          },
+          {
+            "name": "ERROR_REBUS_FAULT",
+            "value": 29968,
+            "label": "error: REbus fault"
+          },
+          {
+            "name": "ERROR_INTERNAL_BUS_FAULT",
+            "value": 29984,
+            "label": "internal bus fault"
+          },
+          {
+            "name": "CONFIGURATION_ERROR",
+            "value": 30464,
+            "label": "configuration error"
+          },
+          {
+            "name": "BAD_RESET_ERROR",
+            "value": 30480,
+            "label": "bad reset error"
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 49152,
+            "label": "ground fault"
+          }
+        ]
+      },
+      {
+        "name": "dcgenerator_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "DC Generator Power",
+        "desc": "Instantaneous DC generator power measurement"
+      },
+      {
+        "name": "generation",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Generation Energy",
+        "desc": "Total energy of connected solar generation devices"
+      },
+      {
+        "name": "consumption",
+        "type": "int64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Consumption Energy",
+        "desc": "Energy consumption of local AC loads"
+      },
+      {
+        "name": "bat_out",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Battery Discharge Energy",
+        "desc": "DC energy discharged from battery"
+      },
+      {
+        "name": "bat_in",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Battery Charge Energy",
+        "desc": "DC energy into battery (charging)"
+      },
+      {
+        "name": "net_out",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Net Exported Energy",
+        "desc": "Total AC energy exported from the site"
+      },
+      {
+        "name": "net_in",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Net Imported Energy",
+        "desc": "Total AC energy imported from the site"
+      },
+      {
+        "name": "inv_out",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Inverter Exported energy",
+        "desc": "AC energy exported to the DC bus through the inverter"
+      },
+      {
+        "name": "inv_in",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Inverter Imported Energy",
+        "desc": "AC energy imported to the DC bus through the inverter"
+      },
+      {
+        "name": "dcgenerator_out",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "DC Generator Exported Energy",
+        "desc": "DC energy exported from the DC generator"
+      },
+      {
+        "name": "dcgenerator_in",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "DC Generator Imported Energy",
+        "desc": "DC energy imported from the DC generator"
+      },
+      {
+        "name": "net_out_var",
+        "type": "uint64",
+        "size": 4,
+        "units": "VAR-seconds",
+        "mandatory": "M",
+        "label": "Net Reactive Energy Injected",
+        "desc": "Total reactive energy injected by site, VAR"
+      },
+      {
+        "name": "net_in_var",
+        "type": "uint64",
+        "size": 4,
+        "units": "VAR-seconds",
+        "mandatory": "M",
+        "label": "Net Reactive Energy Absorbed",
+        "desc": "Total reactive energy absorbed by site"
+      },
+      {
+        "name": "gen_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Generation Power",
+        "desc": "Instantaneous power measurement from solar generation sources"
+      },
+      {
+        "name": "inv_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Inverter Power",
+        "desc": "Instantaneous power measurement of inverter AC output"
+      },
+      {
+        "name": "net_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Net Power",
+        "desc": "Instantaneous AC power measurement from site"
+      },
+      {
+        "name": "bat_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Battery Power",
+        "desc": "Instantaneous battery power measurement"
+      },
+      {
+        "name": "max_sink_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Max Sink Power",
+        "desc": "Estimated maximum amount of power the site is capable of sinking at present"
+      },
+      {
+        "name": "max_source_power",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "mandatory": "M",
+        "label": "Max Source Power",
+        "desc": "Estimated maximum amount of power the site is capable of sourcing at present"
+      },
+      {
+        "name": "previous_time",
+        "type": "uint32",
+        "size": 2,
+        "units": "Unix seconds",
+        "mandatory": "M"
+      },
+      {
+        "name": "generation_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Generation Energy"
+      },
+      {
+        "name": "consumption_delta",
+        "type": "int64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Consumption Energy"
+      },
+      {
+        "name": "bat_out_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Battery Discharge Energy"
+      },
+      {
+        "name": "bat_in_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Battery Charge Energy"
+      },
+      {
+        "name": "net_out_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Net Exported Energy"
+      },
+      {
+        "name": "net_in_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Net Imported Energy"
+      },
+      {
+        "name": "inv_out_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Inverter Exported energy"
+      },
+      {
+        "name": "inv_in_delta",
+        "type": "uint64",
+        "size": 4,
+        "units": "Ws",
+        "mandatory": "M",
+        "label": "Delta Inverter Imported Energy"
+      }
+    ]
+  },
+  "id": 64259
+}

--- a/models/model_64260.json
+++ b/models/model_64260.json
@@ -1,0 +1,115 @@
+{
+  "group": {
+    "name": "tz_config",
+    "type": "group",
+    "label": "Time zone configuration",
+    "desc": "Set/get device's local time zone",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64260
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Tz",
+        "type": "string",
+        "size": 24,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Time zone",
+        "desc": "TZ Database (aka zoneinfo, http://www.iana.org/time-zones) name (e.g., \"US/Pacific\") "
+      },
+      {
+        "name": "Err",
+        "type": "bitfield16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Error code",
+        "desc": "Indicates time zone configuration errors",
+        "symbols": [
+          {
+            "name": "INVALID_TIMEZONE",
+            "value": 0
+          }
+        ]
+      },
+      {
+        "name": "LocalTime",
+        "type": "string",
+        "size": 14,
+        "mandatory": "M",
+        "label": "Local time",
+        "desc": "Local time string in YYYY-MM-DD hh:mm:ss +hhmm (e.g. \"2006-01-02 15:04:05 -0700\")"
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64260
+}

--- a/models/model_64261.json
+++ b/models/model_64261.json
@@ -1,0 +1,97 @@
+{
+  "group": {
+    "name": "output_controls",
+    "type": "group",
+    "label": "Output Controls",
+    "desc": "Generac inverter output controls.",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64261
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "VarRamp",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Rmp_SF",
+        "units": "Pct",
+        "access": "RW",
+        "label": "Reactive power ramp",
+        "desc": "Reactive power ramp-up rate as a percentage of max power."
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad9",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad10",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Rmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "label": "Ramp Rate Scale Factor",
+        "desc": "Ramp Rate Scale Factor"
+      }
+    ]
+  },
+  "id": 64261
+}

--- a/models/model_64262.json
+++ b/models/model_64262.json
@@ -1,0 +1,295 @@
+{
+  "group": {
+    "name": "dc_generator_config",
+    "type": "group",
+    "label": "DC-Coupled Generator Configuration",
+    "desc": "Communicates activation status and other configuration parameters to/from the Endure DC generator.",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64262
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "IsActivated",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Activation status",
+        "symbols": [
+          {
+            "name": "NO",
+            "value": 0,
+            "label": "Generator is not activated",
+            "desc": "The generator cannot be put into Auto mode.  It has not yet passed the steps required by the activation procedure."
+          },
+          {
+            "name": "YES",
+            "value": 1,
+            "label": "Generator is activated",
+            "desc": "The generator may operate in Auto mode.  This value is set from the cloud after the hardware has been registered (to an ESS and in SAP).  This value may also exist after a device has been manually activated directly when in an off-grid configuration."
+          }
+        ]
+      },
+      {
+        "name": "PowerConverterSWVer",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Version_SF",
+        "mandatory": "M",
+        "label": "Power Converter Software Version"
+      },
+      {
+        "name": "PowerConverterBuild",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Power Converter Jenkins Build Number"
+      },
+      {
+        "name": "GeneratorCtrlSWVer",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Version_SF",
+        "mandatory": "M",
+        "label": "Generator Controller Software Version"
+      },
+      {
+        "name": "GeneratorCtrlBuild",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Generator Controller Jenkins Build Number"
+      },
+      {
+        "name": "DisplayCtrlSWVer",
+        "type": "uint16",
+        "size": 1,
+        "sf": "Version_SF",
+        "mandatory": "M",
+        "label": "Display Controller Software Version"
+      },
+      {
+        "name": "DisplayCtrlBuild",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Display Controller Jenkins Build Number"
+      },
+      {
+        "name": "Version_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "EngineCtrlUnitSWVer",
+        "type": "string",
+        "size": 7,
+        "mandatory": "M",
+        "label": "Engine Control Unit Software Version"
+      },
+      {
+        "name": "Pad14",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad15",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad16",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad17",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad18",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad19",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad20",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad21",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad22",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad23",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad24",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad25",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad26",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad27",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad28",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad29",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad30",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad31",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad32",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad33",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad34",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad35",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad36",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad37",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad38",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad39",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad40",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad41",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad42",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad43",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Pad44",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      }
+    ]
+  },
+  "id": 64262
+}

--- a/models/model_64263.json
+++ b/models/model_64263.json
@@ -1,0 +1,244 @@
+{
+  "group": {
+    "name": "pvrss_config",
+    "type": "group",
+    "label": "PV Link Settings",
+    "desc": "Commission the PV Link and configure the Photovoltaic Rapid Shutdown System (PVRSS)",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64263
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Enable",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable",
+        "desc": "Use this command to enable the PV Link. For first-time commissioning with SnapRS, use Auto Cfg PVRSS.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "AutoConfigPVRSS",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Auto Cfg PVRSS",
+        "desc": "Automatically configure and enable the PV Link for use with SnapRS. PV Link will count the number of SnapRS devices and set the installed count accordingly.",
+        "symbols": [
+          {
+            "name": "N/A",
+            "value": 0
+          },
+          {
+            "name": "BEGIN_AUTOCONFIG",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "PLMCh",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "PLM channel",
+        "desc": "Channel for REbus communications. All devices in a system must use the same channel (except REbus Beacon).",
+        "symbols": [
+          {
+            "name": "CH_0",
+            "value": 0
+          },
+          {
+            "name": "CH_1",
+            "value": 1
+          },
+          {
+            "name": "CH_2",
+            "value": 2
+          },
+          {
+            "name": "CH_3",
+            "value": 3
+          },
+          {
+            "name": "CH_4",
+            "value": 4
+          },
+          {
+            "name": "CH_5",
+            "value": 5
+          },
+          {
+            "name": "CH_6",
+            "value": 6
+          },
+          {
+            "name": "CH_7",
+            "value": 7
+          },
+          {
+            "name": "CH_8",
+            "value": 8
+          },
+          {
+            "name": "CH_9",
+            "value": 9
+          },
+          {
+            "name": "CH_10",
+            "value": 10
+          },
+          {
+            "name": "CH_11",
+            "value": 11
+          },
+          {
+            "name": "CH_12",
+            "value": 12
+          }
+        ]
+      },
+      {
+        "name": "VinStartup",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SF_X10",
+        "units": "V",
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Vin Startup (V)",
+        "desc": "Minimum DC input voltage from the PV substring for the PV Link to start making power."
+      },
+      {
+        "name": "NumStrings",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "String Count",
+        "desc": "Number of parallel PV substrings connected to this PV Link.",
+        "symbols": [
+          {
+            "name": "ONE_SUBSTRING",
+            "value": 1
+          },
+          {
+            "name": "TWO_SUBSTRINGS",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "EnablePVRSS",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Enable PVRSS",
+        "desc": "If SnapRS devices are installed, this must be 'on'.",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 0
+          },
+          {
+            "name": "ON",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "SnapRSInstalledCnt",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "SnapRSInstalled",
+        "desc": "The total number of SnapRS devices physically installed on this PV Link. "
+      },
+      {
+        "name": "SnapRSDetectedCnt",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "SnapRSDetected",
+        "desc": "The number of SnapRS devices detected by the PV Link after its daily count. "
+      },
+      {
+        "name": "PVRSSLockoutError",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "PVRSS Lockout Error Status",
+        "desc": "A PVRSS Lockout Error indicates that SnapRSDetected does not equal SnapRSInstalled. Inspect SnapRS devices on this substring(s) for damage and replace as necessary.",
+        "symbols": [
+          {
+            "name": "NO_ERROR",
+            "value": 0
+          },
+          {
+            "name": "ERROR_ACTIVE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "ClearPVRSSLockoutError",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Clear PVRSS Lockout Error",
+        "desc": "Use to clear PVRSS Lockout error after confirming all SnapRS are functioning properly.",
+        "symbols": [
+          {
+            "name": "N/A",
+            "value": 0
+          },
+          {
+            "name": "CLEAR_ERROR",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "SF_X10",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 64263
+}

--- a/models/model_64264.json
+++ b/models/model_64264.json
@@ -1,0 +1,228 @@
+{
+  "group": {
+    "name": "pvrss_telemetry",
+    "type": "group",
+    "label": "PVRSS Telemetry",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64264
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "LastUpdatedUTCTimestamp",
+        "type": "uint32",
+        "size": 2,
+        "label": "Last Updated UTC Timestamp",
+        "desc": "Unix timestamp of when this model data was collected (seconds since 1970-01-01)"
+      },
+      {
+        "name": "Status",
+        "type": "bitfield16",
+        "size": 1,
+        "label": "Status",
+        "desc": "The state of PVRSS",
+        "symbols": [
+          {
+            "name": "INSTALLED_COUNT_IS_LOCKED",
+            "value": 0
+          },
+          {
+            "name": "LOCKOUT_ERROR",
+            "value": 1
+          },
+          {
+            "name": "AUTOCONFIG_ACTIVE",
+            "value": 2
+          },
+          {
+            "name": "MANUAL_TEST_ACTIVE",
+            "value": 3
+          },
+          {
+            "name": "VLOW_HIGH_RANGE",
+            "value": 4
+          },
+          {
+            "name": "VOC_HIGH_RANGE",
+            "value": 5
+          }
+        ]
+      },
+      {
+        "name": "SelfTestResults",
+        "type": "enum16",
+        "size": 1,
+        "label": "Self Test Results",
+        "desc": "The results of the last self test",
+        "symbols": [
+          {
+            "name": "SUCCESS",
+            "value": 0
+          },
+          {
+            "name": "VOC_LOW",
+            "value": 1
+          },
+          {
+            "name": "NONE",
+            "value": 2
+          },
+          {
+            "name": "VLOW_HIGH",
+            "value": 3
+          },
+          {
+            "name": "COUNT_MISMATCH",
+            "value": 4
+          },
+          {
+            "name": "VLOW_TIMEOUT",
+            "value": 5
+          },
+          {
+            "name": "NOT_CONFIGURED",
+            "value": 6
+          },
+          {
+            "name": "COUNT_OUT_OF_RANGE",
+            "value": 7
+          },
+          {
+            "name": "VLOW_LOW",
+            "value": 8
+          }
+        ]
+      },
+      {
+        "name": "TimesCountResultWasSuccess",
+        "type": "uint16",
+        "size": 1,
+        "label": "Times Count Result Was Success",
+        "desc": "The total number of successful counting attempts since the PV Link last powered up"
+      },
+      {
+        "name": "TimesCountResultWasLowSun",
+        "type": "uint16",
+        "size": 1,
+        "label": "Times Count Result Was LowSun",
+        "desc": "The total number of counting attempts that resulted in low sun since the PV Link last powered up"
+      },
+      {
+        "name": "TimesCountResultWasFail",
+        "type": "uint16",
+        "size": 1,
+        "label": "Times Count Result Was Fail",
+        "desc": "The total number of failed counting attempts since the PV Link last powered up"
+      },
+      {
+        "name": "TimesCountResultWasConsecutiveFail",
+        "type": "uint16",
+        "size": 1,
+        "label": "Times Count Result Was Consecutive Fail",
+        "desc": "The number of failed counting attempts in a row"
+      },
+      {
+        "name": "WaitTimeBeforeCountingAgain",
+        "type": "uint16",
+        "size": 1,
+        "label": "Wait Time Before Counting Again"
+      },
+      {
+        "name": "NumStrings",
+        "type": "uint16",
+        "size": 1,
+        "label": "Number of PV Strings"
+      },
+      {
+        "name": "InstalledCount",
+        "type": "uint16",
+        "size": 1,
+        "units": "Num SnapRS",
+        "label": "SnapRS Installed Count"
+      },
+      {
+        "name": "DetectedCount",
+        "type": "uint16",
+        "size": 1,
+        "units": "Num SnapRS",
+        "label": "SnapRS Detected Count"
+      },
+      {
+        "name": "CalculatedOffset",
+        "type": "int16",
+        "size": 1,
+        "label": "Calculated SnapRS Offset",
+        "desc": "Error in the calculation"
+      },
+      {
+        "name": "VWhenSnapRSOff",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X100_SF",
+        "units": "V",
+        "label": "Voltage When SnapRS Off"
+      },
+      {
+        "name": "VWhenSnapRSOn",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X10_SF",
+        "units": "V",
+        "label": "Voltage When SnapRS On"
+      },
+      {
+        "name": "Vlow",
+        "type": "uint16",
+        "size": 1,
+        "label": "Raw Voltage When SnapRS Off"
+      },
+      {
+        "name": "VocCompensated",
+        "type": "uint32",
+        "size": 2,
+        "label": "Raw Voltage When SnapRS On",
+        "desc": "Adjusted to have same range/units as Vlow"
+      },
+      {
+        "name": "CalculatedCountNumerator",
+        "type": "uint32",
+        "size": 2,
+        "label": "Calculated Count Numerator",
+        "desc": "Numerator used to calculate detected count"
+      },
+      {
+        "name": "CalculatedCountDenominator",
+        "type": "uint32",
+        "size": 2,
+        "label": "Calculated Count Denominator",
+        "desc": "Denominator used to calculate detected count"
+      },
+      {
+        "name": "X10_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "X100_SF",
+        "type": "sunssf",
+        "size": 1
+      }
+    ]
+  },
+  "id": 64264
+}

--- a/models/model_64265.json
+++ b/models/model_64265.json
@@ -1,0 +1,132 @@
+{
+  "group": {
+    "name": "balanced_input_telemetry",
+    "type": "group",
+    "label": "Balanced Input Telemetry",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64265
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "LastUpdatedUTCTimestamp",
+        "type": "uint32",
+        "size": 2,
+        "label": "Last Updated UTC Timestamp",
+        "desc": "Unix timestamp of when this model data was collected (seconds since 1970-01-01)"
+      },
+      {
+        "name": "BalancedInputSelfTestResults",
+        "type": "enum16",
+        "size": 1,
+        "symbols": [
+          {
+            "name": "BALANCED_INPUT_SUCCESS",
+            "value": 0
+          },
+          {
+            "name": "PV_POS_TOO_LARGE",
+            "value": 1
+          },
+          {
+            "name": "PV_NEG_TOO_LARGE",
+            "value": 2
+          }
+        ]
+      },
+      {
+        "name": "TimesTestResultWasConsecutiveFail",
+        "type": "uint16",
+        "size": 1,
+        "label": "Times Test Result Was Consecutive Fail",
+        "desc": "The number of failed balanced input startup tests attempts in a row"
+      },
+      {
+        "name": "FullInputVoltage",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X10_SF",
+        "units": "V",
+        "label": "Full Input Voltage",
+        "desc": "Full real input voltage when performing the balanced input test"
+      },
+      {
+        "name": "NegativeInputVoltage",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X10_SF",
+        "units": "V",
+        "label": "Negative Input Voltage",
+        "desc": "Negative real input voltage when performing the balanced input test"
+      },
+      {
+        "name": "MaxNegativeInputVoltage",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X10_SF",
+        "units": "V",
+        "label": "Maximum Negative Input Voltage",
+        "desc": "Maximum negative input voltage value that would still pass the balanced input test"
+      },
+      {
+        "name": "MinNegativeInputVoltage",
+        "type": "uint16",
+        "size": 1,
+        "sf": "X10_SF",
+        "units": "V",
+        "label": "Minimum Negative Input Voltage",
+        "desc": "Minimum negative input voltage value that would still pass the balanced input test"
+      },
+      {
+        "name": "InputVoltageRatio",
+        "type": "uint16",
+        "size": 1,
+        "units": "% * 8192",
+        "label": "Input Voltage Ratio",
+        "desc": "Negative Input Voltage divided by Full Input Voltage X 8192"
+      },
+      {
+        "name": "LargestRecordedVoltageRatio",
+        "type": "uint16",
+        "size": 1,
+        "units": "% * 8192",
+        "label": "Largest Recorded Voltage Ratio",
+        "desc": "Largest negative input voltage divided by the total input voltage recorded since last success X 8192"
+      },
+      {
+        "name": "SmallestRecordedVoltageRatio",
+        "type": "uint16",
+        "size": 1,
+        "units": "% * 8192",
+        "label": "Smallest Recorded Voltage Ratio",
+        "desc": "Smallest negative input voltage divided by the total input voltage recorded since last success X 8192"
+      },
+      {
+        "name": "X10_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 64265
+}

--- a/models/model_64268.json
+++ b/models/model_64268.json
@@ -1,0 +1,435 @@
+{
+  "group": {
+    "name": "Power_Prioritization_Basic_Diagnostics",
+    "type": "group",
+    "label": "Power Prioritization Basic Diagnostics",
+    "desc": "Basic diagnostics model for understanding power prioritization",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 64268
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "AvgGridVoltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Average Grid Voltage from GSL Measurements",
+        "desc": "The average grid voltage as reported by the GSL - when the ATS is grid connected, these measurements are taken from the AC input of the inverter, while when the ATS is not grid connected, the measurements are taken from the interconnect via the CTs and ATS connection to the inverter"
+      },
+      {
+        "name": "GridFrequency",
+        "type": "int32",
+        "size": 2,
+        "sf": "Hz_SF",
+        "units": "Hz",
+        "label": "Grid Frequency from GSL Measurements",
+        "desc": "The grid frequency as reported by the GSL - this is calculated using the voltage measurements' period"
+      },
+      {
+        "name": "RealPower",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Real Power from GSL Measurements",
+        "desc": "The real power being imported from or exported to the grid as reported by the GSL"
+      },
+      {
+        "name": "ReactivePower",
+        "type": "int16",
+        "size": 1,
+        "units": "VAR",
+        "label": "Reactive Power from GSL Measurements",
+        "desc": "The reactive power being imported from or exported to the grid as reported by the GSL"
+      },
+      {
+        "name": "VoltWattExportLimit",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Volt Watt Export Limit",
+        "desc": "The export limit for real power based on the volt watt control algorithm"
+      },
+      {
+        "name": "FreqWattRealPowerTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Frequency Watt Real Power Target",
+        "desc": "The target for real power based on the frequency watt control algorithm"
+      },
+      {
+        "name": "FreqWattActiveStatus",
+        "type": "enum16",
+        "size": 1,
+        "label": "Frequency Watt Active Status",
+        "desc": "Active status of the frequency watt control algorithm",
+        "symbols": [
+          {
+            "name": "INACTIVE",
+            "value": 0
+          },
+          {
+            "name": "ACTIVE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "WattVarReactivePowerTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "VAR",
+        "label": "Watt Var Reactive Power Target",
+        "desc": "The target for reactive power based on the watt var control algorithm"
+      },
+      {
+        "name": "VoltVarReactivePowerTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "VAR",
+        "label": "Volt Var Reactive Power Target",
+        "desc": "The target for reactive power based on the volt var control algorithm"
+      },
+      {
+        "name": "VoltVarReferenceVoltage",
+        "type": "int16",
+        "size": 1,
+        "sf": "V_Percent_SF",
+        "units": "V_Percent",
+        "label": "Volt Var Reference Voltage",
+        "desc": "The reference voltage used to run the volt var algorithm"
+      },
+      {
+        "name": "ConstantPowerFactorReactivePowerTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "VAR",
+        "label": "Constant Power Factor Reactive Power Target",
+        "desc": "The target for reactive power based on the constant power factor control algorithm"
+      },
+      {
+        "name": "ConstantReactivePowerCommandReactivePowerTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "VAR",
+        "label": "Constant Reactive Power Command Reactive Power Target",
+        "desc": "The target for reactive power based on the constant reactive power command"
+      },
+      {
+        "name": "RealPowerLimit",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Real Power Limit",
+        "desc": "The limit for real power based on the real power limit"
+      },
+      {
+        "name": "RealPowerSettingTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Real Power Setting Target",
+        "desc": "The target for real power based on the real power setting"
+      },
+      {
+        "name": "GSLRealPowerCommand",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "GSL Real Power Command",
+        "desc": "The real power command as requested by the GSL"
+      },
+      {
+        "name": "GSLRealPowerLowLimit",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "GSL Real Power Low Limit",
+        "desc": "The lower limit on real power as requested by the GSL"
+      },
+      {
+        "name": "GSLRealPowerHighLimit",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "GSL Real Power High Limit",
+        "desc": "The upper limit on real power as requested by the GSL"
+      },
+      {
+        "name": "GSLRealPowerCommandActiveStatus",
+        "type": "enum16",
+        "size": 1,
+        "label": "GSL Real Power Command Active Status",
+        "desc": "The active status of the GSL's real power command",
+        "symbols": [
+          {
+            "name": "INACTIVE",
+            "value": 0
+          },
+          {
+            "name": "ACTIVE",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "GSLReactivePowerCommand",
+        "type": "int16",
+        "size": 1,
+        "sf": "VAR_Percent_SF",
+        "units": "VAR_Percent",
+        "label": "GSL Reactive Power Command",
+        "desc": "The reactive power command as requested by the GSL"
+      },
+      {
+        "name": "MaxReactiveAmpsReference",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Maximum Reactive Amps Reference",
+        "desc": "The absolute threshold for the reactive amps target"
+      },
+      {
+        "name": "ReactiveAmpsFromCapacitor",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Reactive Amps From Capacitor",
+        "desc": "Reactive amps adjustment from output capacitance"
+      },
+      {
+        "name": "ReactiveAmpsTarget",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Reactive Amps Target",
+        "desc": "Final output reactive amps after adjustments from the GSL, capacitance, and anti-islanding"
+      },
+      {
+        "name": "ReactiveAmpsTargetFromGSL",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Reactive Amps Target From GSL",
+        "desc": "Target for reactive amps from GSL"
+      },
+      {
+        "name": "RealPowerAmpsReferenceTotal",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Real Power Amps Reference Total",
+        "desc": "Used to determine whether power flows toward or away from REbus"
+      },
+      {
+        "name": "RealPowerAmpsReference1",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Real Power Amps Reference for Phase 1",
+        "desc": "Phase 1 component of real power amps reference total - allows us to balance power between the lines"
+      },
+      {
+        "name": "RealPowerAmpsReference2",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Real Power Amps Reference for Phase 2",
+        "desc": "Phase 2 component of real power amps reference total - allows us to balance power between the lines"
+      },
+      {
+        "name": "ReactiveAmpsReference",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Reactive Amps Reference",
+        "desc": "Integral form of the reactive amps target"
+      },
+      {
+        "name": "RealPowerAmpsReferenceTarget",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Real Power Amps Reference Target",
+        "desc": "Target from divy - total"
+      },
+      {
+        "name": "ApparentPowerVectorAmpLimit",
+        "type": "int16",
+        "size": 1,
+        "units": "A",
+        "label": "Apparent Power Vector Amp Limit",
+        "desc": "Restricts all combined real and reactive amps from exceeding this limit"
+      },
+      {
+        "name": "PowerAsWattsNegativeLimit",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Power as Watts Negative Limit",
+        "desc": "Negative real power limit"
+      },
+      {
+        "name": "PowerAsWattsPositiveLimit",
+        "type": "int16",
+        "size": 1,
+        "units": "W",
+        "label": "Power as Watts Positive Limit",
+        "desc": "Positive real power limit"
+      },
+      {
+        "name": "PowerTargetAsPercent",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "Power Target as Percent",
+        "desc": "Target for real power dependent on mode"
+      },
+      {
+        "name": "PowerTargetAsAmps",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Power Target as Amps",
+        "desc": "Amps required to reach the target for real power"
+      },
+      {
+        "name": "CTTargetSelfSupply",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "CT Target for Self Supply",
+        "desc": "CT target for self supply"
+      },
+      {
+        "name": "CTTargetZeroExport",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "CT Target for Zero Export",
+        "desc": "CT target for zero export"
+      },
+      {
+        "name": "CTTargetZeroImport",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "CT Target for Zero Import",
+        "desc": "CT target for zero import"
+      },
+      {
+        "name": "CTTargetGenConnected",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_Percent_SF",
+        "units": "W_Percent",
+        "label": "CT Target when Gen Connected",
+        "desc": "CT target when generator connected"
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "Hz_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "V_Percent_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "W_Percent_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "VAR_Percent_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1
+      },
+      {
+        "name": "Pad0",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad5",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad6",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad7",
+        "type": "pad",
+        "size": 1
+      },
+      {
+        "name": "Pad8",
+        "type": "pad",
+        "size": 1
+      }
+    ]
+  },
+  "id": 64268
+}

--- a/models/model_7.json
+++ b/models/model_7.json
@@ -1,0 +1,185 @@
+{
+  "group": {
+    "name": "model_7",
+    "type": "group",
+    "label": "Secure Write Response Model (DRAFT 1)",
+    "desc": "Include a digital signature over the response",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 7
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "RqSeq",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Request Sequence",
+        "desc": "Sequence number from the request"
+      },
+      {
+        "name": "Sts",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Status",
+        "desc": "Status of last write operation",
+        "symbols": [
+          {
+            "name": "SUCCESS",
+            "value": 0,
+            "label": "SUCCESS",
+            "desc": "Operation succeeded"
+          },
+          {
+            "name": "DS",
+            "value": 1,
+            "label": "DS",
+            "desc": "Operation failed digital signature check"
+          },
+          {
+            "name": "ACL",
+            "value": 2,
+            "label": "ACL",
+            "desc": "Operation failed access control check"
+          },
+          {
+            "name": "OFF",
+            "value": 3,
+            "label": "OFF",
+            "desc": "Operation failed offset check"
+          },
+          {
+            "name": "VAL",
+            "value": 4,
+            "label": "VAL",
+            "desc": "Operation failed valid value check"
+          }
+        ]
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of response"
+      },
+      {
+        "name": "Alm",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Alarm",
+        "desc": "Bitmask alarm code",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No Alarms"
+          },
+          {
+            "name": "ALM",
+            "value": 1,
+            "label": "ALARM",
+            "desc": "Security Alarm"
+          }
+        ]
+      },
+      {
+        "name": "Rsrvd",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers comprising the digital signature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "DS",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M",
+            "label": "DS",
+            "desc": "Digital Signature"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 7
+}

--- a/models/model_701.json
+++ b/models/model_701.json
@@ -1,0 +1,917 @@
+{
+    "group": {
+        "desc": "DER AC measurement model.",
+        "label": "DER AC Measurement",
+        "name": "DERMeasureAC",
+        "points": [
+            {
+                "desc": "DER AC measurement model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 701
+            },
+            {
+                "desc": "DER AC measurement model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 153
+            },
+            {
+                "comments": [
+                    "Wiring Type"
+                ],
+                "desc": "AC wiring type.",
+                "label": "AC Wiring Type",
+                "mandatory": "M",
+                "name": "ACType",
+                "size": 1,
+                "symbols": [
+                    {
+                        "label": "Single Phase",
+                        "name": "SINGLE_PHASE",
+                        "value": 0
+                    },
+                    {
+                        "label": "Split Phase",
+                        "name": "SPLIT_PHASE",
+                        "value": 1
+                    },
+                    {
+                        "label": "Three Phase",
+                        "name": "THREE_PHASE",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "comments": [
+                    "Operating State"
+                ],
+                "desc": "Operating state of the DER.",
+                "label": "Operating State",
+                "name": "St",
+                "size": 1,
+                "symbols": [
+                    {
+                        "label": "Off",
+                        "name": "OFF",
+                        "value": 0
+                    },
+                    {
+                        "label": "On",
+                        "name": "ON",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "comments": [
+                    "Inverter State"
+                ],
+                "desc": "Enumerated value.  Inverter state.",
+                "label": "Inverter State",
+                "name": "InvSt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "name": "OFF",
+                        "value": 0
+                    },
+                    {
+                        "name": "SLEEPING",
+                        "value": 1
+                    },
+                    {
+                        "name": "STARTING",
+                        "value": 2
+                    },
+                    {
+                        "name": "RUNNING",
+                        "value": 3
+                    },
+                    {
+                        "name": "THROTTLED",
+                        "value": 4
+                    },
+                    {
+                        "name": "SHUTTING_DOWN",
+                        "value": 5
+                    },
+                    {
+                        "name": "FAULT",
+                        "value": 6
+                    },
+                    {
+                        "name": "STANDBY",
+                        "value": 7
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "comments": [
+                    "Grid Connection State"
+                ],
+                "desc": "Grid connection state of the DER.",
+                "label": "Grid Connection State",
+                "name": "ConnSt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Disconnected from the grid.",
+                        "label": "Disconnected",
+                        "name": "DISCONNECTED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Connected to the grid.",
+                        "label": "Connected",
+                        "name": "CONNECTED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "comments": [
+                    "Alarms"
+                ],
+                "desc": "Active alarms for the DER.",
+                "label": "Alarm Bitfield",
+                "name": "Alrm",
+                "size": 2,
+                "symbols": [
+                    {
+                        "label": "Ground Fault",
+                        "name": "GROUND_FAULT",
+                        "value": 0
+                    },
+                    {
+                        "label": "DC Over Voltage",
+                        "name": "DC_OVER_VOLT",
+                        "value": 1
+                    },
+                    {
+                        "label": "AC Disconnect Open",
+                        "name": "AC_DISCONNECT",
+                        "value": 2
+                    },
+                    {
+                        "label": "DC Disconnect Open",
+                        "name": "DC_DISCONNECT",
+                        "value": 3
+                    },
+                    {
+                        "label": "Grid Disconnect",
+                        "name": "GRID_DISCONNECT",
+                        "value": 4
+                    },
+                    {
+                        "label": "Cabinet Open",
+                        "name": "CABINET_OPEN",
+                        "value": 5
+                    },
+                    {
+                        "label": "Manual Shutdown",
+                        "name": "MANUAL_SHUTDOWN",
+                        "value": 6
+                    },
+                    {
+                        "label": "Over Temperature",
+                        "name": "OVER_TEMP",
+                        "value": 7
+                    },
+                    {
+                        "label": "Frequency Above Limit",
+                        "name": "OVER_FREQUENCY",
+                        "value": 8
+                    },
+                    {
+                        "label": "Frequency Under Limit",
+                        "name": "UNDER_FREQUENCY",
+                        "value": 9
+                    },
+                    {
+                        "label": "AC Voltage Above Limit",
+                        "name": "AC_OVER_VOLT",
+                        "value": 10
+                    },
+                    {
+                        "label": "AC Voltage Under Limit",
+                        "name": "AC_UNDER_VOLT",
+                        "value": 11
+                    },
+                    {
+                        "label": "Blown String Fuse On Input",
+                        "name": "BLOWN_STRING_FUSE",
+                        "value": 12
+                    },
+                    {
+                        "label": "Under Temperature",
+                        "name": "UNDER_TEMP",
+                        "value": 13
+                    },
+                    {
+                        "label": "Generic Memory Or Communication Error (Internal)",
+                        "name": "MEMORY_LOSS",
+                        "value": 14
+                    },
+                    {
+                        "label": "Hardware Test Failure",
+                        "name": "HW_TEST_FAILURE",
+                        "value": 15
+                    },
+                    {
+                        "desc": "Manufacturer alarm, see ManAlrmInfo field for more information.",
+                        "label": "Manufacturer Alarm",
+                        "name": "MANUFACTURER_ALRM",
+                        "value": 16
+                    }
+                ],
+                "type": "bitfield32"
+            },
+            {
+                "desc": "Current operational characteristics of the DER.",
+                "label": "DER Operational Characteristics",
+                "name": "DERMode",
+                "size": 2,
+                "symbols": [
+                    {
+                        "desc": "The DER is operating as part of a larger grid.",
+                        "label": "Grid Following",
+                        "name": "GRID_FOLLOWING",
+                        "value": 0
+                    },
+                    {
+                        "desc": "The DER is providing the grid.",
+                        "label": "Grid Forming",
+                        "name": "GRID_FORMING",
+                        "value": 1
+                    },
+                    {
+                        "desc": "The PV output is clipped.",
+                        "label": "PV Output Clipped",
+                        "name": "PV_CLIPPED",
+                        "value": 2
+                    }
+                ],
+                "type": "bitfield32"
+            },
+            {
+                "comments": [
+                    "Summary"
+                ],
+                "desc": "Total active power. Active power is positive for DER generation and negative for absorption.",
+                "label": "Active Power",
+                "name": "W",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "W"
+            },
+            {
+                "desc": "Total apparent power.",
+                "label": "Apparent Power",
+                "name": "VA",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "VA"
+            },
+            {
+                "desc": "Total reactive power.",
+                "label": "Reactive Power",
+                "name": "Var",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Var"
+            },
+            {
+                "desc": "Power factor. The sign of power factor should be the sign of active power.",
+                "label": "Power Factor",
+                "name": "PF",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "int16"
+            },
+            {
+                "desc": "Total AC current.",
+                "label": "Total AC Current",
+                "name": "A",
+                "sf": "A_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "A"
+            },
+            {
+                "desc": "Line to line AC voltage as an average of active phases.",
+                "label": "Voltage LL",
+                "name": "LLV",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Line to neutral AC voltage as an average of active phases.",
+                "label": "Voltage LN",
+                "name": "LNV",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "AC frequency.",
+                "label": "Frequency",
+                "name": "Hz",
+                "sf": "Hz_SF",
+                "size": 2,
+                "type": "uint32",
+                "units": "Hz"
+            },
+            {
+                "desc": "Total active energy injected (Quadrants 1 & 4).",
+                "label": "Total Energy Injected",
+                "name": "TotWhInj",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total active energy absorbed (Quadrants 2 & 3).",
+                "label": "Total Energy Absorbed",
+                "name": "TotWhAbs",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total reactive energy injected (Quadrants 1 & 2).",
+                "label": "Total Reactive Energy Inj",
+                "name": "TotVarhInj",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "desc": "Total reactive energy absorbed (Quadrants 3 & 4).",
+                "label": "Total Reactive Energy Abs",
+                "name": "TotVarhAbs",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "comments": [
+                    "Temperatures"
+                ],
+                "desc": "Ambient temperature.",
+                "label": "Ambient Temperature",
+                "name": "TmpAmb",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "desc": "Cabinet temperature.",
+                "label": "Cabinet Temperature",
+                "name": "TmpCab",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "desc": "Heat sink temperature.",
+                "label": "Heat Sink Temperature",
+                "name": "TmpSnk",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "desc": "Transformer temperature.",
+                "label": "Transformer Temperature",
+                "name": "TmpTrns",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "desc": "IGBT/MOSFET temperature.",
+                "label": "IGBT/MOSFET Temperature",
+                "name": "TmpSw",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "desc": "Other temperature.",
+                "label": "Other Temperature",
+                "name": "TmpOt",
+                "sf": "Tmp_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "C"
+            },
+            {
+                "comments": [
+                    "L1"
+                ],
+                "desc": "Active power L1.",
+                "label": "Watts L1",
+                "name": "WL1",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "W"
+            },
+            {
+                "desc": "Apparent power L1.",
+                "label": "VA L1",
+                "name": "VAL1",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "VA"
+            },
+            {
+                "desc": "Reactive power L1.",
+                "label": "Var L1",
+                "name": "VarL1",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Var"
+            },
+            {
+                "desc": "Power factor phase L1.",
+                "label": "PF L1",
+                "name": "PFL1",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "int16"
+            },
+            {
+                "desc": "Current phase L1.",
+                "label": "Amps L1",
+                "name": "AL1",
+                "sf": "A_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "A"
+            },
+            {
+                "desc": "Phase voltage L1-L2.",
+                "label": "Phase Voltage L1-L2",
+                "name": "VL1L2",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Phase voltage L1-N.",
+                "label": "Phase Voltage L1-N",
+                "name": "VL1",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Total active energy injected L1.",
+                "label": "Total Watt-Hours Inj L1",
+                "name": "TotWhInjL1",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total active energy absorbed L1.",
+                "label": "Total Watt-Hours Abs L1",
+                "name": "TotWhAbsL1",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total reactive energy injected L1.",
+                "label": "Total Var-Hours Inj L1",
+                "name": "TotVarhInjL1",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "desc": "Total reactive energy absorbed L1.",
+                "label": "Total Var-Hours Abs L1",
+                "name": "TotVarhAbsL1",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "comments": [
+                    "L2"
+                ],
+                "desc": "Active power L2.",
+                "label": "Watts L2",
+                "name": "WL2",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "W"
+            },
+            {
+                "desc": "Apparent power L2.",
+                "label": "VA L2",
+                "name": "VAL2",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "VA"
+            },
+            {
+                "desc": "Reactive power L2.",
+                "label": "Var L2",
+                "name": "VarL2",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Var"
+            },
+            {
+                "desc": "Power factor L2.",
+                "label": "PF L2",
+                "name": "PFL2",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "int16"
+            },
+            {
+                "desc": "Current L2.",
+                "label": "Amps L2",
+                "name": "AL2",
+                "sf": "A_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "A"
+            },
+            {
+                "desc": "Phase voltage L2-L3.",
+                "label": "Phase Voltage L2-L3",
+                "name": "VL2L3",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Phase voltage L2-N.",
+                "label": "Phase Voltage L2-N",
+                "name": "VL2",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Total active energy injected L2.",
+                "label": "Total Watt-Hours Inj L2",
+                "name": "TotWhInjL2",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total active energy absorbed L2.",
+                "label": "Total Watt-Hours Abs L2",
+                "name": "TotWhAbsL2",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total reactive energy injected L2.",
+                "label": "Total Var-Hours Inj L2",
+                "name": "TotVarhInjL2",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "desc": "Total reactive energy absorbed L2.",
+                "label": "Total Var-Hours Abs L2",
+                "name": "TotVarhAbsL2",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "comments": [
+                    "L3"
+                ],
+                "desc": "Active power L3.",
+                "label": "Watts L3",
+                "name": "WL3",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "W"
+            },
+            {
+                "desc": "Apparent power L3.",
+                "label": "VA L3",
+                "name": "VAL3",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "VA"
+            },
+            {
+                "desc": "Reactive power L3.",
+                "label": "Var L3",
+                "name": "VarL3",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Var"
+            },
+            {
+                "desc": "Power factor L3.",
+                "label": "PF L3",
+                "name": "PFL3",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "int16"
+            },
+            {
+                "desc": "Current L3.",
+                "label": "Amps L3",
+                "name": "AL3",
+                "sf": "A_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "A"
+            },
+            {
+                "desc": "Phase voltage L3-L1.",
+                "label": "Phase Voltage L3-L1",
+                "name": "VL3L1",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Phase voltage L3-N.",
+                "label": "Phase Voltage L3-N",
+                "name": "VL3",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "Total active energy injected L3.",
+                "label": "Total Watt-Hours Inj L3",
+                "name": "TotWhInjL3",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total active energy absorbed L3.",
+                "label": "Total Watt-Hours Abs L3",
+                "name": "TotWhAbsL3",
+                "sf": "TotWh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total reactive energy injected L3.",
+                "label": "Total Var-Hours Inj L3",
+                "name": "TotVarhInjL3",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "desc": "Total reactive energy absorbed L3.",
+                "label": "Total Var-Hours Abs L3",
+                "name": "TotVarhAbsL3",
+                "sf": "TotVarh_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Varh"
+            },
+            {
+                "comments": [
+                    "Active Power Throttling"
+                ],
+                "desc": "Throttling in pct of maximum active power.",
+                "label": "Throttling In Pct",
+                "name": "ThrotPct",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "desc": "Active throttling source.",
+                "label": "Throttle Source Information",
+                "name": "ThrotSrc",
+                "size": 2,
+                "symbols": [
+                    {
+                        "name": "MAX_W",
+                        "value": 0
+                    },
+                    {
+                        "name": "FIXED_W",
+                        "value": 1
+                    },
+                    {
+                        "name": "FIXED_VAR",
+                        "value": 2
+                    },
+                    {
+                        "name": "FIXED_PF",
+                        "value": 3
+                    },
+                    {
+                        "name": "VOLT_VAR",
+                        "value": 4
+                    },
+                    {
+                        "name": "FREQ_WATT",
+                        "value": 5
+                    },
+                    {
+                        "name": "DYN_REACT_CURR",
+                        "value": 6
+                    },
+                    {
+                        "name": "LVRT",
+                        "value": 7
+                    },
+                    {
+                        "name": "HVRT",
+                        "value": 8
+                    },
+                    {
+                        "name": "WATT_VAR",
+                        "value": 9
+                    },
+                    {
+                        "name": "VOLT_WATT",
+                        "value": 10
+                    },
+                    {
+                        "name": "SCHEDULED",
+                        "value": 11
+                    },
+                    {
+                        "name": "LFRT",
+                        "value": 12
+                    },
+                    {
+                        "name": "HFRT",
+                        "value": 13
+                    },
+                    {
+                        "name": "DERATED",
+                        "value": 14
+                    }
+                ],
+                "type": "bitfield32"
+            },
+            {
+                "comments": [
+                    "Scale Factors"
+                ],
+                "desc": "Current scale factor.",
+                "label": "Current Scale Factor",
+                "name": "A_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Voltage scale factor.",
+                "label": "Voltage Scale Factor",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Frequency scale factor.",
+                "label": "Frequency Scale Factor",
+                "name": "Hz_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Active power scale factor.",
+                "label": "Active Power Scale Factor",
+                "name": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Power factor scale factor.",
+                "label": "Power Factor Scale Factor",
+                "name": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Apparent power scale factor.",
+                "label": "Apparent Power Scale Factor",
+                "name": "VA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Reactive power scale factor.",
+                "label": "Reactive Power Scale Factor",
+                "name": "Var_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Active energy scale factor.",
+                "label": "Active Energy Scale Factor",
+                "name": "TotWh_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Reactive energy scale factor.",
+                "label": "Reactive Energy Scale Factor",
+                "name": "TotVarh_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Temperature scale factor.",
+                "label": "Temperature Scale Factor",
+                "name": "Tmp_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "comments": [
+                    "Manufacturer Alarm Information"
+                ],
+                "desc": "Manufacturer alarm information. Valid if MANUFACTURER_ALRM indication is active.",
+                "label": "Manufacturer Alarm Info",
+                "name": "MnAlrmInfo",
+                "size": 32,
+                "type": "string"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 701
+}

--- a/models/model_702.json
+++ b/models/model_702.json
@@ -1,0 +1,643 @@
+{
+    "group": {
+        "desc": "DER capacity model.",
+        "label": "DER Capacity",
+        "name": "DERCapacity",
+        "points": [
+            {
+                "desc": "DER capacity model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 702
+            },
+            {
+                "desc": "DER capacity model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 50
+            },
+            {
+                "comments": [
+                    "Nameplate Ratings - Specifies capacity ratings"
+                ],
+                "desc": "Maximum active power rating at unity power factor in watts.",
+                "label": "Active Power Max Rating",
+                "name": "WMaxRtg",
+                "sf": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "desc": "Active power rating at specified over-excited power factor in watts.",
+                "label": "Active Power (Over-Excited) Rating",
+                "name": "WOvrExtRtg",
+                "sf": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "desc": "Specified over-excited power factor.",
+                "label": "Specified Over-Excited PF",
+                "name": "WOvrExtRtgPF",
+                "sf": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Active power rating at specified under-excited power factor in watts.",
+                "label": "Active Power (Under-Excited) Rating",
+                "name": "WUndExtRtg",
+                "sf": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "desc": "Specified under-excited power factor.",
+                "label": "Specified Under-Excited PF",
+                "name": "WUndExtRtgPF",
+                "sf": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Maximum apparent power rating in voltamperes.",
+                "label": "Apparent Power Max Rating",
+                "name": "VAMaxRtg",
+                "sf": "VA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "desc": "Maximum injected reactive power rating in vars.",
+                "label": "Reactive Power Injected Rating",
+                "name": "VarMaxInjRtg",
+                "sf": "Var_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "Var"
+            },
+            {
+                "desc": "Maximum absorbed reactive power rating in vars.",
+                "label": "Reactive Power Absorbed Rating",
+                "name": "VarMaxAbsRtg",
+                "sf": "Var_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "Var"
+            },
+            {
+                "desc": "Maximum active power charge rate in watts.",
+                "label": "Charge Rate Max Rating",
+                "name": "WChaRteMaxRtg",
+                "sf": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "desc": "Maximum active power discharge rate in watts.",
+                "label": "Discharge Rate Max Rating",
+                "name": "WDisChaRteMaxRtg",
+                "sf": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "desc": "Maximum apparent power charge rate in voltamperes.",
+                "label": "Charge Rate Max VA Rating",
+                "name": "VAChaRteMaxRtg",
+                "sf": "VA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "desc": "Maximum apparent power discharge rate in voltamperes.",
+                "label": "Discharge Rate Max VA Rating",
+                "name": "VADisChaRteMaxRtg",
+                "sf": "VA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "desc": "AC voltage nominal rating.",
+                "label": "AC Voltage Nominal Rating",
+                "name": "VNomRtg",
+                "sf": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "AC voltage maximum rating.",
+                "label": "AC Voltage Max Rating",
+                "name": "VMaxRtg",
+                "sf": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "AC voltage minimum rating.",
+                "label": "AC Voltage Min Rating",
+                "name": "VMinRtg",
+                "sf": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "desc": "AC current maximum rating in amps.",
+                "label": "AC Current Max Rating",
+                "name": "AMaxRtg",
+                "sf": "A_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "A"
+            },
+            {
+                "desc": "Power factor over-excited rating.",
+                "label": "PF Over-Excited Rating",
+                "name": "PFOvrExtRtg",
+                "sf": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Power factor under-excited rating.",
+                "label": "PF Under-Excited Rating",
+                "name": "PFUndExtRtg",
+                "sf": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Reactive susceptance that remains connected to the Area EPS in the cease to energize and trip state.",
+                "label": "Reactive Susceptance",
+                "name": "ReactSusceptRtg",
+                "sf": "S_SF",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "units": "S"
+            },
+            {
+                "desc": "Normal operating performance category as specified in IEEE 1547-2018.",
+                "label": "Normal Operating Category",
+                "name": "NorOpCatRtg",
+                "size": 1,
+                "static": "S",
+                "symbols": [
+                    {
+                        "label": "Category A",
+                        "name": "CAT_A",
+                        "value": 0
+                    },
+                    {
+                        "label": "Category B",
+                        "name": "CAT_B",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Abnormal operating performance category as specified in IEEE 1547-2018.",
+                "label": "Abnormal Operating Category",
+                "name": "AbnOpCatRtg",
+                "size": 1,
+                "static": "S",
+                "symbols": [
+                    {
+                        "label": "Category I",
+                        "name": "CAT_1",
+                        "value": 0
+                    },
+                    {
+                        "label": "Category II",
+                        "name": "CAT_2",
+                        "value": 1
+                    },
+                    {
+                        "label": "Category III",
+                        "name": "CAT_3",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Supported control mode functions.",
+                "label": "Supported Control Modes",
+                "name": "CtrlModes",
+                "size": 2,
+                "static": "S",
+                "symbols": [
+                    {
+                        "label": "Limit Maximum Active Power",
+                        "name": "MAX_W",
+                        "value": 0
+                    },
+                    {
+                        "label": "Fixed Active Power",
+                        "name": "FIXED_W",
+                        "value": 1
+                    },
+                    {
+                        "label": "Fixed Reactive Power",
+                        "name": "FIXED_VAR",
+                        "value": 2
+                    },
+                    {
+                        "label": "Fixed Power Factor",
+                        "name": "FIXED_PF",
+                        "value": 3
+                    },
+                    {
+                        "label": "Volt-Var Function",
+                        "name": "VOLT_VAR",
+                        "value": 4
+                    },
+                    {
+                        "label": "Freq-Watt Function",
+                        "name": "FREQ_WATT",
+                        "value": 5
+                    },
+                    {
+                        "label": "Dynamic Reactive Current Function",
+                        "name": "DYN_REACT_CURR",
+                        "value": 6
+                    },
+                    {
+                        "label": "Low-Voltage Trip",
+                        "name": "LV_TRIP",
+                        "value": 7
+                    },
+                    {
+                        "label": "High-Voltage Trip",
+                        "name": "HV_TRIP",
+                        "value": 8
+                    },
+                    {
+                        "label": "Watt-Var Function",
+                        "name": "WATT_VAR",
+                        "value": 9
+                    },
+                    {
+                        "label": "Volt-Watt Function",
+                        "name": "VOLT_WATT",
+                        "value": 10
+                    },
+                    {
+                        "label": "Scheduling",
+                        "name": "SCHEDULED",
+                        "value": 11
+                    },
+                    {
+                        "label": "Low-Frequency Trip",
+                        "name": "LF_TRIP",
+                        "value": 12
+                    },
+                    {
+                        "label": "High-Frequency Trip",
+                        "name": "HF_TRIP",
+                        "value": 13
+                    }
+                ],
+                "type": "bitfield32"
+            },
+            {
+                "desc": "Intentional island categories.",
+                "label": "Intentional Island Categories",
+                "name": "IntIslandCatRtg",
+                "size": 1,
+                "static": "S",
+                "symbols": [
+                    {
+                        "label": "Uncategorized",
+                        "name": "UNCATEGORIZED",
+                        "value": 0
+                    },
+                    {
+                        "label": "Intentional Island-Capable",
+                        "name": "INT_ISL_CAPABLE",
+                        "value": 1
+                    },
+                    {
+                        "label": "Black Start-Capable",
+                        "name": "BLACK_START_CAPABLE",
+                        "value": 2
+                    },
+                    {
+                        "label": "Isochronous-Capable",
+                        "name": "ISOCH_CAPABLE",
+                        "value": 3
+                    }
+                ],
+                "type": "bitfield16"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Settings - Used to adjust nameplate ratings"
+                ],
+                "desc": "Maximum active power setting used to adjust maximum active power setting.",
+                "label": "Active Power Max Setting",
+                "name": "WMax",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Active power setting at specified over-excited power factor in watts.",
+                "label": "Active Power (Over-Excited) Setting",
+                "name": "WMaxOvrExt",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Specified over-excited power factor.",
+                "label": "Specified Over-Excited PF",
+                "name": "WOvrExtPF",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Active power setting at specified under-excited power factor in watts.",
+                "label": "Active Power (Under-Excited) Setting",
+                "name": "WMaxUndExt",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Specified under-excited power factor.",
+                "label": "Specified Under-Excited PF",
+                "name": "WUndExtPF",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum apparent power setting used to adjust maximum apparent power rating.",
+                "label": "Apparent Power Max Setting",
+                "name": "VAMax",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum injected reactive power setting used to adjust maximum injected reactive power rating.",
+                "label": "Reactive Power Injected Setting",
+                "name": "VarMaxInj",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Var"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum absorbed reactive power setting used to adjust maximum absorbed reactive power rating.",
+                "label": "Reactive Power Absorbed Setting",
+                "name": "VarMaxAbs",
+                "sf": "Var_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Var"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum active power charge rate setting used to adjust maximum active power charge rate rating.",
+                "label": "Charge Rate Max Setting",
+                "name": "WChaRteMax",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum active power discharge rate setting used to adjust maximum active power discharge rate rating.",
+                "label": "Discharge Rate Max Setting",
+                "name": "WDisChaRteMax",
+                "sf": "W_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum apparent power charge rate setting used to adjust maximum apparent power charge rate rating.",
+                "label": "Charge Rate Max VA Setting",
+                "name": "VAChaRteMax",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum apparent power discharge rate setting used to adjust maximum apparent power discharge rate rating.",
+                "label": "Discharge Rate Max VA Setting",
+                "name": "VADisChaRteMax",
+                "sf": "VA_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "VA"
+            },
+            {
+                "access": "RW",
+                "desc": "Nominal AC voltage setting.",
+                "label": "Nominal AC Voltage Setting",
+                "name": "VNom",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "access": "RW",
+                "desc": "AC voltage maximum setting used to adjust AC voltage maximum rating.",
+                "label": "AC Voltage Max Setting",
+                "name": "VMax",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "access": "RW",
+                "desc": "AC voltage minimum setting used to adjust AC voltage minimum rating.",
+                "label": "AC Voltage Min Setting",
+                "name": "VMin",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "V"
+            },
+            {
+                "access": "RW",
+                "desc": "Maximum AC current setting used to adjust maximum AC current rating.",
+                "label": "AC Current Max Setting",
+                "name": "AMax",
+                "sf": "A_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "A"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor over-excited setting.",
+                "label": "PF Over-Excited Setting",
+                "name": "PFOvrExt",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor under-excited setting.",
+                "label": "PF Under-Excited Setting",
+                "name": "PFUndExt",
+                "sf": "PF_SF",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Intentional island categories.",
+                "label": "Intentional Island Categories",
+                "name": "IntIslandCat",
+                "size": 1,
+                "symbols": [
+                    {
+                        "label": "Uncategorized",
+                        "name": "UNCATEGORIZED",
+                        "value": 0
+                    },
+                    {
+                        "label": "Intentional Island-Capable",
+                        "name": "INT_ISL_CAPABLE",
+                        "value": 1
+                    },
+                    {
+                        "label": "Black Start-Capable",
+                        "name": "BLACK_START_CAPABLE",
+                        "value": 2
+                    },
+                    {
+                        "label": "Isochronous-Capable",
+                        "name": "ISOCH_CAPABLE",
+                        "value": 3
+                    }
+                ],
+                "type": "bitfield16"
+            },
+            {
+                "comments": [
+                    "Scale Factors"
+                ],
+                "desc": "Active power scale factor.",
+                "label": "Active Power Scale Factor",
+                "name": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Power factor scale factor.",
+                "label": "Power Factor Scale Factor",
+                "name": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Apparent power scale factor.",
+                "label": "Apparent Power Scale Factor",
+                "name": "VA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Reactive power scale factor.",
+                "label": "Reactive Power Scale Factor",
+                "name": "Var_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Voltage scale factor.",
+                "label": "Voltage Scale Factor",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Current scale factor.",
+                "label": "Current Scale Factor",
+                "name": "A_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Susceptance scale factor.",
+                "label": "Susceptance Scale Factor",
+                "name": "S_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 702
+}

--- a/models/model_703.json
+++ b/models/model_703.json
@@ -1,0 +1,140 @@
+{
+    "group": {
+        "desc": "Enter service model.",
+        "label": "Enter Service",
+        "name": "DEREnterService",
+        "points": [
+            {
+                "desc": "Enter service model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 703
+            },
+            {
+                "desc": "Enter service model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 17
+            },
+            {
+                "access": "RW",
+                "desc": "Permit enter service.",
+                "label": "Permit Enter Service",
+                "name": "ES",
+                "size": 1,
+                "symbols": [
+                    {
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service voltage high threshold as percent of normal voltage.",
+                "label": "Enter Service Voltage High",
+                "name": "ESVHi",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service voltage low threshold as percent of normal voltage.",
+                "label": "Enter Service Voltage Low",
+                "name": "ESVLo",
+                "sf": "V_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service frequency high threshold.",
+                "label": "Enter Service Frequency High",
+                "name": "ESHzHi",
+                "sf": "Hz_SF",
+                "size": 2,
+                "type": "uint32",
+                "units": "Hz"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service frequency low threshold.",
+                "label": "Enter Service Frequency Low",
+                "name": "ESHzLo",
+                "sf": "Hz_SF",
+                "size": 2,
+                "type": "uint32",
+                "units": "Hz"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service delay time in seconds.",
+                "label": "Enter Service Delay Time",
+                "name": "ESDlyTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service random delay in seconds.",
+                "label": "Enter Service Random Delay",
+                "name": "ESRndTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Enter service ramp time in seconds.",
+                "label": "Enter Service Ramp Time",
+                "name": "ESRmpTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Enter service delay time remaining in seconds.",
+                "label": "Enter Service Delay Remaining",
+                "name": "ESDlyRemTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Voltage percentage scale factor.",
+                "label": "Voltage Scale Factor",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Frequency scale factor.",
+                "label": "Frequency Scale Factor",
+                "name": "Hz_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 703
+}

--- a/models/model_704.json
+++ b/models/model_704.json
@@ -1,0 +1,818 @@
+{
+    "group": {
+        "desc": "DER AC controls model.",
+        "groups": [
+            {
+                "comments": [
+                    "Power Factor Settings"
+                ],
+                "desc": "Power factor setpoint when injecting active power.",
+                "label": "Power Factor (W Inj) ",
+                "name": "PFWInj",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Power factor setpoint when injecting active power.",
+                        "label": "Power Factor (W Inj) ",
+                        "name": "PF",
+                        "sf": "PF_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Power factor excitation setpoint when injecting active power.",
+                        "label": "Power Factor Excitation (W Inj)",
+                        "name": "Ext",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Power factor over-excited excitation.",
+                                "label": "Over-Excited",
+                                "name": "OVER_EXCITED",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Power factor under-excited excitation.",
+                                "label": "Under-Excited",
+                                "name": "UNDER_EXCITED",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "sync"
+            },
+            {
+                "desc": "Reversion power factor setpoint when injecting active power.",
+                "label": "Reversion Power Factor (W Inj) ",
+                "name": "PFWInjRvrt",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Reversion power factor setpoint when injecting active power.",
+                        "label": "Reversion Power Factor (W Inj) ",
+                        "name": "PF",
+                        "sf": "PF_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Reversion power factor excitation setpoint when injecting active power.",
+                        "label": "Reversion PF Excitation (W Inj)",
+                        "name": "Ext",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Power factor over-excited excitation.",
+                                "label": "Over-Excited",
+                                "name": "OVER_EXCITED",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Power factor under-excited excitation.",
+                                "label": "Under-Excited",
+                                "name": "UNDER_EXCITED",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "sync"
+            },
+            {
+                "desc": "Power factor setpoint when absorbing active power.",
+                "label": "Power Factor (W Abs) ",
+                "name": "PFWAbs",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Power factor setpoint when absorbing active power.",
+                        "label": "Power Factor (W Abs) ",
+                        "name": "PF",
+                        "sf": "PF_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Power factor excitation setpoint when absorbing active power.",
+                        "label": "Power Factor Excitation (W Abs)",
+                        "name": "Ext",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Power factor over-excited excitation.",
+                                "label": "Over-Excited",
+                                "name": "OVER_EXCITED",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Power factor under-excited excitation.",
+                                "label": "Under-Excited",
+                                "name": "UNDER_EXCITED",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "sync"
+            },
+            {
+                "desc": "Reversion power factor setpoint when absorbing active power.",
+                "label": "Reversion Power Factor (W Abs) ",
+                "name": "PFWAbsRvrt",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Reversion power factor setpoint when absorbing active power.",
+                        "label": "Reversion Power Factor (W Abs) ",
+                        "name": "PF",
+                        "sf": "PF_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Reversion power factor excitation setpoint when absorbing active power.",
+                        "label": "Reversion PF Excitation (W Abs)",
+                        "name": "Ext",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Power factor over-excited excitation.",
+                                "label": "Over-Excited",
+                                "name": "OVER_EXCITED",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Power factor under-excited excitation.",
+                                "label": "Under-Excited",
+                                "name": "UNDER_EXCITED",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "sync"
+            }
+        ],
+        "label": "DER AC Controls",
+        "name": "DERCtlAC",
+        "points": [
+            {
+                "desc": "DER AC controls model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 704
+            },
+            {
+                "desc": "DER AC controls model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 65
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Set Power Factor (when injecting active power)"
+                ],
+                "desc": "Power factor enable when injecting active power.",
+                "label": "Power Factor Enable (W Inj) Enable",
+                "name": "PFWInjEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor reversion timer when injecting active power enable.",
+                "label": "Power Factor Reversion Enable (W Inj)",
+                "name": "PFWInjEnaRvrt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor reversion timer when injecting active power.",
+                "label": "PF Reversion Time (W Inj)",
+                "name": "PFWInjRvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Power factor reversion time remaining when injecting active power.",
+                "label": "PF Reversion Time Rem (W Inj)",
+                "name": "PFWInjRvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Set Power Factor (when absorbing active power)"
+                ],
+                "desc": "Power factor enable when absorbing active power.",
+                "label": "Power Factor Enable (W Abs) Enable",
+                "name": "PFWAbsEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor reversion timer when absorbing active power enable.",
+                "label": "Power Factor Reversion Enable (W Abs)",
+                "name": "PFWAbsEnaRvrt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Power factor reversion timer when absorbing active power.",
+                "label": "PF Reversion Time (W Abs)",
+                "name": "PFWAbsRvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Power factor reversion time remaining when absorbing active power.",
+                "label": "PF Reversion Time Rem (W Abs)",
+                "name": "PFWAbsRvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Limit Maximum Active Power Generation"
+                ],
+                "desc": "Limit maximum active power percent enable.",
+                "label": "Limit Max Power Pct Enable",
+                "name": "WMaxLimPctEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Limit maximum active power percent value.",
+                "label": "Limit Max Power Pct Setpoint",
+                "name": "WMaxLimPct",
+                "sf": "WMaxLimPct_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion limit maximum active power percent value.",
+                "label": "Reversion Limit Max Power Pct",
+                "name": "WMaxLimPctRvrt",
+                "sf": "WMaxLimPct_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion limit maximum active power percent value enable.",
+                "label": "Reversion Limit Max Power Pct Enable",
+                "name": "WMaxLimPctEnaRvrt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Limit maximum active power percent reversion time.",
+                "label": "Limit Max Power Pct Reversion Time",
+                "name": "WMaxLimPctRvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Limit maximum active power percent reversion time remaining.",
+                "label": "Limit Max Power Pct Rev Time Rem",
+                "name": "WMaxLimPctRvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Set Active Power Level (may be negative for charging)"
+                ],
+                "desc": "Set active power enable.",
+                "label": "Set Active Power Enable",
+                "name": "WSetEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set active power mode.",
+                "label": "Set Active Power Mode",
+                "name": "WSetMod",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Active power setting is percentage of maximum active power.",
+                        "label": "Active Power As Max Percent",
+                        "name": "W_MAX_PCT",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Active power setting is in watts.",
+                        "label": "Active Power As Watts",
+                        "name": "WATTS",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Active power setting value in watts.",
+                "label": "Active Power Setpoint (W)",
+                "name": "WSet",
+                "sf": "WSet_SF",
+                "size": 2,
+                "type": "int32",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion active power setting value in watts.",
+                "label": "Reversion Active Power (W)",
+                "name": "WSetRvrt",
+                "sf": "WSet_SF",
+                "size": 2,
+                "type": "int32",
+                "units": "W"
+            },
+            {
+                "access": "RW",
+                "desc": "Active power setting value as percent.",
+                "label": "Active Power Setpoint (Pct)",
+                "name": "WSetPct",
+                "sf": "WSetPct_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion active power setting value as percent.",
+                "label": "Reversion Active Power (Pct)",
+                "name": "WSetPctRvrt",
+                "sf": "WSetPct_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion active power function enable.",
+                "label": "Reversion Active Power Enable",
+                "name": "WSetEnaRvrt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set active power reversion time.",
+                "label": "Active Power Reversion Time",
+                "name": "WSetRvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Set active power reversion time remaining.",
+                "label": "Active Power Rev Time Rem",
+                "name": "WSetRvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Set Reacitve Power Level"
+                ],
+                "desc": "Set reactive power enable.",
+                "label": "Set Reactive Power Enable",
+                "name": "VarSetEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set reactive power mode.",
+                "label": "Set Reactive Power Mode",
+                "name": "VarSetMod",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Reactive power setting is percent of maximum active power.",
+                        "label": "Reactive Power As Watt Max Pct",
+                        "name": "W_MAX_PCT",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Reactive power setting is percent of maximum reactive power.",
+                        "label": "Reactive Power As Var Max Pct",
+                        "name": "VAR_MAX_PCT",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Reactive power setting is percent of available reactive  power.",
+                        "label": "Reactive Power As Var Avail Pct",
+                        "name": "VAR_AVAIL_PCT",
+                        "value": 2
+                    },
+                    {
+                        "desc": "Reactive power setting is percent of maximum apparent power.",
+                        "label": "Reactive Power As VA Max Pct",
+                        "name": "VA_MAX_PCT",
+                        "value": 3
+                    },
+                    {
+                        "desc": "Reactive power is in vars.",
+                        "label": "Reactive Power As Vars",
+                        "name": "VARS",
+                        "value": 4
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reactive power priority.",
+                "label": "Reactive Power Priority",
+                "name": "VarSetPri",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Active power priority.",
+                        "label": "Active Power Priority",
+                        "name": "ACTIVE",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Reactive power priority.",
+                        "label": "Reactive Power Priority",
+                        "name": "REACTIVE",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Power priority is vendor specific mode.",
+                        "label": "Vendor Power Priority",
+                        "name": "VENDOR",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reactive power setting value in vars.",
+                "label": "Reactive Power Setpoint (Vars)",
+                "name": "VarSet",
+                "sf": "VarSet_SF",
+                "size": 2,
+                "type": "int32",
+                "units": "Var"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion reactive power setting value in vars.",
+                "label": "Reversion Reactive Power (Vars)",
+                "name": "VarSetRvrt",
+                "sf": "VarSet_SF",
+                "size": 2,
+                "type": "int32",
+                "units": "Var"
+            },
+            {
+                "access": "RW",
+                "desc": "Reactive power setting value as percent.",
+                "label": "Reactive Power Setpoint (Pct)",
+                "name": "VarSetPct",
+                "sf": "VarSetPct_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion reactive power setting value as percent.",
+                "label": "Reversion Reactive Power (Pct)",
+                "name": "VarSetPctRvrt",
+                "sf": "VarSetPct_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "Pct"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion reactive power function enable.",
+                "label": "Reversion Reactive Power Enable",
+                "name": "VarSetEnaRvrt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set reactive power reversion time.",
+                "label": "Reactive Power Reversion Time",
+                "name": "VarSetRvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Set reactive power reversion time remaining.",
+                "label": "Reactive Power Rev Time Rem",
+                "name": "VarSetRvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "comments": [
+                    "Ramp Rate"
+                ],
+                "desc": "Ramp rate for increases in active power during normal generation.",
+                "label": "Normal Ramp Rate",
+                "name": "WRmp",
+                "size": 1,
+                "type": "uint16",
+                "units": "%Max/Sec"
+            },
+            {
+                "access": "RW",
+                "desc": "Ramp rate reference unit for increases in active power or current during normal generation.",
+                "label": "Normal Ramp Rate Reference",
+                "name": "WRmpRef",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Ramp based on percent of max current per second.",
+                        "label": "Max Current Ramp",
+                        "name": "A_MAX",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Ramp based on percent of max active power per second.",
+                        "label": "Max Active Power Ramp",
+                        "name": "W_MAX",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Ramp rate based on max reactive power per second.",
+                "label": "Reactive Power Ramp Rate",
+                "name": "VarRmp",
+                "size": 1,
+                "type": "uint16",
+                "units": "%Max/Sec"
+            },
+            {
+                "access": "RW",
+                "desc": "Anti-islanding enable.",
+                "label": "Anti-Islanding Enable",
+                "name": "AntiIslEna",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Anti-islanding is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Anti-islanding is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "comments": [
+                    "Scale Factors"
+                ],
+                "desc": "Power factor scale factor.",
+                "label": "Power Factor Scale Factor",
+                "name": "PF_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Limit maximum power scale factor.",
+                "label": "Limit Max Power Scale Factor",
+                "name": "WMaxLimPct_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Active power scale factor.",
+                "label": "Active Power Scale Factor",
+                "name": "WSet_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Active power pct scale factor.",
+                "label": "Active Power Pct Scale Factor",
+                "name": "WSetPct_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Reactive power scale factor.",
+                "label": "Reactive Power Scale Factor",
+                "name": "VarSet_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Reactive power pct scale factor.",
+                "label": "Reactive Power Pct Scale Factor",
+                "name": "VarSetPct_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 704
+}

--- a/models/model_705.json
+++ b/models/model_705.json
@@ -1,0 +1,359 @@
+{
+    "group": {
+        "desc": "DER Volt-Var model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored Curve Sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrv",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored Curve Sets - Curve points for each stored curve - Number of curve points contained in NPt"
+                        ],
+                        "count": "NPt",
+                        "desc": "Stored curve points.",
+                        "label": "Stored Curve Points",
+                        "name": "Pt",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Curve voltage point as percentage.",
+                                "label": "Voltage Point",
+                                "name": "V",
+                                "sf": "V_SF",
+                                "size": 1,
+                                "type": "uint16",
+                                "units": "VNomPct"
+                            },
+                            {
+                                "access": "RW",
+                                "desc": "Curve reactive power point as set in DeptRef point.",
+                                "label": "Reactive Power Point",
+                                "name": "Var",
+                                "sf": "DeptRef_SF",
+                                "size": 1,
+                                "type": "int16",
+                                "units": "DeptRef"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Number of active points.",
+                        "label": "Active Points",
+                        "mandatory": "M",
+                        "name": "ActPt",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Curve dependent reference.",
+                        "label": "Dependent Reference",
+                        "mandatory": "M",
+                        "name": "DeptRef",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "label": "Percent Max Watts",
+                                "name": "W_MAX_PCT",
+                                "value": 0
+                            },
+                            {
+                                "label": "Percent Max Vars",
+                                "name": "VAR_MAX_PCT",
+                                "value": 1
+                            },
+                            {
+                                "label": "Percent Available Vars",
+                                "name": "VAR_AVAL_PCT",
+                                "value": 2
+                            },
+                            {
+                                "label": "Percent Max Apparent Power",
+                                "name": "VA_MAX_PCT",
+                                "value": 3
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Power priority.",
+                        "label": "Power Priority",
+                        "name": "Pri",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Active power priority.",
+                                "label": "Active Power Priority",
+                                "name": "ACTIVE",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Reactive power priority.",
+                                "label": "Reactive Power Priority",
+                                "name": "REACTIVE",
+                                "value": 1
+                            },
+                            {
+                                "desc": "Power priority is vendor specific mode.",
+                                "label": "Vendor Power Priority",
+                                "name": "VENDOR",
+                                "value": 2
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Vref adjustment as percentage of nominal voltage.",
+                        "label": "Vref Adjustment",
+                        "name": "VRef",
+                        "sf": "V_SF",
+                        "size": 1,
+                        "type": "uint16",
+                        "units": "VNomPct"
+                    },
+                    {
+                        "desc": "Autonomous vref value as a percentage of nominal voltage.",
+                        "label": "Current Autonomous Vref",
+                        "name": "VRefAuto",
+                        "sf": "V_SF",
+                        "size": 1,
+                        "type": "uint16",
+                        "units": "VNomPct"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Enable autonomous vref.",
+                        "label": "Autonomous Vref Enable",
+                        "name": "VRefAutoEna",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Disabled flag (Disabled = 0, Enabled = 1).",
+                                "label": "Disabled Flag",
+                                "name": "DISABLED",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
+                                "label": "Enabled Flag",
+                                "name": "ENABLED",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Autonomous vref time constant.",
+                        "label": "Auto Vref Time Constant",
+                        "name": "VRefAutoTms",
+                        "size": 1,
+                        "type": "uint16",
+                        "units": "Secs"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Open loop response time.",
+                        "label": "Open Loop Response Time",
+                        "name": "RspTms",
+                        "sf": "RspTms_SF",
+                        "size": 2,
+                        "type": "uint32",
+                        "units": "Secs"
+                    },
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Volt-Var",
+        "name": "DERVoltVar",
+        "points": [
+            {
+                "desc": "DER Volt-Var model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 705
+            },
+            {
+                "desc": "DER Volt-Var model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Volt-Var control enable.",
+                "label": "DER Volt-Var Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrv",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "label": "Reversion Timeout",
+                "name": "RvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Reversion time remaining in seconds.",
+                "label": "Reversion Time Remaining",
+                "name": "RvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Default curve after reversion timeout.",
+                "label": "Reversion Curve",
+                "name": "RvrtCrv",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve voltage points.",
+                "label": "Voltage Scale Factor",
+                "mandatory": "M",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve var points.",
+                "label": "Var Scale Factor",
+                "mandatory": "M",
+                "name": "DeptRef_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Open loop response time scale factor.",
+                "label": "Open-Loop Scale Factor",
+                "mandatory": "M",
+                "name": "RspTms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 705
+}

--- a/models/model_706.json
+++ b/models/model_706.json
@@ -1,0 +1,269 @@
+{
+    "group": {
+        "desc": "DER Volt-Watt model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrv",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve sets - curve points for each stored curve - Number of curve points contained in NPt"
+                        ],
+                        "count": "NPt",
+                        "desc": "Stored curve points.",
+                        "label": "Stored Curve Points",
+                        "name": "Pt",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Curve voltage point as percentage.",
+                                "label": "Voltage Point",
+                                "name": "V",
+                                "sf": "V_SF",
+                                "size": 1,
+                                "type": "uint16",
+                                "units": "VNomPct"
+                            },
+                            {
+                                "access": "RW",
+                                "desc": "Active power in percent of rated active power.",
+                                "label": "Dependent Reference",
+                                "name": "W",
+                                "sf": "DeptRef_SF",
+                                "size": 1,
+                                "type": "int16",
+                                "units": "DeptRef"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Number of active points.",
+                        "label": "Active Points",
+                        "mandatory": "M",
+                        "name": "ActPt",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Curve dependent reference.",
+                        "label": "Dependent Reference",
+                        "mandatory": "M",
+                        "name": "DeptRef",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "name": "W_MAX_PCT",
+                                "value": 0
+                            },
+                            {
+                                "name": "W_AVAL_PCT",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Open loop response time.",
+                        "label": "Open Loop Response Time",
+                        "name": "RspTms",
+                        "sf": "RspTms_SF",
+                        "size": 2,
+                        "type": "uint32",
+                        "units": "Secs"
+                    },
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Volt-Watt",
+        "name": "DERVoltWatt",
+        "points": [
+            {
+                "desc": "DER Volt-Watt model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 706
+            },
+            {
+                "desc": "DER Volt-Watt model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Volt-Watt control enable.",
+                "label": "DER Volt-Watt Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrv",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "label": "Reversion Timeout",
+                "name": "RvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Reversion time remaining in seconds.",
+                "label": "Reversion Time Remaining",
+                "name": "RvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Default curve after reversion timeout.",
+                "label": "Reversion Curve",
+                "name": "RvrtCrv",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve voltage points.",
+                "label": "Voltage Scale Factor",
+                "mandatory": "M",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve watt points.",
+                "label": "Watt Scale Factor",
+                "mandatory": "M",
+                "name": "DeptRef_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Open loop response time scale factor.",
+                "label": "Open-Loop Scale Factor",
+                "mandatory": "M",
+                "name": "RspTms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 706
+}

--- a/models/model_707.json
+++ b/models/model_707.json
@@ -1,0 +1,309 @@
+{
+    "group": {
+        "desc": "DER low voltage trip model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrvSet - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrvSet",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
+                        ],
+                        "desc": "Stored must trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Must trip curve points.",
+                                "label": "Must Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Must Trip Curve",
+                        "name": "MustTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in must trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored may trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "May trip curve points.",
+                                "label": "May Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "May Trip Curve",
+                        "name": "MayTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in may trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored momentary cessation curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Momentary cessation curve points.",
+                                "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in the momentary cessation curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Trip LV",
+        "name": "DERTripLV",
+        "points": [
+            {
+                "desc": "DER low voltage trip model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 707
+            },
+            {
+                "desc": "DER low voltage trip model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER low voltage trip control enable.",
+                "label": "DER Trip LV Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrvSet",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve voltage points.",
+                "label": "Voltage Scale Factor",
+                "mandatory": "M",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve time points.",
+                "label": "Time Point Scale Factor",
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 707
+}

--- a/models/model_708.json
+++ b/models/model_708.json
@@ -1,0 +1,309 @@
+{
+    "group": {
+        "desc": "DER high voltage trip model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrvSet - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrvSet",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
+                        ],
+                        "desc": "Stored must trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Must trip curve points.",
+                                "label": "Must Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Must Trip Curve",
+                        "name": "MustTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in must trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored may trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "May trip curve points.",
+                                "label": "May Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "May Trip Curve",
+                        "name": "MayTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in may trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored momentary cessation curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Momentary cessation curve points.",
+                                "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve voltage point as percentage.",
+                                        "label": "Voltage Point",
+                                        "name": "V",
+                                        "sf": "V_SF",
+                                        "size": 1,
+                                        "type": "uint16",
+                                        "units": "VNomPct"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in the momentary cessation curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Trip HV",
+        "name": "DERTripHV",
+        "points": [
+            {
+                "desc": "DER high voltage trip model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 708
+            },
+            {
+                "desc": "DER high voltage trip model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER high voltage trip control enable.",
+                "label": "DER Trip HV Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrvSet",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve voltage points.",
+                "label": "Voltage Scale Factor",
+                "mandatory": "M",
+                "name": "V_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve time points.",
+                "label": "Time Point Scale Factor",
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 708
+}

--- a/models/model_709.json
+++ b/models/model_709.json
@@ -1,0 +1,309 @@
+{
+    "group": {
+        "desc": "DER low frequency trip model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrvSet - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrvSet",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
+                        ],
+                        "desc": "Stored must trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Must trip curve points.",
+                                "label": "Must Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Must Trip Curve",
+                        "name": "MustTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in must trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored may trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "May trip curve points.",
+                                "label": "May Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "May Trip Curve",
+                        "name": "MayTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in may trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored momentary cessation curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Momentary cessation curve points.",
+                                "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in the momentary cessation curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Trip LF",
+        "name": "DERTripLF",
+        "points": [
+            {
+                "desc": "DER low frequency trip model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 709
+            },
+            {
+                "desc": "DER low frequency trip model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER low frequency trip control enable.",
+                "label": "DER Trip LF Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrvSet",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve frequency points.",
+                "label": "Frequency Scale Factor",
+                "mandatory": "M",
+                "name": "Hz_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve time points.",
+                "label": "Time Point Scale Factor",
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 709
+}

--- a/models/model_710.json
+++ b/models/model_710.json
@@ -1,0 +1,309 @@
+{
+    "group": {
+        "desc": "DER high frequency trip model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrvSet - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrvSet",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
+                        ],
+                        "desc": "Stored must trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Must trip curve points.",
+                                "label": "Must Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Must Trip Curve",
+                        "name": "MustTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in must trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored may trip curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "May trip curve points.",
+                                "label": "May Trip Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "May Trip Curve",
+                        "name": "MayTrip",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in may trip curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    },
+                    {
+                        "desc": "Stored momentary cessation curve.",
+                        "groups": [
+                            {
+                                "count": "NPt",
+                                "desc": "Momentary cessation curve points.",
+                                "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
+                                "points": [
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve frequency point.",
+                                        "label": "Frequency Point",
+                                        "name": "Hz",
+                                        "sf": "Hz_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Hz"
+                                    },
+                                    {
+                                        "access": "RW",
+                                        "desc": "Curve time point in seconds.",
+                                        "label": "Time Point",
+                                        "name": "Tms",
+                                        "sf": "Tms_SF",
+                                        "size": 2,
+                                        "type": "uint32",
+                                        "units": "Secs"
+                                    }
+                                ],
+                                "type": "group"
+                            }
+                        ],
+                        "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Number of active points in the momentary cessation curve.",
+                                "label": "Number Of Active Points",
+                                "name": "ActPt",
+                                "size": 1,
+                                "type": "uint16"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Trip HF",
+        "name": "DERTripHF",
+        "points": [
+            {
+                "desc": "DER high frequency trip model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 710
+            },
+            {
+                "desc": "DER high frequency trip model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER high frequency trip control enable.",
+                "label": "DER Trip HF Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrvSet",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve frequency points.",
+                "label": "Frequency Scale Factor",
+                "mandatory": "M",
+                "name": "Hz_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve time points.",
+                "label": "Time Point Scale Factor",
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 710
+}

--- a/models/model_711.json
+++ b/models/model_711.json
@@ -1,0 +1,250 @@
+{
+    "group": {
+        "desc": "DER Frequency Droop model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored control sets - Number of control sets contained in NCtl - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCtl",
+                "desc": "Stored control sets.",
+                "label": "Stored Controls",
+                "name": "Ctl",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "The deadband value for over-frequency conditions in Hz.",
+                        "label": "Over-Frequency Deadband",
+                        "mandatory": "M",
+                        "name": "DbOf",
+                        "sf": "Db_SF",
+                        "size": 2,
+                        "type": "uint32",
+                        "units": "Hz"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "The deadband value for under-frequency conditions in Hz.",
+                        "label": "Under-Frequency Deadband",
+                        "mandatory": "M",
+                        "name": "DbUf",
+                        "sf": "Db_SF",
+                        "size": 2,
+                        "type": "uint32",
+                        "units": "Hz"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Frequency droop per-unit frequency change for over-frequency conditions corresponding to 1 per-unit power output change.",
+                        "label": "Over-Frequency Change Ratio",
+                        "mandatory": "M",
+                        "name": "KOf",
+                        "sf": "K_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Frequency droop per-unit frequency change for under-frequency conditions corresponding to 1 per-unit power output change.",
+                        "label": "Under-Frequency Change Ratio",
+                        "mandatory": "M",
+                        "name": "KUf",
+                        "sf": "K_SF",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "The open-loop response time in seconds.",
+                        "label": "Open-Loop Response Time",
+                        "mandatory": "M",
+                        "name": "RspTms",
+                        "sf": "RspTms_SF",
+                        "size": 2,
+                        "type": "uint32",
+                        "units": "Secs"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "The minimum active power output due to DER prime mover constraints, in percent of the DER active power rating. The valid range is -100 to 100. This setting applies only to the frequency droop control.",
+                        "label": "Minimum Active Power",
+                        "name": "PMin",
+                        "size": 1,
+                        "type": "int16",
+                        "units": "Pct"
+                    },
+                    {
+                        "desc": "Control read-write access.",
+                        "label": "Control Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Control has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Control has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Frequency Droop",
+        "name": "DERFreqDroop",
+        "points": [
+            {
+                "desc": "DER Frequency Droop model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 711
+            },
+            {
+                "desc": "DER Frequency Droop model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER Frequency-Watt (Frequency-Droop) control enable.",
+                "label": "DER Frequency Droop Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set active control. 0 = No active control.",
+                "label": "Set Active Control Request",
+                "mandatory": "M",
+                "name": "AdptCtlReq",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last set active control operation.",
+                "label": "Set Active Control Result",
+                "mandatory": "M",
+                "name": "AdptCtlRslt",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Control update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Control update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Control update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of stored controls supported.",
+                "label": "Stored Control Count",
+                "mandatory": "M",
+                "name": "NCtl",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "label": "Reversion Timeout",
+                "name": "RvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Reversion time remaining in seconds.",
+                "label": "Reversion Time Left",
+                "name": "RvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Default control after reversion timeout.",
+                "label": "Reversion Control",
+                "name": "RvrtCtl",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Deadband scale factor.",
+                "label": "Deadband Scale Factor",
+                "mandatory": "M",
+                "name": "Db_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Frequency change scale factor.",
+                "label": "Frequency Change Scale Factor",
+                "mandatory": "M",
+                "name": "K_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Open loop response time scale factor.",
+                "label": "Open-Loop Scale Factor",
+                "mandatory": "M",
+                "name": "RspTms_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 711
+}

--- a/models/model_712.json
+++ b/models/model_712.json
@@ -1,0 +1,286 @@
+{
+    "group": {
+        "desc": "DER Watt-Var model.",
+        "groups": [
+            {
+                "comments": [
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCrv",
+                "desc": "Stored curve sets.",
+                "groups": [
+                    {
+                        "comments": [
+                            "Stored curve sets - curve points for each stored curve - Number of curve points contained in NPt"
+                        ],
+                        "count": "NPt",
+                        "desc": "Stored curve points.",
+                        "label": "Stored Curve Points",
+                        "name": "Pt",
+                        "points": [
+                            {
+                                "access": "RW",
+                                "desc": "Curve active power point as percentage.",
+                                "label": "Active Power Point",
+                                "name": "W",
+                                "sf": "W_SF",
+                                "size": 1,
+                                "type": "int16",
+                                "units": "WMaxPct"
+                            },
+                            {
+                                "access": "RW",
+                                "desc": "Curve reactive power point as set in DeptRef point.",
+                                "label": "Reactive Power Point",
+                                "name": "Var",
+                                "sf": "DeptRef_SF",
+                                "size": 1,
+                                "type": "int16",
+                                "units": "VarPct"
+                            }
+                        ],
+                        "type": "group"
+                    }
+                ],
+                "label": "Stored Curves",
+                "name": "Crv",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "Number of active points.",
+                        "label": "Active Points",
+                        "mandatory": "M",
+                        "name": "ActPt",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Curve dependent reference.",
+                        "label": "Dependent Reference",
+                        "mandatory": "M",
+                        "name": "DeptRef",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "label": "Percent Max Watts",
+                                "name": "W_MAX_PCT",
+                                "value": 0
+                            },
+                            {
+                                "label": "Percent Max Vars",
+                                "name": "VAR_MAX_PCT",
+                                "value": 1
+                            },
+                            {
+                                "label": "Percent Available Vars",
+                                "name": "VAR_AVAL_PCT",
+                                "value": 2
+                            },
+                            {
+                                "label": "Percent Max Apparent Power",
+                                "name": "VA_MAX_PCT",
+                                "value": 3
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Power priority.",
+                        "label": "Power Priority",
+                        "name": "Pri",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "desc": "Active power priority.",
+                                "label": "Active Power Priority",
+                                "name": "ACTIVE",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Reactive power priority.",
+                                "label": "Reactive Power Priority",
+                                "name": "REACTIVE",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "desc": "Curve read-write access.",
+                        "label": "Curve Access",
+                        "mandatory": "M",
+                        "name": "ReadOnly",
+                        "size": 1,
+                        "static": "S",
+                        "symbols": [
+                            {
+                                "desc": "Curve has read-write access.",
+                                "label": "Read-Write Access",
+                                "name": "RW",
+                                "value": 0
+                            },
+                            {
+                                "desc": "Curve has read-only access.",
+                                "label": "Read-Only Access",
+                                "name": "R",
+                                "value": 1
+                            }
+                        ],
+                        "type": "enum16"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER Watt-Var",
+        "name": "DERWattVar",
+        "points": [
+            {
+                "desc": "DER Watt-Var model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 712
+            },
+            {
+                "desc": "DER Watt-Var model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "DER Watt-Var control enable.",
+                "label": "DER Watt-Var Module Enable",
+                "mandatory": "M",
+                "name": "Ena",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "Function is disabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Function is enabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Set active curve. 0 = No active curve.",
+                "label": "Set Active Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Result of last set active curve operation.",
+                "label": "Set Active Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "size": 1,
+                "static": "S",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Number of curve points supported.",
+                "label": "Number Of Points",
+                "mandatory": "M",
+                "name": "NPt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCrv",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "label": "Reversion Timeout",
+                "name": "RvrtTms",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "desc": "Reversion time remaining in seconds.",
+                "label": "Reversion Time Left",
+                "name": "RvrtRem",
+                "size": 2,
+                "type": "uint32",
+                "units": "Secs"
+            },
+            {
+                "access": "RW",
+                "desc": "Default curve after reversion timeout.",
+                "label": "Reversion Curve",
+                "name": "RvrtCrv",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve active power points.",
+                "label": "Active Power Scale Factor",
+                "mandatory": "M",
+                "name": "W_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for curve var points.",
+                "label": "Var Scale Factor",
+                "mandatory": "M",
+                "name": "DeptRef_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 712
+}

--- a/models/model_713.json
+++ b/models/model_713.json
@@ -1,0 +1,110 @@
+{
+    "group": {
+        "desc": "DER storage capacity.",
+        "label": "DER Storage Capacity",
+        "name": "DERStorageCapacity",
+        "points": [
+            {
+                "desc": "DER storage capacity model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 713
+            },
+            {
+                "desc": "DER storage capacity model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 7
+            },
+            {
+                "desc": "Energy rating of the DER storage.",
+                "label": "Energy Rating",
+                "name": "WHRtg",
+                "sf": "WH_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "WH"
+            },
+            {
+                "desc": "Energy available of the DER storage (WHAvail = WHRtg * SoC * SoH)",
+                "label": "Energy Available",
+                "name": "WHAvail",
+                "sf": "WH_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "WH"
+            },
+            {
+                "desc": "State of charge of the DER storage.",
+                "label": "State of Charge",
+                "name": "SoC",
+                "sf": "Pct_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "desc": "State of health of the DER storage.",
+                "label": "State of Health",
+                "name": "SoH",
+                "sf": "Pct_SF",
+                "size": 1,
+                "type": "uint16",
+                "units": "Pct"
+            },
+            {
+                "desc": "Storage status.",
+                "label": "Status",
+                "name": "Sta",
+                "size": 1,
+                "symbols": [
+                    {
+                        "desc": "No warnings or errors pending.",
+                        "label": "OK",
+                        "name": "OK",
+                        "value": 0
+                    },
+                    {
+                        "desc": "One or more warnings pending.",
+                        "label": "Warning",
+                        "name": "WARNING",
+                        "value": 1
+                    },
+                    {
+                        "desc": "One or more errors pending.",
+                        "label": "Error",
+                        "name": "ERROR",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Scale factor for energy capacity.",
+                "label": "Energy Scale Factor",
+                "name": "WH_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Scale factor for percentage.",
+                "label": "Percent Scale Factor",
+                "name": "Pct_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 713
+}

--- a/models/model_714.json
+++ b/models/model_714.json
@@ -1,0 +1,356 @@
+{
+    "group": {
+        "desc": "DER DC measurement.",
+        "groups": [
+            {
+                "comments": [
+                    "DC Port"
+                ],
+                "count": "NPrt",
+                "name": "Prt",
+                "points": [
+                    {
+                        "desc": "Port type.",
+                        "label": "Port Type",
+                        "name": "PrtTyp",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "label": "Photovoltaic",
+                                "name": "PV",
+                                "value": 0
+                            },
+                            {
+                                "label": "Energy Storage System",
+                                "name": "ESS",
+                                "value": 1
+                            },
+                            {
+                                "label": "Electric Vehicle",
+                                "name": "EV",
+                                "value": 2
+                            },
+                            {
+                                "label": "Generic Injecting",
+                                "name": "INJ",
+                                "value": 3
+                            },
+                            {
+                                "label": "Generic Absorbing",
+                                "name": "ABS",
+                                "value": 4
+                            },
+                            {
+                                "label": "Generic Bidirectional",
+                                "name": "BIDIR",
+                                "value": 5
+                            },
+                            {
+                                "label": "DC to DC",
+                                "name": "DC_DC",
+                                "value": 6
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "desc": "Port ID.",
+                        "label": "Port ID",
+                        "name": "ID",
+                        "size": 1,
+                        "type": "uint16"
+                    },
+                    {
+                        "desc": "Port ID string.",
+                        "label": "Port ID String",
+                        "name": "IDStr",
+                        "size": 8,
+                        "type": "string"
+                    },
+                    {
+                        "desc": "DC current for the port.",
+                        "label": "DC Current",
+                        "name": "DCA",
+                        "sf": "DCA_SF",
+                        "size": 1,
+                        "type": "int16",
+                        "units": "A"
+                    },
+                    {
+                        "desc": "DC voltage for the port.",
+                        "label": "DC Voltage",
+                        "name": "DCV",
+                        "sf": "DCV_SF",
+                        "size": 1,
+                        "type": "uint16",
+                        "units": "V"
+                    },
+                    {
+                        "desc": "DC power for the port.",
+                        "label": "DC Power",
+                        "name": "DCW",
+                        "sf": "DCW_SF",
+                        "size": 1,
+                        "type": "int16",
+                        "units": "W"
+                    },
+                    {
+                        "desc": "Total cumulative DC energy injected for the port.",
+                        "label": "DC Energy Injected",
+                        "name": "DCWhInj",
+                        "sf": "DCWH_SF",
+                        "size": 4,
+                        "type": "uint64",
+                        "units": "Wh"
+                    },
+                    {
+                        "desc": "Total cumulative DC energy absorbed for the port.",
+                        "label": "DC Energy Absorbed",
+                        "name": "DCWhAbs",
+                        "sf": "DCWH_SF",
+                        "size": 4,
+                        "type": "uint64",
+                        "units": "Wh"
+                    },
+                    {
+                        "desc": "DC port temperature.",
+                        "label": "DC Port Temperature",
+                        "name": "Tmp",
+                        "sf": "Tmp_SF",
+                        "size": 1,
+                        "type": "int16",
+                        "units": "C"
+                    },
+                    {
+                        "desc": "DC port status.",
+                        "label": "DC Port Status",
+                        "name": "DCSta",
+                        "size": 1,
+                        "symbols": [
+                            {
+                                "label": "Off",
+                                "name": "OFF",
+                                "value": 0
+                            },
+                            {
+                                "label": "On",
+                                "name": "ON",
+                                "value": 1
+                            },
+                            {
+                                "label": "Warning",
+                                "name": "WARNING",
+                                "value": 2
+                            },
+                            {
+                                "label": "Error",
+                                "name": "ERROR",
+                                "value": 3
+                            }
+                        ],
+                        "type": "enum16"
+                    },
+                    {
+                        "desc": "DC port alarm.",
+                        "label": "DC Port Alarm",
+                        "name": "DCAlrm",
+                        "size": 2,
+                        "symbols": [
+                            {
+                                "label": "Ground Fault",
+                                "name": "GROUND_FAULT",
+                                "value": 0
+                            },
+                            {
+                                "label": "Input Over Voltage",
+                                "name": "INPUT_OVER_VOLTAGE",
+                                "value": 1
+                            },
+                            {
+                                "label": "DC Disconnect",
+                                "name": "DC_DISCONNECT",
+                                "value": 3
+                            },
+                            {
+                                "label": "Cabinet Open",
+                                "name": "CABINET_OPEN",
+                                "value": 5
+                            },
+                            {
+                                "label": "Manual Shutdown",
+                                "name": "MANUAL_SHUTDOWN",
+                                "value": 6
+                            },
+                            {
+                                "label": "Over Temperature",
+                                "name": "OVER_TEMP",
+                                "value": 7
+                            },
+                            {
+                                "label": "Blown Fuse",
+                                "name": "BLOWN_FUSE",
+                                "value": 12
+                            },
+                            {
+                                "label": "Under Temperature",
+                                "name": "UNDER_TEMP",
+                                "value": 13
+                            },
+                            {
+                                "label": "Memory Loss",
+                                "name": "MEMORY_LOSS",
+                                "value": 14
+                            },
+                            {
+                                "label": "Arc Detection",
+                                "name": "ARC_DETECTION",
+                                "value": 15
+                            },
+                            {
+                                "label": "Reserved",
+                                "name": "RESERVED",
+                                "value": 19
+                            },
+                            {
+                                "label": "Test Failed",
+                                "name": "TEST_FAILED",
+                                "value": 20
+                            },
+                            {
+                                "label": "Under Voltage",
+                                "name": "INPUT_UNDER_VOLTAGE",
+                                "value": 21
+                            },
+                            {
+                                "label": "Over Current",
+                                "name": "INPUT_OVER_CURRENT",
+                                "value": 22
+                            }
+                        ],
+                        "type": "bitfield32"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
+        "label": "DER DC Measurement",
+        "name": "DERMeasureDC",
+        "points": [
+            {
+                "desc": "DER DC measurement model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "static": "S",
+                "type": "uint16",
+                "value": 714
+            },
+            {
+                "desc": "DER DC measurement model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "comments": [
+                    "DC General"
+                ],
+                "desc": "Bitfield of ports with active alarms. Bit is 1 if port has an active alarm. Bit 0 is first port.",
+                "label": "Port Alarms",
+                "name": "PrtAlrms",
+                "size": 2,
+                "type": "bitfield32"
+            },
+            {
+                "desc": "Number of DC ports.",
+                "label": "Number Of Ports",
+                "name": "NPrt",
+                "size": 1,
+                "static": "S",
+                "type": "uint16"
+            },
+            {
+                "desc": "Total DC current for all ports.",
+                "label": "DC Current",
+                "name": "DCA",
+                "sf": "DCA_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "A"
+            },
+            {
+                "desc": "Total DC power for all ports.",
+                "label": "DC Power",
+                "name": "DCW",
+                "sf": "DCW_SF",
+                "size": 1,
+                "type": "int16",
+                "units": "W"
+            },
+            {
+                "desc": "Total cumulative DC energy injected for all ports.",
+                "label": "DC Energy Injected",
+                "name": "DCWhInj",
+                "sf": "DCWH_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "Total cumulative DC energy absorbed for all ports.",
+                "label": "DC Energy Absorbed",
+                "name": "DCWhAbs",
+                "sf": "DCWH_SF",
+                "size": 4,
+                "type": "uint64",
+                "units": "Wh"
+            },
+            {
+                "desc": "DC current scale factor.",
+                "label": "DC Current Scale Factor",
+                "name": "DCA_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "DC voltage scale factor.",
+                "label": "DC Voltage Scale Factor",
+                "name": "DCV_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "DC power scale factor.",
+                "label": "DC Power Scale Factor",
+                "name": "DCW_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "DC energy scale factor.",
+                "label": "DC Energy Scale Factor",
+                "name": "DCWH_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Temperature Scale Factor.",
+                "label": "Temperature Scale Factor",
+                "name": "Tmp_SF",
+                "size": 1,
+                "static": "S",
+                "type": "sunssf"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 714
+}

--- a/models/model_715.json
+++ b/models/model_715.json
@@ -1,0 +1,105 @@
+{
+    "group": {
+        "desc": "DER Control",
+        "label": "DERCtl",
+        "name": "DERCtl",
+        "points": [
+            {
+                "desc": "DER control model ID.",
+                "label": "Model ID",
+                "mandatory": "M",
+                "name": "ID",
+                "size": 1,
+                "type": "uint16",
+                "value": 715
+            },
+            {
+                "desc": "DER control model length.",
+                "label": "Model Length",
+                "mandatory": "M",
+                "name": "L",
+                "size": 1,
+                "type": "uint16",
+                "value": 7
+            },
+            {
+                "comments": [
+                    "DER Controls"
+                ],
+                "desc": "DER control mode. Enumeration.",
+                "label": "Control Mode",
+                "name": "LocRemCtl",
+                "size": 1,
+                "symbols": [
+                    {
+                        "label": "Remote Control",
+                        "name": "REMOTE",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Local mode is required for manual/maintenance operations. Once invoked, it must be explicitly exited for the inverter to be controlled remotely.",
+                        "label": "Local Control",
+                        "name": "LOCAL",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "desc": "Value is incremented every second by the DER with periodic resets to zero.",
+                "label": "DER Heartbeat",
+                "name": "DERHb",
+                "size": 2,
+                "type": "uint32"
+            },
+            {
+                "access": "RW",
+                "desc": "Value is incremented every second by the controller with periodic resets to zero.",
+                "label": "Controller Heartbeat",
+                "name": "ControllerHb",
+                "size": 2,
+                "type": "uint32"
+            },
+            {
+                "access": "RW",
+                "desc": "Used to reset any latched alarms. 1 = Reset.",
+                "label": "Alarm Reset",
+                "name": "AlarmReset",
+                "size": 1,
+                "type": "uint16"
+            },
+            {
+                "access": "RW",
+                "desc": "Commands to PCS. Enumerated value.",
+                "label": "Set Operation",
+                "name": "OpCtl",
+                "size": 1,
+                "symbols": [
+                    {
+                        "label": "Stop the DER",
+                        "name": "STOP",
+                        "value": 0
+                    },
+                    {
+                        "label": "Start the DER",
+                        "name": "START",
+                        "value": 1
+                    },
+                    {
+                        "label": "Enter Standby Mode",
+                        "name": "ENTER_STANDBY",
+                        "value": 2
+                    },
+                    {
+                        "label": "Exit Standby Mode",
+                        "name": "EXIT_STANDBY",
+                        "value": 3
+                    }
+                ],
+                "type": "enum16"
+            }
+        ],
+        "type": "group"
+    },
+    "id": 715
+}

--- a/models/model_8.json
+++ b/models/model_8.json
@@ -1,0 +1,80 @@
+{
+  "group": {
+    "name": "model_8",
+    "type": "group",
+    "label": "Get Device Security Certificate",
+    "desc": "Security model for PKI",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 8
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Fmt",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Format",
+        "desc": "X.509 format of the certificate. DER or PEM.",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE"
+          },
+          {
+            "name": "X509_PEM",
+            "value": 1,
+            "label": "PEM"
+          },
+          {
+            "name": "X509_DER",
+            "value": 2,
+            "label": "DER"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers to follow for the certificate"
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "Cert",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Cert",
+            "desc": "X.509 Certificate of the device"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 8
+}

--- a/models/model_801.json
+++ b/models/model_801.json
@@ -1,0 +1,38 @@
+{
+  "group": {
+    "name": "storage",
+    "type": "group",
+    "label": "Energy Storage Base Model (DEPRECATED)",
+    "desc": "This model has been deprecated.",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 801
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "DEPRECATED",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Deprecated Model",
+        "desc": "This model has been deprecated."
+      }
+    ]
+  },
+  "id": 801
+}

--- a/models/model_802.json
+++ b/models/model_802.json
@@ -1,0 +1,886 @@
+{
+  "group": {
+    "name": "battery",
+    "type": "group",
+    "label": "Battery Base Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 802
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "AHRtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AHRtg_SF",
+        "units": "Ah",
+        "mandatory": "M",
+        "label": "Nameplate Charge Capacity",
+        "desc": "Nameplate charge capacity in amp-hours."
+      },
+      {
+        "name": "WHRtg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WHRtg_SF",
+        "units": "Wh",
+        "mandatory": "M",
+        "label": "Nameplate Energy Capacity",
+        "desc": "Nameplate energy capacity in DC watt-hours."
+      },
+      {
+        "name": "WChaRteMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WChaDisChaMax_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Nameplate Max Charge Rate",
+        "desc": "Maximum rate of energy transfer into the storage device in DC watts."
+      },
+      {
+        "name": "WDisChaRteMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "WChaDisChaMax_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Nameplate Max Discharge Rate",
+        "desc": "Maximum rate of energy transfer out of the storage device in DC watts."
+      },
+      {
+        "name": "DisChaRte",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DisChaRte_SF",
+        "units": "%WHRtg",
+        "label": "Self Discharge Rate",
+        "desc": "Self discharge rate.  Percentage of capacity (WHRtg) discharged per day."
+      },
+      {
+        "name": "SoCMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%WHRtg",
+        "access": "RW",
+        "label": "Nameplate Max SoC",
+        "desc": "Manufacturer maximum state of charge, expressed as a percentage."
+      },
+      {
+        "name": "SoCMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%WHRtg",
+        "access": "RW",
+        "label": "Nameplate Min SoC",
+        "desc": "Manufacturer minimum state of charge, expressed as a percentage."
+      },
+      {
+        "name": "SoCRsvMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%WHRtg",
+        "access": "RW",
+        "label": "Max Reserve Percent",
+        "desc": "Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage."
+      },
+      {
+        "name": "SoCRsvMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%WHRtg",
+        "access": "RW",
+        "label": "Min Reserve Percent",
+        "desc": "Setpoint for minimum reserve for storage as a percentage of the nominal maximum storage."
+      },
+      {
+        "name": "SoC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%WHRtg",
+        "mandatory": "M",
+        "label": "State of Charge",
+        "desc": "State of charge, expressed as a percentage."
+      },
+      {
+        "name": "DoD",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DoD_SF",
+        "units": "%",
+        "label": "Depth of Discharge",
+        "desc": "Depth of discharge, expressed as a percentage."
+      },
+      {
+        "name": "SoH",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoH_SF",
+        "units": "%",
+        "label": "State of Health",
+        "desc": "Percentage of battery life remaining."
+      },
+      {
+        "name": "NCyc",
+        "type": "uint32",
+        "size": 2,
+        "label": "Cycle Count",
+        "desc": "Number of cycles executed in the battery."
+      },
+      {
+        "name": "ChaSt",
+        "type": "enum16",
+        "size": 1,
+        "label": "Charge Status",
+        "desc": "Charge status of storage device. Enumeration.",
+        "symbols": [
+          {
+            "name": "OFF",
+            "value": 1
+          },
+          {
+            "name": "EMPTY",
+            "value": 2
+          },
+          {
+            "name": "DISCHARGING",
+            "value": 3
+          },
+          {
+            "name": "CHARGING",
+            "value": 4
+          },
+          {
+            "name": "FULL",
+            "value": 5
+          },
+          {
+            "name": "HOLDING",
+            "value": 6
+          },
+          {
+            "name": "TESTING",
+            "value": 7
+          }
+        ]
+      },
+      {
+        "name": "LocRemCtl",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Control Mode",
+        "desc": "Battery control mode. Enumeration.",
+        "symbols": [
+          {
+            "name": "REMOTE",
+            "value": 0,
+            "label": "Remote Control",
+            "desc": "Battery is controlled remotely (e.g. by the site controller)."
+          },
+          {
+            "name": "LOCAL",
+            "value": 1,
+            "label": "Local Control",
+            "desc": "Battery is controlled by a local operator (e.g. through battery HMI)."
+          }
+        ]
+      },
+      {
+        "name": "Hb",
+        "type": "uint16",
+        "size": 1,
+        "label": "Battery Heartbeat",
+        "desc": "Value is incremented every second with periodic resets to zero."
+      },
+      {
+        "name": "CtrlHb",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "label": "Controller Heartbeat",
+        "desc": "Value is incremented every second with periodic resets to zero."
+      },
+      {
+        "name": "AlmRst",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Alarm Reset",
+        "desc": "Used to reset any latched alarms.  1 = Reset."
+      },
+      {
+        "name": "Typ",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Battery Type",
+        "desc": "Type of battery. Enumeration.",
+        "symbols": [
+          {
+            "name": "NOT APPLICABLE_UNKNOWN",
+            "value": 0,
+            "label": "Not Applicable or Unknown",
+            "desc": "Battery type is not applicable or unknown."
+          },
+          {
+            "name": "LEAD_ACID",
+            "value": 1,
+            "label": "Lead-Acid",
+            "desc": "Lead-acid battery type."
+          },
+          {
+            "name": "NICKEL_METAL_HYDRATE",
+            "value": 2,
+            "label": "Nickel-Metal Hydrate",
+            "desc": "Nickel-metal hydrate battery type."
+          },
+          {
+            "name": "NICKEL_CADMIUM",
+            "value": 3,
+            "label": "Nickel-Cadmium",
+            "desc": "Nickel-cadmium battery type."
+          },
+          {
+            "name": "LITHIUM_ION",
+            "value": 4,
+            "label": "Lithium-Ion",
+            "desc": "Lithium-ion battery type."
+          },
+          {
+            "name": "CARBON_ZINC",
+            "value": 5,
+            "label": "Carbon-Zinc",
+            "desc": "Carbon-zinc battery type."
+          },
+          {
+            "name": "ZINC_CHLORIDE",
+            "value": 6,
+            "label": "Zinc Chloride",
+            "desc": "Zinc chloride battery type."
+          },
+          {
+            "name": "ALKALINE",
+            "value": 7,
+            "label": "Alkaline",
+            "desc": "Alkaline battery type."
+          },
+          {
+            "name": "RECHARGEABLE_ALKALINE",
+            "value": 8,
+            "label": "Rechargeable Alkaline",
+            "desc": "Rechargeable alkaline battery type."
+          },
+          {
+            "name": "SODIUM_SULFUR",
+            "value": 9,
+            "label": "Sodium-Sulfur",
+            "desc": "Sodium-sulfur battery type."
+          },
+          {
+            "name": "FLOW",
+            "value": 10,
+            "label": "Flow",
+            "desc": "Flow battery type."
+          },
+          {
+            "name": "OTHER",
+            "value": 99,
+            "label": "Other",
+            "desc": "Other battery type."
+          }
+        ]
+      },
+      {
+        "name": "State",
+        "type": "enum16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "State of the Battery Bank",
+        "desc": "State of the battery bank.  Enumeration.",
+        "symbols": [
+          {
+            "name": "DISCONNECTED",
+            "value": 1,
+            "label": "Disconnected",
+            "desc": "Battery bank is disconnected. All contactors are open."
+          },
+          {
+            "name": "INITIALIZING",
+            "value": 2,
+            "label": "Initializing",
+            "desc": "Battery bank is initializing but not ready for operating. String balancing may occur."
+          },
+          {
+            "name": "CONNECTED",
+            "value": 3,
+            "label": "Connected",
+            "desc": "Battery bank is ready for operation. All enabled contactors are closed."
+          },
+          {
+            "name": "STANDBY",
+            "value": 4,
+            "label": "Standby",
+            "desc": "Battery bank is connected and in standby/power saving mode."
+          },
+          {
+            "name": "SOC PROTECTION",
+            "value": 5,
+            "label": "SoC Protection",
+            "desc": "Battery bank is connected but SoC is too low. Battery should be considered \"offline\"."
+          },
+          {
+            "name": "SUSPENDING",
+            "value": 6,
+            "label": "Suspending",
+            "desc": "Battery bank is suspending operation and will disconnect."
+          },
+          {
+            "name": "FAULT",
+            "value": 99,
+            "label": "Fault",
+            "desc": "The battery has experienced a critical failure and may not be operated."
+          }
+        ]
+      },
+      {
+        "name": "StateVnd",
+        "type": "enum16",
+        "size": 1,
+        "label": "Vendor Battery Bank State",
+        "desc": "Vendor specific battery bank state.  Enumeration."
+      },
+      {
+        "name": "WarrDt",
+        "type": "uint32",
+        "size": 2,
+        "label": "Warranty Date",
+        "desc": "Date the device warranty expires."
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Battery Event 1 Bitfield",
+        "desc": "Alarms and warnings.  Bit flags.",
+        "symbols": [
+          {
+            "name": "COMMUNICATION_ERROR",
+            "value": 0,
+            "label": "Communication Error",
+            "desc": "Unable to communicate with BMS or BMS is unable to communicate with battery strings."
+          },
+          {
+            "name": "OVER_TEMP_ALARM",
+            "value": 1,
+            "label": "Over Temperature Alarm",
+            "desc": "Battery has exceeded maximum operating temperature"
+          },
+          {
+            "name": "OVER_TEMP_WARNING",
+            "value": 2,
+            "label": "Over Temperature  Warning",
+            "desc": "Battery is approaching maximum operating temperature."
+          },
+          {
+            "name": "UNDER_TEMP_ALARM",
+            "value": 3,
+            "label": "Under Temperature Alarm",
+            "desc": "Battery has exceeded minimum operating temperature"
+          },
+          {
+            "name": "UNDER_TEMP_WARNING",
+            "value": 4,
+            "label": "Under Temperature Warning",
+            "desc": "Battery is approaching minimum operating temperature."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_ALARM",
+            "value": 5,
+            "label": "Over Charge Current Alarm",
+            "desc": "Battery maximum charge current has been exceeded."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_WARNING",
+            "value": 6,
+            "label": "Over Charge Current Warning",
+            "desc": "Approaching battery maximum charge current."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_ALARM",
+            "value": 7,
+            "label": "Over Discharge Current Alarm",
+            "desc": "Battery maximum discharge current has been exceeded."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_WARNING",
+            "value": 8,
+            "label": "Over Discharge Current Warning",
+            "desc": "Approaching battery maximum discharge current."
+          },
+          {
+            "name": "OVER_VOLT_ALARM",
+            "value": 9,
+            "label": "Over Voltage Alarm",
+            "desc": "Battery voltage has exceeded maximum limit."
+          },
+          {
+            "name": "OVER_VOLT_WARNING",
+            "value": 10,
+            "label": "Over Voltage Warning",
+            "desc": "Battery voltage is approaching maximum limit."
+          },
+          {
+            "name": "UNDER_VOLT_ALARM",
+            "value": 11,
+            "label": "Under Voltage Alarm",
+            "desc": "Battery voltage has exceeded minimum limit."
+          },
+          {
+            "name": "UNDER_VOLT_WARNING",
+            "value": 12,
+            "label": "Under Voltage Warning",
+            "desc": "Battery voltage is approaching minimum limit."
+          },
+          {
+            "name": "UNDER_SOC_MIN_ALARM",
+            "value": 13,
+            "label": "Under State of Charge Min Alarm",
+            "desc": "Battery state of charge has reached or exceeded SoCMin"
+          },
+          {
+            "name": "UNDER_SOC_MIN_WARNING",
+            "value": 14,
+            "label": "Under State of Charge Min Warning",
+            "desc": "Battery state of charge is approaching SoCMin"
+          },
+          {
+            "name": "OVER_SOC_MAX_ALARM",
+            "value": 15,
+            "label": "Over State of Charge Max Alarm",
+            "desc": "Battery state of charge has reached or exceeded SoCMax"
+          },
+          {
+            "name": "OVER_SOC_MAX_WARNING",
+            "value": 16,
+            "label": "Over State of Charge Max Warning",
+            "desc": "Battery state of charge is approaching SoCMax"
+          },
+          {
+            "name": "VOLTAGE_IMBALANCE_WARNING",
+            "value": 17,
+            "label": "Voltage Imbalance Warning",
+            "desc": "A voltage imbalance exists between the strings in the battery bank."
+          },
+          {
+            "name": "TEMPERATURE_IMBALANCE_ALARM",
+            "value": 18,
+            "label": "Temperature Imbalance Alarm",
+            "desc": "A temperature imbalance exists between the strings in the battery bank."
+          },
+          {
+            "name": "TEMPERATURE_IMBALANCE_WARNING",
+            "value": 19,
+            "label": "Temperature Imbalance Warning",
+            "desc": "A temperature imbalance is developing between the strings in the battery bank."
+          },
+          {
+            "name": "CONTACTOR_ERROR",
+            "value": 20,
+            "label": "Contactor Error",
+            "desc": "A contactor failed to open or close as requested."
+          },
+          {
+            "name": "FAN_ERROR",
+            "value": 21,
+            "label": "Fan Error",
+            "desc": "One or more battery fans has failed."
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 22,
+            "label": "Ground Fault Error",
+            "desc": "Ground fault detected."
+          },
+          {
+            "name": "OPEN_DOOR_ERROR",
+            "value": 23,
+            "label": "Open Door Error",
+            "desc": "One or more doors are open."
+          },
+          {
+            "name": "CURRENT_IMBALANCE_WARNING",
+            "value": 24,
+            "label": "Current Imbalance Warning",
+            "desc": "A current imbalance exists between the strings in the battery bank."
+          },
+          {
+            "name": "OTHER_ALARM",
+            "value": 25,
+            "label": "Other Battery Alarm",
+            "desc": "A vendor specific alarm has occurred."
+          },
+          {
+            "name": "OTHER_WARNING",
+            "value": 26,
+            "label": "Other Battery Warning",
+            "desc": "A vendor specific warning has occurred."
+          },
+          {
+            "name": "RESERVED_1",
+            "value": 27,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "CONFIGURATION_ALARM",
+            "value": 28,
+            "label": "Configuration Alarm",
+            "desc": "The battery bank has been configured incorrectly and will not operate."
+          },
+          {
+            "name": "CONFIGURATION_WARNING",
+            "value": 29,
+            "label": "Configuration Warning",
+            "desc": "The battery bank has been configured incorrectly and may not operated as expected."
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Battery Event 2 Bitfield",
+        "desc": "Alarms and warnings.  Bit flags."
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "External Battery Voltage",
+        "desc": "DC Bus Voltage."
+      },
+      {
+        "name": "VMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Max Battery Voltage",
+        "desc": "Instantaneous maximum battery voltage."
+      },
+      {
+        "name": "VMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Min Battery Voltage",
+        "desc": "Instantaneous minimum battery voltage."
+      },
+      {
+        "name": "CellVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Max Cell Voltage",
+        "desc": "Maximum voltage for all cells in the bank."
+      },
+      {
+        "name": "CellVMaxStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage String",
+        "desc": "String containing the cell with maximum voltage."
+      },
+      {
+        "name": "CellVMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage Module",
+        "desc": "Module containing the cell with maximum voltage."
+      },
+      {
+        "name": "CellVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Min Cell Voltage",
+        "desc": "Minimum voltage for all cells in the bank."
+      },
+      {
+        "name": "CellVMinStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage String",
+        "desc": "String containing the cell with minimum voltage."
+      },
+      {
+        "name": "CellVMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage Module",
+        "desc": "Module containing the cell with minimum voltage."
+      },
+      {
+        "name": "CellVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Average Cell Voltage",
+        "desc": "Average cell voltage for all cells in the bank."
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "Total DC Current",
+        "desc": "Total DC current flowing to/from the battery bank."
+      },
+      {
+        "name": "AChaMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AMax_SF",
+        "units": "A",
+        "access": "RW",
+        "label": "Max Charge Current",
+        "desc": "Instantaneous maximum DC charge current."
+      },
+      {
+        "name": "ADisChaMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "AMax_SF",
+        "units": "A",
+        "access": "RW",
+        "label": "Max Discharge Current",
+        "desc": "Instantaneous maximum DC discharge current."
+      },
+      {
+        "name": "W",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "mandatory": "M",
+        "label": "Total Power",
+        "desc": "Total power flowing to/from the battery bank."
+      },
+      {
+        "name": "ReqInvState",
+        "type": "enum16",
+        "size": 1,
+        "label": "Inverter State Request",
+        "desc": "Request from battery to start or stop the inverter.  Enumeration.",
+        "symbols": [
+          {
+            "name": "NO REQUEST",
+            "value": 0,
+            "label": "No Request",
+            "desc": "Battery has no requests of the inverter."
+          },
+          {
+            "name": "START",
+            "value": 1,
+            "label": "Start Inverter",
+            "desc": "Battery requests that the inverter be started."
+          },
+          {
+            "name": "STOP",
+            "value": 2,
+            "label": "Stop Inverter",
+            "desc": "Battery requests that the inverter be stopped."
+          }
+        ]
+      },
+      {
+        "name": "ReqW",
+        "type": "int16",
+        "size": 1,
+        "sf": "W_SF",
+        "units": "W",
+        "label": "Battery Power Request",
+        "desc": "AC Power requested by battery."
+      },
+      {
+        "name": "SetOp",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Set Operation",
+        "desc": "Instruct the battery bank to perform an operation such as connecting.  Enumeration.",
+        "symbols": [
+          {
+            "name": "CONNECT",
+            "value": 1,
+            "label": "Connect the Battery Bank",
+            "desc": "Initialize the battery bank and close contactors for all enabled strings."
+          },
+          {
+            "name": "DISCONNECT",
+            "value": 2,
+            "label": "Disconnect the Battery Bank",
+            "desc": "Open contactors for all strings."
+          }
+        ]
+      },
+      {
+        "name": "SetInvState",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Set Inverter State",
+        "desc": "Set the current state of the inverter.",
+        "symbols": [
+          {
+            "name": "INVERTER_STOPPED",
+            "value": 1,
+            "label": "Inverter is Stopped"
+          },
+          {
+            "name": "INVERTER_STANDBY",
+            "value": 2,
+            "label": "Inverter is in Standby"
+          },
+          {
+            "name": "INVERTER_STARTED",
+            "value": 3,
+            "label": "Inverter is Started"
+          }
+        ]
+      },
+      {
+        "name": "AHRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for charge capacity."
+      },
+      {
+        "name": "WHRtg_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for energy capacity."
+      },
+      {
+        "name": "WChaDisChaMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for maximum charge and discharge rate."
+      },
+      {
+        "name": "DisChaRte_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for self discharge rate."
+      },
+      {
+        "name": "SoC_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for state of charge values."
+      },
+      {
+        "name": "DoD_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for depth of discharge."
+      },
+      {
+        "name": "SoH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for state of health."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for DC bus voltage."
+      },
+      {
+        "name": "CellV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for cell voltage."
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for DC current."
+      },
+      {
+        "name": "AMax_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for instantaneous DC charge/discharge current."
+      },
+      {
+        "name": "W_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for AC power request."
+      }
+    ]
+  },
+  "id": 802
+}

--- a/models/model_803.json
+++ b/models/model_803.json
@@ -1,0 +1,920 @@
+{
+  "group": {
+    "name": "lithium_ion_bank",
+    "type": "group",
+    "label": "Lithium-Ion Battery Bank Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 803
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "NStr",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "String Count",
+        "desc": "Number of strings in the bank."
+      },
+      {
+        "name": "NStrCon",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Connected String Count",
+        "desc": "Number of strings with contactor closed."
+      },
+      {
+        "name": "ModTmpMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "ModTmp_SF",
+        "mandatory": "M",
+        "label": "Max Module Temperature",
+        "desc": "Maximum temperature for all modules in the bank."
+      },
+      {
+        "name": "ModTmpMaxStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Module Temperature String",
+        "desc": "String containing the module with maximum temperature."
+      },
+      {
+        "name": "ModTmpMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Module Temperature Module",
+        "desc": "Module with maximum temperature."
+      },
+      {
+        "name": "ModTmpMin",
+        "type": "int16",
+        "size": 1,
+        "sf": "ModTmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Min Module Temperature",
+        "desc": "Minimum temperature for all modules in the bank."
+      },
+      {
+        "name": "ModTmpMinStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Module Temperature String",
+        "desc": "String containing the module with minimum temperature."
+      },
+      {
+        "name": "ModTmpMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Module Temperature Module",
+        "desc": "Module with minimum temperature."
+      },
+      {
+        "name": "ModTmpAvg",
+        "type": "uint16",
+        "size": 1,
+        "label": "Average Module Temperature",
+        "desc": "Average temperature for all modules in the bank."
+      },
+      {
+        "name": "StrVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Max String Voltage",
+        "desc": "Maximum string voltage for all strings in the bank."
+      },
+      {
+        "name": "StrVMaxStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max String Voltage String",
+        "desc": "String with maximum voltage."
+      },
+      {
+        "name": "StrVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Min String Voltage",
+        "desc": "Minimum string voltage for all strings in the bank."
+      },
+      {
+        "name": "StrVMinStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min String Voltage String",
+        "desc": "String with minimum voltage."
+      },
+      {
+        "name": "StrVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "Average String Voltage",
+        "desc": "Average string voltage for all strings in the bank."
+      },
+      {
+        "name": "StrAMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Max String Current",
+        "desc": "Maximum current of any string in the bank."
+      },
+      {
+        "name": "StrAMaxStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max String Current String",
+        "desc": "String with the maximum current."
+      },
+      {
+        "name": "StrAMin",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Min String Current",
+        "desc": "Minimum current of any string in the bank."
+      },
+      {
+        "name": "StrAMinStr",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min String Current String",
+        "desc": "String with the minimum current."
+      },
+      {
+        "name": "StrAAvg",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "label": "Average String Current",
+        "desc": "Average string current for all strings in the bank."
+      },
+      {
+        "name": "NCellBal",
+        "type": "uint16",
+        "size": 1,
+        "label": "Battery Cell Balancing Count",
+        "desc": "Total number of cells that are currently being balanced."
+      },
+      {
+        "name": "CellV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for cell voltage."
+      },
+      {
+        "name": "ModTmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for module temperatures."
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for string currents."
+      },
+      {
+        "name": "SoH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for string state of health."
+      },
+      {
+        "name": "SoC_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for string state of charge."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for string voltage."
+      }
+    ],
+    "groups": [
+      {
+        "name": "string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "StrNMod",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Module Count",
+            "desc": "Count of modules in the string."
+          },
+          {
+            "name": "StrSt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "String Status",
+            "desc": "Current status of the string.",
+            "symbols": [
+              {
+                "name": "STRING_ENABLED",
+                "value": 0,
+                "label": "String Is Enabled",
+                "desc": "String is enabled and will connect next time battery is asked to connect."
+              },
+              {
+                "name": "CONTACTOR_STATUS",
+                "value": 1,
+                "label": "Contactor Status",
+                "desc": "String contactor is closed."
+              }
+            ]
+          },
+          {
+            "name": "StrConFail",
+            "type": "enum16",
+            "size": 1,
+            "label": "Connection Failure Reason",
+            "symbols": [
+              {
+                "name": "NO_FAILURE",
+                "value": 0,
+                "label": "No Failure",
+                "desc": "Connect did not fail."
+              },
+              {
+                "name": "BUTTON_PUSHED",
+                "value": 1,
+                "label": "Button Pushed",
+                "desc": "A button was pushed which prevented connection."
+              },
+              {
+                "name": "STR_GROUND_FAULT",
+                "value": 2,
+                "label": "Ground Fault",
+                "desc": "Ground fault during auto-connect."
+              },
+              {
+                "name": "OUTSIDE_VOLTAGE_RANGE",
+                "value": 3,
+                "label": "Outside Voltage Range",
+                "desc": "Outside voltage target window during auto-connect."
+              },
+              {
+                "name": "STRING_NOT_ENABLED",
+                "value": 4,
+                "label": "String Not Enabled",
+                "desc": "The string is not enabled."
+              },
+              {
+                "name": "FUSE_OPEN",
+                "value": 5,
+                "label": "Fuse Open",
+                "desc": "A fuse is open which prevents connection."
+              },
+              {
+                "name": "CONTACTOR_FAILURE",
+                "value": 6,
+                "label": "Contactor Failure",
+                "desc": "A contactor failed to operate."
+              },
+              {
+                "name": "PRECHARGE_FAILURE",
+                "value": 7,
+                "label": "Precharge Failure",
+                "desc": "A failure during precharge occurred."
+              },
+              {
+                "name": "STRING_FAULT",
+                "value": 8,
+                "label": "String Fault",
+                "desc": "A string fault has occurred."
+              }
+            ]
+          },
+          {
+            "name": "StrSoC",
+            "type": "uint16",
+            "size": 1,
+            "sf": "SoC_SF",
+            "units": "%",
+            "mandatory": "M",
+            "label": "String State of Charge",
+            "desc": "Battery string state of charge, expressed as a percentage."
+          },
+          {
+            "name": "StrSoH",
+            "type": "uint16",
+            "size": 1,
+            "sf": "SoH_SF",
+            "units": "%",
+            "label": "String State of Health",
+            "desc": "Battery string state of health, expressed as a percentage."
+          },
+          {
+            "name": "StrA",
+            "type": "int16",
+            "size": 1,
+            "sf": "A_SF",
+            "units": "A",
+            "mandatory": "M",
+            "label": "String Current",
+            "desc": "String current measurement."
+          },
+          {
+            "name": "StrCellVMax",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Max Cell Voltage",
+            "desc": "Maximum voltage for all cells in the string."
+          },
+          {
+            "name": "StrCellVMaxMod",
+            "type": "uint16",
+            "size": 1,
+            "label": "Max Cell Voltage Module",
+            "desc": "Module containing the maximum cell voltage."
+          },
+          {
+            "name": "StrCellVMin",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Min Cell Voltage",
+            "desc": "Minimum voltage for all cells in the string."
+          },
+          {
+            "name": "StrCellVMinMod",
+            "type": "uint16",
+            "size": 1,
+            "label": "Min Cell Voltage Module",
+            "desc": "Module containing the minimum cell voltage."
+          },
+          {
+            "name": "StrCellVAvg",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Average Cell Voltage",
+            "desc": "Average voltage for all cells in the string."
+          },
+          {
+            "name": "StrModTmpMax",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Max Module Temperature",
+            "desc": "Maximum temperature for all modules in the bank."
+          },
+          {
+            "name": "StrModTmpMaxMod",
+            "type": "uint16",
+            "size": 1,
+            "label": "Max Module Temperature Module",
+            "desc": "Module with the maximum temperature."
+          },
+          {
+            "name": "StrModTmpMin",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Min Module Temperature",
+            "desc": "Minimum temperature for all modules in the bank."
+          },
+          {
+            "name": "StrModTmpMinMod",
+            "type": "uint16",
+            "size": 1,
+            "label": "Min Module Temperature Module",
+            "desc": "Module with the minimum temperature."
+          },
+          {
+            "name": "StrModTmpAvg",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Average Module Temperature",
+            "desc": "Average temperature for all modules in the bank."
+          },
+          {
+            "name": "StrDisRsn",
+            "type": "enum16",
+            "size": 1,
+            "label": "Disabled Reason",
+            "desc": "Reason why the string is currently disabled.",
+            "symbols": [
+              {
+                "name": "NONE",
+                "value": 0,
+                "label": "No Reason",
+                "desc": "No reason provided."
+              },
+              {
+                "name": "FAULT",
+                "value": 1,
+                "label": "Fault",
+                "desc": "A fault has occurred which caused the string to be disabled."
+              },
+              {
+                "name": "MAINTENANCE",
+                "value": 2,
+                "label": "Maintenance",
+                "desc": "The string has been disabled for maintenance reasons."
+              },
+              {
+                "name": "EXTERNAL",
+                "value": 3,
+                "label": "External",
+                "desc": "The string has been disabled by an external user or controller."
+              },
+              {
+                "name": "OTHER",
+                "value": 4,
+                "label": "Other",
+                "desc": "The string has been disabled for some other reason."
+              }
+            ]
+          },
+          {
+            "name": "StrConSt",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Contactor Status",
+            "desc": "Status of the contactor(s) for the string.",
+            "symbols": [
+              {
+                "name": "CONTACTOR_0",
+                "value": 0,
+                "label": "Contactor 0 Closed"
+              },
+              {
+                "name": "CONTACTOR_1",
+                "value": 1,
+                "label": "Contactor 1 Closed"
+              },
+              {
+                "name": "CONTACTOR_2",
+                "value": 2,
+                "label": "Contactor 2 Closed"
+              },
+              {
+                "name": "CONTACTOR_3",
+                "value": 3,
+                "label": "Contactor 3 Closed"
+              },
+              {
+                "name": "CONTACTOR_4",
+                "value": 4,
+                "label": "Contactor 4 Closed"
+              },
+              {
+                "name": "CONTACTOR_5",
+                "value": 5,
+                "label": "Contactor 5 Closed"
+              },
+              {
+                "name": "CONTACTOR_6",
+                "value": 6,
+                "label": "Contactor 6 Closed"
+              },
+              {
+                "name": "CONTACTOR_7",
+                "value": 7,
+                "label": "Contactor 7 Closed"
+              },
+              {
+                "name": "CONTACTOR_8",
+                "value": 8,
+                "label": "Contactor 8 Closed"
+              },
+              {
+                "name": "CONTACTOR_9",
+                "value": 9,
+                "label": "Contactor 9 Closed"
+              },
+              {
+                "name": "CONTACTOR_10",
+                "value": 10,
+                "label": "Contactor 10 Closed"
+              },
+              {
+                "name": "CONTACTOR_11",
+                "value": 11,
+                "label": "Contactor 11 Closed"
+              },
+              {
+                "name": "CONTACTOR_12",
+                "value": 12,
+                "label": "Contactor 12 Closed"
+              },
+              {
+                "name": "CONTACTOR_13",
+                "value": 13,
+                "label": "Contactor 13 Closed"
+              },
+              {
+                "name": "CONTACTOR_14",
+                "value": 14,
+                "label": "Contactor 14 Closed"
+              },
+              {
+                "name": "CONTACTOR_15",
+                "value": 15,
+                "label": "Contactor 15 Closed"
+              },
+              {
+                "name": "CONTACTOR_16",
+                "value": 16,
+                "label": "Contactor 16 Closed"
+              },
+              {
+                "name": "CONTACTOR_17",
+                "value": 17,
+                "label": "Contactor 17 Closed"
+              },
+              {
+                "name": "CONTACTOR_18",
+                "value": 18,
+                "label": "Contactor 18 Closed"
+              },
+              {
+                "name": "CONTACTOR_19",
+                "value": 19,
+                "label": "Contactor 19 Closed"
+              },
+              {
+                "name": "CONTACTOR_20",
+                "value": 20,
+                "label": "Contactor 20 Closed"
+              },
+              {
+                "name": "CONTACTOR_21",
+                "value": 21,
+                "label": "Contactor 21 Closed"
+              },
+              {
+                "name": "CONTACTOR_22",
+                "value": 22,
+                "label": "Contactor 22 Closed"
+              },
+              {
+                "name": "CONTACTOR_23",
+                "value": 23,
+                "label": "Contactor 23 Closed"
+              },
+              {
+                "name": "CONTACTOR_24",
+                "value": 24,
+                "label": "Contactor 24 Closed"
+              },
+              {
+                "name": "CONTACTOR_25",
+                "value": 25,
+                "label": "Contactor 25 Closed"
+              },
+              {
+                "name": "CONTACTOR_26",
+                "value": 26,
+                "label": "Contactor 26 Closed"
+              },
+              {
+                "name": "CONTACTOR_27",
+                "value": 27,
+                "label": "Contactor 27 Closed"
+              },
+              {
+                "name": "CONTACTOR_28",
+                "value": 28,
+                "label": "Contactor 28 Closed"
+              },
+              {
+                "name": "CONTACTOR_29",
+                "value": 29,
+                "label": "Contactor 29 Closed"
+              },
+              {
+                "name": "CONTACTOR_30",
+                "value": 30,
+                "label": "Contactor 30 Closed"
+              }
+            ]
+          },
+          {
+            "name": "StrEvt1",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "String Event 1",
+            "desc": "Alarms, warnings and status values.  Bit flags.",
+            "symbols": [
+              {
+                "name": "COMMUNICATION_ERROR",
+                "value": 0,
+                "label": "Communication Error",
+                "desc": "String is unable to communicate with battery modules."
+              },
+              {
+                "name": "OVER_TEMP_ALARM",
+                "value": 1,
+                "label": "Over Temperature Alarm",
+                "desc": "Battery string has exceeded maximum operating temperature"
+              },
+              {
+                "name": "OVER_TEMP_WARNING",
+                "value": 2,
+                "label": "Over Temperature  Warning",
+                "desc": "Battery string is approaching maximum operating temperature."
+              },
+              {
+                "name": "UNDER_TEMP_ALARM",
+                "value": 3,
+                "label": "Under Temperature Alarm",
+                "desc": "Battery string has exceeded minimum operating temperature"
+              },
+              {
+                "name": "UNDER_TEMP_WARNING",
+                "value": 4,
+                "label": "Under Temperature Warning",
+                "desc": "Battery string is approaching minimum operating temperature."
+              },
+              {
+                "name": "OVER_CHARGE_CURRENT_ALARM",
+                "value": 5,
+                "label": "Over Charge Current Alarm",
+                "desc": "Battery string maximum charge current has been exceeded."
+              },
+              {
+                "name": "OVER_CHARGE_CURRENT_WARNING",
+                "value": 6,
+                "label": "Over Charge Current Warning",
+                "desc": "Approaching battery string maximum charge current."
+              },
+              {
+                "name": "OVER_DISCHARGE_CURRENT_ALARM",
+                "value": 7,
+                "label": "Over Discharge Current Alarm",
+                "desc": "Battery string maximum discharge current has been exceeded."
+              },
+              {
+                "name": "OVER_DISCHARGE_CURRENT_WARNING",
+                "value": 8,
+                "label": "Over Discharge Current Warning",
+                "desc": "Approaching battery string maximum discharge current."
+              },
+              {
+                "name": "OVER_VOLT_ALARM",
+                "value": 9,
+                "label": "Over Voltage Alarm",
+                "desc": "Battery string voltage has exceeded maximum limit."
+              },
+              {
+                "name": "OVER_VOLT_WARNING",
+                "value": 10,
+                "label": "Over Voltage Warning",
+                "desc": "Battery string voltage is approaching maximum limit."
+              },
+              {
+                "name": "UNDER_VOLT_ALARM",
+                "value": 11,
+                "label": "Under Voltage Alarm",
+                "desc": "Battery string voltage has exceeded minimum limit."
+              },
+              {
+                "name": "UNDER_VOLT_WARNING",
+                "value": 12,
+                "label": "Under Voltage Warning",
+                "desc": "Battery string voltage is approaching minimum limit."
+              },
+              {
+                "name": "UNDER_SOC_MIN_ALARM",
+                "value": 13,
+                "label": "Under State of Charge Min Alarm",
+                "desc": "Battery string state of charge has reached or exceeded SoCMin"
+              },
+              {
+                "name": "UNDER_SOC_MIN_WARNING",
+                "value": 14,
+                "label": "Under State of Charge Min Warning",
+                "desc": "Battery string state of charge is approaching SoCMin"
+              },
+              {
+                "name": "OVER_SOC_MAX_ALARM",
+                "value": 15,
+                "label": "Over State of Charge Max Alarm",
+                "desc": "Battery string state of charge has reached or exceeded SoCMax"
+              },
+              {
+                "name": "OVER_SOC_MAX_WARNING",
+                "value": 16,
+                "label": "Over State of Charge Max Warning",
+                "desc": "Battery string state of charge is approaching SoCMax"
+              },
+              {
+                "name": "VOLTAGE_IMBALANCE_WARNING",
+                "value": 17,
+                "label": "Voltage Imbalance Warning",
+                "desc": "A voltage imbalance exists between the modules in the battery string."
+              },
+              {
+                "name": "TEMPERATURE_IMBALANCE_ALARM",
+                "value": 18,
+                "label": "Temperature Imbalance Alarm",
+                "desc": "A temperature imbalance exists between the modules in the battery string."
+              },
+              {
+                "name": "TEMPERATURE_IMBALANCE_WARNING",
+                "value": 19,
+                "label": "Temperature Imbalance Warning",
+                "desc": "A temperature imbalance is developing between the modules in the battery string."
+              },
+              {
+                "name": "CONTACTOR_ERROR",
+                "value": 20,
+                "label": "Contactor Error",
+                "desc": "A contactor failed to open or close as requested."
+              },
+              {
+                "name": "FAN_ERROR",
+                "value": 21,
+                "label": "Fan Error",
+                "desc": "One or more battery fans has failed."
+              },
+              {
+                "name": "GROUND_FAULT",
+                "value": 22,
+                "label": "Ground Fault Error",
+                "desc": "Ground fault detected."
+              },
+              {
+                "name": "OPEN_DOOR_ERROR",
+                "value": 23,
+                "label": "Open Door Error",
+                "desc": "One or more doors are open."
+              },
+              {
+                "name": "RESERVED_1",
+                "value": 24,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "OTHER_ALARM",
+                "value": 25,
+                "label": "Other String Alarm",
+                "desc": "A vendor specific alarm has occurred."
+              },
+              {
+                "name": "OTHER_WARNING",
+                "value": 26,
+                "label": "Other String Warning",
+                "desc": "A vendor specific warning has occurred."
+              },
+              {
+                "name": "RESERVED_2",
+                "value": 27,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "CONFIGURATION_ALARM",
+                "value": 28,
+                "label": "Configuration Alarm",
+                "desc": "The battery string has been configured incorrectly and will not operate."
+              },
+              {
+                "name": "CONFIGURATION_WARNING",
+                "value": 29,
+                "label": "Configuration Warning",
+                "desc": "The battery string has been configured incorrectly and may not operate as expected."
+              }
+            ]
+          },
+          {
+            "name": "StrEvt2",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "String Event 2",
+            "desc": "Alarms, warnings and status values.  Bit flags."
+          },
+          {
+            "name": "StrEvtVnd1",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Vendor String Event Bitfield 1",
+            "desc": "Vendor defined events."
+          },
+          {
+            "name": "StrEvtVnd2",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Vendor String Event Bitfield 2",
+            "desc": "Vendor defined events."
+          },
+          {
+            "name": "StrSetEna",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Enable/Disable String",
+            "desc": "Enables and disables the string.",
+            "symbols": [
+              {
+                "name": "ENABLE_STRING",
+                "value": 1,
+                "label": "Enable String",
+                "desc": "Enable the string."
+              },
+              {
+                "name": "DISABLE_STRING",
+                "value": 2,
+                "label": "Disable String",
+                "desc": "Disable the string."
+              }
+            ]
+          },
+          {
+            "name": "StrSetCon",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Connect/Disconnect String",
+            "desc": "Connects and disconnects the string.",
+            "symbols": [
+              {
+                "name": "CONNECT_STRING",
+                "value": 1,
+                "label": "Connect String",
+                "desc": "Connect the string."
+              },
+              {
+                "name": "DISCONNECT_STRING",
+                "value": 2,
+                "label": "Disconnect String",
+                "desc": "Disconnect the string."
+              }
+            ]
+          },
+          {
+            "name": "Pad1",
+            "type": "pad",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Pad",
+            "desc": "Pad register."
+          },
+          {
+            "name": "Pad2",
+            "type": "pad",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Pad",
+            "desc": "Pad register."
+          }
+        ]
+      }
+    ]
+  },
+  "id": 803
+}

--- a/models/model_804.json
+++ b/models/model_804.json
@@ -1,0 +1,922 @@
+{
+  "group": {
+    "name": "lithium_ion_string",
+    "type": "group",
+    "label": "Lithium-Ion String Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 804
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Idx",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "String Index",
+        "desc": "Index of the string within the bank."
+      },
+      {
+        "name": "NMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Count",
+        "desc": "Count of modules in the string."
+      },
+      {
+        "name": "St",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "String Status",
+        "desc": "Current status of the string.",
+        "symbols": [
+          {
+            "name": "STRING_ENABLED",
+            "value": 0,
+            "label": "String Is Enabled",
+            "desc": "String is enabled and will connect next time battery is asked to connect."
+          },
+          {
+            "name": "CONTACTOR_STATUS",
+            "value": 1,
+            "label": "Contactor Status",
+            "desc": "String contactor is closed."
+          }
+        ]
+      },
+      {
+        "name": "ConFail",
+        "type": "enum16",
+        "size": 1,
+        "label": "Connection Failure Reason",
+        "symbols": [
+          {
+            "name": "NO_FAILURE",
+            "value": 0,
+            "label": "No Failure",
+            "desc": "Connect did not fail."
+          },
+          {
+            "name": "BUTTON_PUSHED",
+            "value": 1,
+            "label": "Button Pushed",
+            "desc": "A button was pushed which prevented connection."
+          },
+          {
+            "name": "STR_GROUND_FAULT",
+            "value": 2,
+            "label": "Ground Fault",
+            "desc": "Ground fault during auto-connect."
+          },
+          {
+            "name": "OUTSIDE_VOLTAGE_RANGE",
+            "value": 3,
+            "label": "Outside Voltage Range",
+            "desc": "Outside voltage target window during auto-connect."
+          },
+          {
+            "name": "STRING_NOT_ENABLED",
+            "value": 4,
+            "label": "String Not Enabled",
+            "desc": "The string is not enabled."
+          },
+          {
+            "name": "FUSE_OPEN",
+            "value": 5,
+            "label": "Fuse Open",
+            "desc": "A fuse is open which prevents connection."
+          },
+          {
+            "name": "CONTACTOR_FAILURE",
+            "value": 6,
+            "label": "Contactor Failure",
+            "desc": "A contactor failed to operate."
+          },
+          {
+            "name": "PRECHARGE_FAILURE",
+            "value": 7,
+            "label": "Precharge Failure",
+            "desc": "A precharge failure occurred."
+          },
+          {
+            "name": "STRING_FAULT",
+            "value": 8,
+            "label": "String Fault",
+            "desc": "A string fault has occurred."
+          }
+        ]
+      },
+      {
+        "name": "NCellBal",
+        "type": "uint16",
+        "size": 1,
+        "label": "String Cell Balancing Count",
+        "desc": "Number of cells currently being balanced in the string."
+      },
+      {
+        "name": "SoC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%",
+        "mandatory": "M",
+        "label": "String State of Charge",
+        "desc": "Battery string state of charge, expressed as a percentage."
+      },
+      {
+        "name": "DoD",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DoD_SF",
+        "units": "%",
+        "label": "String Depth of Discharge",
+        "desc": "Depth of discharge for the string, expressed as a percentage."
+      },
+      {
+        "name": "NCyc",
+        "type": "uint32",
+        "size": 2,
+        "label": "String Cycle Count",
+        "desc": "Number of discharge cycles executed upon the string."
+      },
+      {
+        "name": "SoH",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoH_SF",
+        "units": "%",
+        "label": "String State of Health",
+        "desc": "Battery string state of health, expressed as a percentage."
+      },
+      {
+        "name": "A",
+        "type": "int16",
+        "size": 1,
+        "sf": "A_SF",
+        "units": "A",
+        "mandatory": "M",
+        "label": "String Current",
+        "desc": "String current measurement."
+      },
+      {
+        "name": "V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "label": "String Voltage",
+        "desc": "String voltage measurement."
+      },
+      {
+        "name": "CellVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Max Cell Voltage",
+        "desc": "Maximum voltage for all cells in the string."
+      },
+      {
+        "name": "CellVMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage Module",
+        "desc": "Module containing the cell with maximum cell voltage."
+      },
+      {
+        "name": "CellVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Min Cell Voltage",
+        "desc": "Minimum voltage for all cells in the string."
+      },
+      {
+        "name": "CellVMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage Module",
+        "desc": "Module containing the cell with minimum cell voltage."
+      },
+      {
+        "name": "CellVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Average Cell Voltage",
+        "desc": "Average voltage for all cells in the string."
+      },
+      {
+        "name": "ModTmpMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "ModTmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Max Module Temperature",
+        "desc": "Maximum temperature for all modules in the string."
+      },
+      {
+        "name": "ModTmpMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Max Module Temperature Module",
+        "desc": "Module with the maximum temperature."
+      },
+      {
+        "name": "ModTmpMin",
+        "type": "int16",
+        "size": 1,
+        "sf": "ModTmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Min Module Temperature",
+        "desc": "Minimum temperature for all modules in the string."
+      },
+      {
+        "name": "ModTmpMinMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Min Module Temperature Module",
+        "desc": "Module with the minimum temperature."
+      },
+      {
+        "name": "ModTmpAvg",
+        "type": "int16",
+        "size": 1,
+        "sf": "ModTmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Average Module Temperature",
+        "desc": "Average temperature for all modules in the string."
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Pad register."
+      },
+      {
+        "name": "ConSt",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Contactor Status",
+        "desc": "Status of the contactor(s) for the string.",
+        "symbols": [
+          {
+            "name": "CONTACTOR_0",
+            "value": 0,
+            "label": "Contactor 0 Closed"
+          },
+          {
+            "name": "CONTACTOR_1",
+            "value": 1,
+            "label": "Contactor 1 Closed"
+          },
+          {
+            "name": "CONTACTOR_2",
+            "value": 2,
+            "label": "Contactor 2 Closed"
+          },
+          {
+            "name": "CONTACTOR_3",
+            "value": 3,
+            "label": "Contactor 3 Closed"
+          },
+          {
+            "name": "CONTACTOR_4",
+            "value": 4,
+            "label": "Contactor 4 Closed"
+          },
+          {
+            "name": "CONTACTOR_5",
+            "value": 5,
+            "label": "Contactor 5 Closed"
+          },
+          {
+            "name": "CONTACTOR_6",
+            "value": 6,
+            "label": "Contactor 6 Closed"
+          },
+          {
+            "name": "CONTACTOR_7",
+            "value": 7,
+            "label": "Contactor 7 Closed"
+          },
+          {
+            "name": "CONTACTOR_8",
+            "value": 8,
+            "label": "Contactor 8 Closed"
+          },
+          {
+            "name": "CONTACTOR_9",
+            "value": 9,
+            "label": "Contactor 9 Closed"
+          },
+          {
+            "name": "CONTACTOR_10",
+            "value": 10,
+            "label": "Contactor 10 Closed"
+          },
+          {
+            "name": "CONTACTOR_11",
+            "value": 11,
+            "label": "Contactor 11 Closed"
+          },
+          {
+            "name": "CONTACTOR_12",
+            "value": 12,
+            "label": "Contactor 12 Closed"
+          },
+          {
+            "name": "CONTACTOR_13",
+            "value": 13,
+            "label": "Contactor 13 Closed"
+          },
+          {
+            "name": "CONTACTOR_14",
+            "value": 14,
+            "label": "Contactor 14 Closed"
+          },
+          {
+            "name": "CONTACTOR_15",
+            "value": 15,
+            "label": "Contactor 15 Closed"
+          },
+          {
+            "name": "CONTACTOR_16",
+            "value": 16,
+            "label": "Contactor 16 Closed"
+          },
+          {
+            "name": "CONTACTOR_17",
+            "value": 17,
+            "label": "Contactor 17 Closed"
+          },
+          {
+            "name": "CONTACTOR_18",
+            "value": 18,
+            "label": "Contactor 18 Closed"
+          },
+          {
+            "name": "CONTACTOR_19",
+            "value": 19,
+            "label": "Contactor 19 Closed"
+          },
+          {
+            "name": "CONTACTOR_20",
+            "value": 20,
+            "label": "Contactor 20 Closed"
+          },
+          {
+            "name": "CONTACTOR_21",
+            "value": 21,
+            "label": "Contactor 21 Closed"
+          },
+          {
+            "name": "CONTACTOR_22",
+            "value": 22,
+            "label": "Contactor 22 Closed"
+          },
+          {
+            "name": "CONTACTOR_23",
+            "value": 23,
+            "label": "Contactor 23 Closed"
+          },
+          {
+            "name": "CONTACTOR_24",
+            "value": 24,
+            "label": "Contactor 24 Closed"
+          },
+          {
+            "name": "CONTACTOR_25",
+            "value": 25,
+            "label": "Contactor 25 Closed"
+          },
+          {
+            "name": "CONTACTOR_26",
+            "value": 26,
+            "label": "Contactor 26 Closed"
+          },
+          {
+            "name": "CONTACTOR_27",
+            "value": 27,
+            "label": "Contactor 27 Closed"
+          },
+          {
+            "name": "CONTACTOR_28",
+            "value": 28,
+            "label": "Contactor 28 Closed"
+          },
+          {
+            "name": "CONTACTOR_29",
+            "value": 29,
+            "label": "Contactor 29 Closed"
+          },
+          {
+            "name": "CONTACTOR_30",
+            "value": 30,
+            "label": "Contactor 30 Closed"
+          }
+        ]
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "String Event 1",
+        "desc": "Alarms, warnings and status values.  Bit flags.",
+        "symbols": [
+          {
+            "name": "COMMUNICATION_ERROR",
+            "value": 0,
+            "label": "Communication Error",
+            "desc": "String is unable to communicate with battery modules."
+          },
+          {
+            "name": "OVER_TEMP_ALARM",
+            "value": 1,
+            "label": "Over Temperature Alarm",
+            "desc": "Battery string has exceeded maximum operating temperature"
+          },
+          {
+            "name": "OVER_TEMP_WARNING",
+            "value": 2,
+            "label": "Over Temperature  Warning",
+            "desc": "Battery string is approaching maximum operating temperature."
+          },
+          {
+            "name": "UNDER_TEMP_ALARM",
+            "value": 3,
+            "label": "Under Temperature Alarm",
+            "desc": "Battery string has exceeded minimum operating temperature"
+          },
+          {
+            "name": "UNDER_TEMP_WARNING",
+            "value": 4,
+            "label": "Under Temperature Warning",
+            "desc": "Battery string is approaching minimum operating temperature."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_ALARM",
+            "value": 5,
+            "label": "Over Charge Current Alarm",
+            "desc": "Battery string maximum charge current has been exceeded."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_WARNING",
+            "value": 6,
+            "label": "Over Charge Current Warning",
+            "desc": "Approaching battery string maximum charge current."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_ALARM",
+            "value": 7,
+            "label": "Over Discharge Current Alarm",
+            "desc": "Battery string maximum discharge current has been exceeded."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_WARNING",
+            "value": 8,
+            "label": "Over Discharge Current Warning",
+            "desc": "Approaching battery string maximum discharge current."
+          },
+          {
+            "name": "OVER_VOLT_ALARM",
+            "value": 9,
+            "label": "Over Voltage Alarm",
+            "desc": "Battery string voltage has exceeded maximum limit."
+          },
+          {
+            "name": "OVER_VOLT_WARNING",
+            "value": 10,
+            "label": "Over Voltage Warning",
+            "desc": "Battery string voltage is approaching maximum limit."
+          },
+          {
+            "name": "UNDER_VOLT_ALARM",
+            "value": 11,
+            "label": "Under Voltage Alarm",
+            "desc": "Battery string voltage has exceeded minimum limit."
+          },
+          {
+            "name": "UNDER_VOLT_WARNING",
+            "value": 12,
+            "label": "Under Voltage Warning",
+            "desc": "Battery string voltage is approaching minimum limit."
+          },
+          {
+            "name": "UNDER_SOC_MIN_ALARM",
+            "value": 13,
+            "label": "Under State of Charge Min Alarm",
+            "desc": "Battery string state of charge has reached or exceeded SoCMin."
+          },
+          {
+            "name": "UNDER_SOC_MIN_WARNING",
+            "value": 14,
+            "label": "Under State of Charge Min Warning",
+            "desc": "Battery string state of charge is approaching SoCMin."
+          },
+          {
+            "name": "OVER_SOC_MAX_ALARM",
+            "value": 15,
+            "label": "Over State of Charge Max Alarm",
+            "desc": "Battery string state of charge has reached or exceeded SoCMax."
+          },
+          {
+            "name": "OVER_SOC_MAX_WARNING",
+            "value": 16,
+            "label": "Over State of Charge Max Warning",
+            "desc": "Battery string state of charge is approaching SoCMax."
+          },
+          {
+            "name": "VOLTAGE_IMBALANCE_WARNING",
+            "value": 17,
+            "label": "Voltage Imbalance Warning",
+            "desc": "A voltage imbalance exists between the modules in the battery string."
+          },
+          {
+            "name": "TEMPERATURE_IMBALANCE_ALARM",
+            "value": 18,
+            "label": "Temperature Imbalance Alarm",
+            "desc": "A temperature imbalance exists between the modules in the battery string."
+          },
+          {
+            "name": "TEMPERATURE_IMBALANCE_WARNING",
+            "value": 19,
+            "label": "Temperature Imbalance Warning",
+            "desc": "A temperature imbalance is developing between the modules in the battery string."
+          },
+          {
+            "name": "CONTACTOR_ERROR",
+            "value": 20,
+            "label": "Contactor Error",
+            "desc": "A contactor failed to open or close as requested."
+          },
+          {
+            "name": "FAN_ERROR",
+            "value": 21,
+            "label": "Fan Error",
+            "desc": "One or more battery fans has failed."
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 22,
+            "label": "Ground Fault Error",
+            "desc": "Ground fault detected."
+          },
+          {
+            "name": "OPEN_DOOR_ERROR",
+            "value": 23,
+            "label": "Open Door Error",
+            "desc": "One or more doors are open."
+          },
+          {
+            "name": "RESERVED_1",
+            "value": 24,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "OTHER_ALARM",
+            "value": 25,
+            "label": "Other String Alarm",
+            "desc": "A vendor specific alarm has occurred."
+          },
+          {
+            "name": "OTHER_WARNING",
+            "value": 26,
+            "label": "Other String Warning",
+            "desc": "A vendor specific warning has occurred."
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 27,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "CONFIGURATION_ALARM",
+            "value": 28,
+            "label": "Configuration Alarm",
+            "desc": "The battery string has been configured incorrectly and will not operate as expected."
+          },
+          {
+            "name": "CONFIGURATION_WARNING",
+            "value": 29,
+            "label": "Configuration Warning",
+            "desc": "The battery string has been configured incorrectly and may not operate as expected."
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "String Event 2",
+        "desc": "Alarms, warnings and status values.  Bit flags."
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "SetEna",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Enable/Disable String",
+        "desc": "Enables and disables the string.  Should reset to 0 upon completion.",
+        "symbols": [
+          {
+            "name": "DISABLED",
+            "value": 0
+          },
+          {
+            "name": "ENABLED",
+            "value": 1
+          }
+        ]
+      },
+      {
+        "name": "SetCon",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "label": "Connect/Disconnect String",
+        "desc": "Connects and disconnects the string.",
+        "symbols": [
+          {
+            "name": "CONNECT_STRING",
+            "value": 1,
+            "label": "Connect String",
+            "desc": "Connect the string."
+          },
+          {
+            "name": "DISCONNECT_STRING",
+            "value": 2,
+            "label": "Disconnect String",
+            "desc": "Disconnect the string."
+          }
+        ]
+      },
+      {
+        "name": "SoC_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for string state of charge."
+      },
+      {
+        "name": "SoH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for string state of health."
+      },
+      {
+        "name": "DoD_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for string depth of discharge."
+      },
+      {
+        "name": "A_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for string current."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for string voltage."
+      },
+      {
+        "name": "CellV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for cell voltage."
+      },
+      {
+        "name": "ModTmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for module temperature."
+      },
+      {
+        "name": "Pad2",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Pad register."
+      },
+      {
+        "name": "Pad3",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Pad register."
+      },
+      {
+        "name": "Pad4",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Pad register."
+      }
+    ],
+    "groups": [
+      {
+        "name": "lithium_ion_string_module",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ModNCell",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Module Cell Count",
+            "desc": "Count of all cells in the module."
+          },
+          {
+            "name": "ModSoC",
+            "type": "uint16",
+            "size": 1,
+            "sf": "SoC_SF",
+            "units": "%",
+            "label": "Module SoC",
+            "desc": "Module state of charge, expressed as a percentage."
+          },
+          {
+            "name": "ModSoH",
+            "type": "uint16",
+            "size": 1,
+            "sf": "SoH_SF",
+            "units": "%",
+            "label": "Module SoH",
+            "desc": "Module state of health, expressed as a percentage."
+          },
+          {
+            "name": "ModCellVMax",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Max Cell Voltage",
+            "desc": "Maximum voltage for all cells in the module."
+          },
+          {
+            "name": "ModCellVMaxCell",
+            "type": "uint16",
+            "size": 1,
+            "label": "Max Cell Voltage Cell",
+            "desc": "Cell with maximum voltage."
+          },
+          {
+            "name": "ModCellVMin",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Min Cell Voltage",
+            "desc": "Minimum voltage for all cells in the module."
+          },
+          {
+            "name": "ModCellVMinCell",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "label": "Min Cell Voltage Cell",
+            "desc": "Cell with minimum voltage."
+          },
+          {
+            "name": "ModCellVAvg",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Average Cell Voltage",
+            "desc": "Average voltage for all cells in the module."
+          },
+          {
+            "name": "ModCellTmpMax",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Max Cell Temperature",
+            "desc": "Maximum temperature for all cells in the module."
+          },
+          {
+            "name": "ModCellTmpMaxCell",
+            "type": "uint16",
+            "size": 1,
+            "label": "Max Cell Temperature Cell",
+            "desc": "Cell with maximum temperature."
+          },
+          {
+            "name": "ModCellTmpMin",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Min Cell Temperature",
+            "desc": "Minimum temperature for all cells in the module."
+          },
+          {
+            "name": "ModCellTmpMinCell",
+            "type": "uint16",
+            "size": 1,
+            "label": "Min Cell Temperature Cell",
+            "desc": "Cell with minimum temperature."
+          },
+          {
+            "name": "ModCellTmpAvg",
+            "type": "int16",
+            "size": 1,
+            "sf": "ModTmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Average Cell Temperature",
+            "desc": "Average temperature for all cells in the module."
+          },
+          {
+            "name": "Pad5",
+            "type": "pad",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Pad",
+            "desc": "Pad register."
+          },
+          {
+            "name": "Pad6",
+            "type": "pad",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Pad",
+            "desc": "Pad register."
+          },
+          {
+            "name": "Pad7",
+            "type": "pad",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Pad",
+            "desc": "Pad register."
+          }
+        ]
+      }
+    ]
+  },
+  "id": 804
+}

--- a/models/model_805.json
+++ b/models/model_805.json
@@ -1,0 +1,282 @@
+{
+  "group": {
+    "name": "lithium-ion-module",
+    "type": "group",
+    "label": "Lithium-Ion Module Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 805
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "StrIdx",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "String Index",
+        "desc": "Index of the string containing the module."
+      },
+      {
+        "name": "ModIdx",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Index",
+        "desc": "Index of the module within the string."
+      },
+      {
+        "name": "NCell",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Cell Count",
+        "desc": "Count of all cells in the module."
+      },
+      {
+        "name": "SoC",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoC_SF",
+        "units": "%",
+        "label": "Module SoC",
+        "desc": "Module state of charge, expressed as a percentage."
+      },
+      {
+        "name": "DoD",
+        "type": "uint16",
+        "size": 1,
+        "sf": "DoD_SF",
+        "units": "%",
+        "label": "Depth of Discharge",
+        "desc": "Depth of discharge for the module."
+      },
+      {
+        "name": "SoH",
+        "type": "uint16",
+        "size": 1,
+        "sf": "SoH_SF",
+        "units": "%",
+        "label": "Module SoH",
+        "desc": "Module state of health, expressed as a percentage."
+      },
+      {
+        "name": "NCyc",
+        "type": "uint32",
+        "size": 2,
+        "label": "Cycle Count",
+        "desc": "Count of cycles executed."
+      },
+      {
+        "name": "V",
+        "type": "uint16",
+        "size": 1,
+        "sf": "V_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Module Voltage",
+        "desc": "Voltage of the module."
+      },
+      {
+        "name": "CellVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Max Cell Voltage",
+        "desc": "Maximum voltage for all cells in the module."
+      },
+      {
+        "name": "CellVMaxCell",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage Cell",
+        "desc": "Cell with the maximum voltage."
+      },
+      {
+        "name": "CellVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Min Cell Voltage",
+        "desc": "Minimum voltage for all cells in the module."
+      },
+      {
+        "name": "CellVMinCell",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage Cell",
+        "desc": "Cell with the minimum voltage."
+      },
+      {
+        "name": "CellVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Average Cell Voltage",
+        "desc": "Average voltage for all cells in the module."
+      },
+      {
+        "name": "CellTmpMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Max Cell Temperature",
+        "desc": "Maximum temperature for all cells in the module."
+      },
+      {
+        "name": "CellTmpMaxCell",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Temperature Cell",
+        "desc": "Cell with the maximum cell temperature."
+      },
+      {
+        "name": "CellTmpMin",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Min Cell Temperature",
+        "desc": "Minimum temperature for all cells in the module."
+      },
+      {
+        "name": "CellTmpMinCell",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Temperature Cell",
+        "desc": "Cell with the minimum cell temperature."
+      },
+      {
+        "name": "CellTmpAvg",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Average Cell Temperature",
+        "desc": "Average temperature for all cells in the module."
+      },
+      {
+        "name": "NCellBal",
+        "type": "uint16",
+        "size": 1,
+        "label": "Balanced Cell Count",
+        "desc": "Number of cells currently being balanced in the module."
+      },
+      {
+        "name": "SN",
+        "type": "string",
+        "size": 16,
+        "label": "Serial Number",
+        "desc": "Serial number for the module."
+      },
+      {
+        "name": "SoC_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for module state of charge."
+      },
+      {
+        "name": "SoH_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for module state of health."
+      },
+      {
+        "name": "DoD_SF",
+        "type": "sunssf",
+        "size": 1,
+        "desc": "Scale factor for module depth of discharge."
+      },
+      {
+        "name": "V_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for module voltage."
+      },
+      {
+        "name": "CellV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for cell voltage."
+      },
+      {
+        "name": "Tmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for module temperature."
+      }
+    ],
+    "groups": [
+      {
+        "name": "lithium-ion-module-cell",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "CellV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Cell Voltage",
+            "desc": "Cell terminal voltage."
+          },
+          {
+            "name": "CellTmp",
+            "type": "int16",
+            "size": 1,
+            "sf": "Tmp_SF",
+            "units": "C",
+            "mandatory": "M",
+            "label": "Cell Temperature",
+            "desc": "Cell temperature."
+          },
+          {
+            "name": "CellSt",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Cell Status",
+            "desc": "Status of the cell.",
+            "symbols": [
+              {
+                "name": "CELL_IS_BALANCING",
+                "value": 0,
+                "label": "Cell Is Balancing",
+                "desc": "Cell is currently being balanced."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 805
+}

--- a/models/model_806.json
+++ b/models/model_806.json
@@ -1,0 +1,52 @@
+{
+  "group": {
+    "name": "flow_battery",
+    "type": "group",
+    "label": "Flow Battery Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 806
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "BatTBD",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Battery Points To Be Determined"
+      }
+    ],
+    "groups": [
+      {
+        "name": "battery_string",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "BatStTBD",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Battery String Points To Be Determined"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 806
+}

--- a/models/model_807.json
+++ b/models/model_807.json
@@ -1,0 +1,1166 @@
+{
+  "group": {
+    "name": "flow_battery_string",
+    "type": "group",
+    "label": "Flow Battery String Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 807
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "Idx",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "String Index",
+        "desc": "Index of the string within the bank."
+      },
+      {
+        "name": "NMod",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Count",
+        "desc": "Number of modules in this string."
+      },
+      {
+        "name": "NModCon",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Connected Module Count",
+        "desc": "Number of electrically connected modules in this string."
+      },
+      {
+        "name": "ModVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ModV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Max Module Voltage",
+        "desc": "Maximum voltage for all modules in the string."
+      },
+      {
+        "name": "ModVMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Module Voltage Module",
+        "desc": "Module with the maximum voltage."
+      },
+      {
+        "name": "ModVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ModV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Min Module Voltage",
+        "desc": "Minimum voltage for all modules in the string."
+      },
+      {
+        "name": "ModVMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Module Voltage Module",
+        "desc": "Module with the minimum voltage."
+      },
+      {
+        "name": "ModVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "ModV_SF",
+        "units": "V",
+        "mandatory": "M",
+        "label": "Average Module Voltage",
+        "desc": "Average voltage for all modules in the string."
+      },
+      {
+        "name": "CellVMax",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Max Cell Voltage",
+        "desc": "Maximum voltage for all cells in the string."
+      },
+      {
+        "name": "CellVMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage Module",
+        "desc": "Module containing the cell with the maximum voltage."
+      },
+      {
+        "name": "CellVMaxStk",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Cell Voltage Stack",
+        "desc": "Stack containing the cell with the maximum voltage."
+      },
+      {
+        "name": "CellVMin",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Min Cell Voltage",
+        "desc": "Minimum voltage for all cells in the string."
+      },
+      {
+        "name": "CellVMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage Module",
+        "desc": "Module containing the cell with the minimum voltage."
+      },
+      {
+        "name": "CellVMinStk",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Cell Voltage Stack",
+        "desc": "Stack containing the cell with the minimum voltage."
+      },
+      {
+        "name": "CellVAvg",
+        "type": "uint16",
+        "size": 1,
+        "sf": "CellV_SF",
+        "units": "V",
+        "label": "Average Cell Voltage",
+        "desc": "Average voltage for all cells in the string."
+      },
+      {
+        "name": "TmpMax",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Max Temperature",
+        "desc": "Maximum electrolyte temperature for all modules in the string."
+      },
+      {
+        "name": "TmpMaxMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Max Temperature Module",
+        "desc": "Module with the maximum temperature."
+      },
+      {
+        "name": "TmpMin",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Min Temperature",
+        "desc": "Minimum electrolyte temperature for all modules in the string."
+      },
+      {
+        "name": "TmpMinMod",
+        "type": "uint16",
+        "size": 1,
+        "label": "Min Temperature Module",
+        "desc": "Module with the minimum temperature."
+      },
+      {
+        "name": "TmpAvg",
+        "type": "int16",
+        "size": 1,
+        "sf": "Tmp_SF",
+        "units": "C",
+        "mandatory": "M",
+        "label": "Average Temperature",
+        "desc": "Average electrolyte temperature for all modules in the string."
+      },
+      {
+        "name": "Evt1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "String Event 1",
+        "desc": "Alarms, warnings and status values.  Bit flags.",
+        "symbols": [
+          {
+            "name": "COMMUNICATION_ERROR",
+            "value": 0,
+            "label": "Communication Error",
+            "desc": "BMS is unable to communicate with modules."
+          },
+          {
+            "name": "OVER_TEMP_ALARM",
+            "value": 1,
+            "label": "Over Temperature Alarm",
+            "desc": "Battery string has exceeded maximum operating temperature"
+          },
+          {
+            "name": "OVER_TEMP_WARNING",
+            "value": 2,
+            "label": "Over Temperature  Warning",
+            "desc": "Battery string is approaching maximum operating temperature."
+          },
+          {
+            "name": "UNDER_TEMP_ALARM",
+            "value": 3,
+            "label": "Under Temperature Alarm",
+            "desc": "Battery string has exceeded minimum operating temperature"
+          },
+          {
+            "name": "UNDER_TEMP_WARNING",
+            "value": 4,
+            "label": "Under Temperature Warning",
+            "desc": "Battery string is approaching minimum operating temperature."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_ALARM",
+            "value": 5,
+            "label": "Over Charge Current Alarm",
+            "desc": "Battery string maximum charge current has been exceeded."
+          },
+          {
+            "name": "OVER_CHARGE_CURRENT_WARNING",
+            "value": 6,
+            "label": "Over Charge Current Warning",
+            "desc": "Approaching battery string maximum charge current."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_ALARM",
+            "value": 7,
+            "label": "Over Discharge Current Alarm",
+            "desc": "Battery string maximum discharge current has been exceeded."
+          },
+          {
+            "name": "OVER_DISCHARGE_CURRENT_WARNING",
+            "value": 8,
+            "label": "Over Discharge Current Warning",
+            "desc": "Approaching battery string maximum discharge current."
+          },
+          {
+            "name": "OVER_VOLT_ALARM",
+            "value": 9,
+            "label": "Over Voltage Alarm",
+            "desc": "Battery string voltage has exceeded maximum limit."
+          },
+          {
+            "name": "OVER_VOLT_WARNING",
+            "value": 10,
+            "label": "Over Voltage Warning",
+            "desc": "Battery string voltage is approaching maximum limit."
+          },
+          {
+            "name": "UNDER_VOLT_ALARM",
+            "value": 11,
+            "label": "Under Voltage Alarm",
+            "desc": "Battery string voltage has exceeded minimum limit."
+          },
+          {
+            "name": "UNDER_VOLT_WARNING",
+            "value": 12,
+            "label": "Under Voltage Warning",
+            "desc": "Battery string voltage is approaching minimum limit."
+          },
+          {
+            "name": "UNDER_SOC_MIN_ALARM",
+            "value": 13,
+            "label": "Under State of Charge Minimum Alarm",
+            "desc": "Battery string state of charge has reached or exceeded SoCMin."
+          },
+          {
+            "name": "UNDER_SOC_MIN_WARNING",
+            "value": 14,
+            "label": "Under State of Charge Minimum Warning",
+            "desc": "Battery string state of charge is approaching SoCMin."
+          },
+          {
+            "name": "OVER_SOC_MAX_ALARM",
+            "value": 15,
+            "label": "Over State of Charge Maximum Alarm",
+            "desc": "Battery string state of charge has reached or exceeded SoCMax."
+          },
+          {
+            "name": "OVER_SOC_MAX_WARNING",
+            "value": 16,
+            "label": "Over State of Charge Maximum Warning",
+            "desc": "Battery string state of charge is approaching SoCMax"
+          },
+          {
+            "name": "VOLTAGE_IMBALANCE_WARNING",
+            "value": 17,
+            "label": "Voltage Imbalance Warning",
+            "desc": "A voltage imbalance exists between the modules in the string."
+          },
+          {
+            "name": "RESERVED_1",
+            "value": 18,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "RESERVED_2",
+            "value": 19,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "CONTACTOR_ERROR",
+            "value": 20,
+            "label": "Contactor Error",
+            "desc": "A contactor failed to open or close as requested."
+          },
+          {
+            "name": "FAN_ERROR",
+            "value": 21,
+            "label": "Fan Error",
+            "desc": "One or more battery string fans has failed."
+          },
+          {
+            "name": "GROUND_FAULT",
+            "value": 22,
+            "label": "Ground Fault Error",
+            "desc": "Ground fault detected."
+          },
+          {
+            "name": "OPEN_DOOR_ERROR",
+            "value": 23,
+            "label": "Open Door Error",
+            "desc": "One or more doors are open."
+          },
+          {
+            "name": "RESERVED_3",
+            "value": 24,
+            "label": "Reserved",
+            "desc": "Reserved bit."
+          },
+          {
+            "name": "OTHER_ALARM",
+            "value": 25,
+            "label": "Other String Alarm",
+            "desc": "A vendor specific alarm has occurred."
+          },
+          {
+            "name": "OTHER_WARNING",
+            "value": 26,
+            "label": "Other String Warning",
+            "desc": "A vendor specific warning has occurred."
+          },
+          {
+            "name": "FIRE_ALARM",
+            "value": 27,
+            "label": "Fire Alarm",
+            "desc": "A fire has been detected."
+          },
+          {
+            "name": "CONFIGURATION_ALARM",
+            "value": 28,
+            "label": "Configuration Alarm",
+            "desc": "The battery string has been configured incorrectly and will not operate."
+          },
+          {
+            "name": "CONFIGURATION_WARNING",
+            "value": 29,
+            "label": "Configuration Warning",
+            "desc": "The battery string has been configured incorrectly and may not operate as expected."
+          }
+        ]
+      },
+      {
+        "name": "Evt2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "String Event 2",
+        "desc": "Alarms, warnings and status values.  Bit flags.",
+        "symbols": [
+          {
+            "name": "LEAK_ALARM",
+            "value": 0,
+            "label": "Leak Alarm",
+            "desc": "A leak has been detected."
+          },
+          {
+            "name": "PUMP_ALARM",
+            "value": 1,
+            "label": "Pump Alarm",
+            "desc": "A pump has experienced an alarm condition or some other error."
+          },
+          {
+            "name": "HIGH_PRESSURE_ALARM",
+            "value": 2,
+            "label": "High Pressure Alarm",
+            "desc": "Pressure exceeds maximum value."
+          },
+          {
+            "name": "HIGH_PRESSURE_WARNING",
+            "value": 3,
+            "label": "High Pressure Warning",
+            "desc": "Pressure approaching maximum value."
+          },
+          {
+            "name": "LOW_FLOW_ALARM",
+            "value": 4,
+            "label": "Low Flow Alarm",
+            "desc": "Flow exceeds minimum value."
+          },
+          {
+            "name": "LOW_FLOW_WARNING",
+            "value": 5,
+            "label": "Low Flow Warning",
+            "desc": "Flow approaching minimum value."
+          }
+        ]
+      },
+      {
+        "name": "EvtVnd1",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Vendor Event Bitfield 1",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "EvtVnd2",
+        "type": "bitfield32",
+        "size": 2,
+        "mandatory": "M",
+        "label": "Vendor Event Bitfield 2",
+        "desc": "Vendor defined events."
+      },
+      {
+        "name": "ModV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M"
+      },
+      {
+        "name": "CellV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for voltage."
+      },
+      {
+        "name": "Tmp_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for temperature."
+      },
+      {
+        "name": "SoC_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for state of charge."
+      },
+      {
+        "name": "OCV_SF",
+        "type": "sunssf",
+        "size": 1,
+        "mandatory": "M",
+        "desc": "Scale factor for open circuit voltage."
+      },
+      {
+        "name": "Pad1",
+        "type": "pad",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Pad",
+        "desc": "Pad register."
+      }
+    ],
+    "groups": [
+      {
+        "name": "module",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "ModIdx",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Module Index",
+            "desc": "Index of the module within the string."
+          },
+          {
+            "name": "ModNStk",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Stack Count",
+            "desc": "Number of stacks in this module."
+          },
+          {
+            "name": "ModSt",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Module Status",
+            "desc": "Current status of the module.",
+            "symbols": [
+              {
+                "name": "MODULE_ENABLED",
+                "value": 0,
+                "label": "Module Is Enabled",
+                "desc": "Module is enabled and will connect next time battery is asked to connect."
+              },
+              {
+                "name": "CONTACTOR_STATUS",
+                "value": 1,
+                "label": "Contactor Status",
+                "desc": "Module contactor is closed."
+              }
+            ]
+          },
+          {
+            "name": "ModSoC",
+            "type": "uint16",
+            "size": 1,
+            "sf": "SoC_SF",
+            "units": "%",
+            "mandatory": "M",
+            "label": "Module State of Charge",
+            "desc": "State of charge for this module."
+          },
+          {
+            "name": "ModOCV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "OCV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "Open Circuit Voltage",
+            "desc": "Open circuit voltage for this module."
+          },
+          {
+            "name": "ModV",
+            "type": "uint16",
+            "size": 1,
+            "sf": "ModV_SF",
+            "units": "V",
+            "mandatory": "M",
+            "label": "External Voltage",
+            "desc": "External voltage fo this module."
+          },
+          {
+            "name": "ModCellVMax",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "label": "Maximum Cell Voltage",
+            "desc": "Maximum voltage for all cells in this module."
+          },
+          {
+            "name": "ModCellVMaxCell",
+            "type": "uint16",
+            "size": 1,
+            "label": "Max Cell Voltage Cell",
+            "desc": "Cell with the maximum cell voltage."
+          },
+          {
+            "name": "ModCellVMin",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "label": "Minimum Cell Voltage",
+            "desc": "Minimum voltage for all cells in this module."
+          },
+          {
+            "name": "ModCellVMinCell",
+            "type": "uint16",
+            "size": 1,
+            "label": "Min Cell Voltage Cell",
+            "desc": "Cell with the minimum cell voltage."
+          },
+          {
+            "name": "ModCellVAvg",
+            "type": "uint16",
+            "size": 1,
+            "sf": "CellV_SF",
+            "units": "V",
+            "label": "Average Cell Voltage",
+            "desc": "Average voltage for all cells in this module."
+          },
+          {
+            "name": "ModAnoTmp",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tmp_SF",
+            "units": "C",
+            "label": "Anolyte Temperature"
+          },
+          {
+            "name": "ModCatTmp",
+            "type": "uint16",
+            "size": 1,
+            "sf": "Tmp_SF",
+            "units": "C",
+            "label": "Catholyte Temperature"
+          },
+          {
+            "name": "ModConSt",
+            "type": "bitfield32",
+            "size": 2,
+            "label": "Contactor Status",
+            "symbols": [
+              {
+                "name": "CONTACTOR_0",
+                "value": 0,
+                "label": "Contactor 0 Closed"
+              },
+              {
+                "name": "CONTACTOR_1",
+                "value": 1,
+                "label": "Contactor 1 Closed"
+              },
+              {
+                "name": "CONTACTOR_2",
+                "value": 2,
+                "label": "Contactor 2 Closed"
+              },
+              {
+                "name": "CONTACTOR_3",
+                "value": 3,
+                "label": "Contactor 3 Closed"
+              },
+              {
+                "name": "CONTACTOR_4",
+                "value": 4,
+                "label": "Contactor 4 Closed"
+              },
+              {
+                "name": "CONTACTOR_5",
+                "value": 5,
+                "label": "Contactor 5 Closed"
+              },
+              {
+                "name": "CONTACTOR_6",
+                "value": 6,
+                "label": "Contactor 6 Closed"
+              },
+              {
+                "name": "CONTACTOR_7",
+                "value": 7,
+                "label": "Contactor 7 Closed"
+              },
+              {
+                "name": "CONTACTOR_8",
+                "value": 8,
+                "label": "Contactor 8 Closed"
+              },
+              {
+                "name": "CONTACTOR_9",
+                "value": 9,
+                "label": "Contactor 9 Closed"
+              },
+              {
+                "name": "CONTACTOR_10",
+                "value": 10,
+                "label": "Contactor 10 Closed"
+              },
+              {
+                "name": "CONTACTOR_11",
+                "value": 11,
+                "label": "Contactor 11 Closed"
+              },
+              {
+                "name": "CONTACTOR_12",
+                "value": 12,
+                "label": "Contactor 12 Closed"
+              },
+              {
+                "name": "CONTACTOR_13",
+                "value": 13,
+                "label": "Contactor 13 Closed"
+              },
+              {
+                "name": "CONTACTOR_14",
+                "value": 14,
+                "label": "Contactor 14 Closed"
+              },
+              {
+                "name": "CONTACTOR_15",
+                "value": 15,
+                "label": "Contactor 15 Closed"
+              },
+              {
+                "name": "CONTACTOR_16",
+                "value": 16,
+                "label": "Contactor 16 Closed"
+              },
+              {
+                "name": "CONTACTOR_17",
+                "value": 17,
+                "label": "Contactor 17 Closed"
+              },
+              {
+                "name": "CONTACTOR_18",
+                "value": 18,
+                "label": "Contactor 18 Closed"
+              },
+              {
+                "name": "CONTACTOR_19",
+                "value": 19,
+                "label": "Contactor 19 Closed"
+              },
+              {
+                "name": "CONTACTOR_20",
+                "value": 20,
+                "label": "Contactor 20 Closed"
+              },
+              {
+                "name": "CONTACTOR_21",
+                "value": 21,
+                "label": "Contactor 21 Closed"
+              },
+              {
+                "name": "CONTACTOR_22",
+                "value": 22,
+                "label": "Contactor 22 Closed"
+              },
+              {
+                "name": "CONTACTOR_23",
+                "value": 23,
+                "label": "Contactor 23 Closed"
+              },
+              {
+                "name": "CONTACTOR_24",
+                "value": 24,
+                "label": "Contactor 24 Closed"
+              },
+              {
+                "name": "CONTACTOR_25",
+                "value": 25,
+                "label": "Contactor 25 Closed"
+              },
+              {
+                "name": "CONTACTOR_26",
+                "value": 26,
+                "label": "Contactor 26 Closed"
+              },
+              {
+                "name": "CONTACTOR_27",
+                "value": 27,
+                "label": "Contactor 27 Closed"
+              },
+              {
+                "name": "CONTACTOR_28",
+                "value": 28,
+                "label": "Contactor 28 Closed"
+              },
+              {
+                "name": "CONTACTOR_29",
+                "value": 29,
+                "label": "Contactor 29 Closed"
+              },
+              {
+                "name": "CONTACTOR_30",
+                "value": 30,
+                "label": "Contactor 30 Closed"
+              }
+            ]
+          },
+          {
+            "name": "ModEvt1",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Module Event 1",
+            "desc": "Alarms, warnings and status values.  Bit flags.",
+            "symbols": [
+              {
+                "name": "COMMUNICATION_ERROR",
+                "value": 0,
+                "label": "Communication Error",
+                "desc": "Module is unable to communicate with the BMS or other components."
+              },
+              {
+                "name": "OVER_TEMP_ALARM",
+                "value": 1,
+                "label": "Over Temperature Alarm",
+                "desc": "Module has exceeded maximum operating temperature"
+              },
+              {
+                "name": "OVER_TEMP_WARNING",
+                "value": 2,
+                "label": "Over Temperature  Warning",
+                "desc": "Module is approaching maximum operating temperature."
+              },
+              {
+                "name": "UNDER_TEMP_ALARM",
+                "value": 3,
+                "label": "Under Temperature Alarm",
+                "desc": "Module has exceeded minimum operating temperature"
+              },
+              {
+                "name": "UNDER_TEMP_WARNING",
+                "value": 4,
+                "label": "Under Temperature Warning",
+                "desc": "Module is approaching minimum operating temperature."
+              },
+              {
+                "name": "OVER_CHARGE_CURRENT_ALARM",
+                "value": 5,
+                "label": "Over Charge Current Alarm",
+                "desc": "Module maximum charge current has been exceeded."
+              },
+              {
+                "name": "OVER_CHARGE_CURRENT_WARNING",
+                "value": 6,
+                "label": "Over Charge Current Warning",
+                "desc": "Approaching module maximum charge current."
+              },
+              {
+                "name": "OVER_DISCHARGE_CURRENT_ALARM",
+                "value": 7,
+                "label": "Over Discharge Current Alarm",
+                "desc": "Module maximum discharge current has been exceeded."
+              },
+              {
+                "name": "OVER_DISCHARGE_CURRENT_WARNING",
+                "value": 8,
+                "label": "Over Discharge Current Warning",
+                "desc": "Approaching module maximum discharge current."
+              },
+              {
+                "name": "OVER_VOLT_ALARM",
+                "value": 9,
+                "label": "Over Voltage Alarm",
+                "desc": "Module voltage has exceeded maximum limit."
+              },
+              {
+                "name": "OVER_VOLT_WARNING",
+                "value": 10,
+                "label": "Over Voltage Warning",
+                "desc": "Module voltage is approaching maximum limit."
+              },
+              {
+                "name": "UNDER_VOLT_ALARM",
+                "value": 11,
+                "label": "Under Voltage Alarm",
+                "desc": "Module voltage has exceeded minimum limit."
+              },
+              {
+                "name": "UNDER_VOLT_WARNING",
+                "value": 12,
+                "label": "Under Voltage Warning",
+                "desc": "Module voltage is approaching minimum limit."
+              },
+              {
+                "name": "UNDER_SOC_MIN_ALARM",
+                "value": 13,
+                "label": "Under State of Charge Minimum Alarm",
+                "desc": "Module state of charge has reached or exceeded SoCMin."
+              },
+              {
+                "name": "UNDER_SOC_MIN_WARNING",
+                "value": 14,
+                "label": "Under State of Charge Minimum Warning",
+                "desc": "Module state of charge is approaching SoCMin."
+              },
+              {
+                "name": "OVER_SOC_MAX_ALARM",
+                "value": 15,
+                "label": "Over State of Charge Maximum Alarm",
+                "desc": "Module state of charge has reached or exceeded SoCMax."
+              },
+              {
+                "name": "OVER_SOC_MAX_WARNING",
+                "value": 16,
+                "label": "Over State of Charge Maximum Warning",
+                "desc": "Module state of charge is approaching SoCMax."
+              },
+              {
+                "name": "VOLTAGE_IMBALANCE_WARNING",
+                "value": 17,
+                "label": "Voltage Imbalance Warning",
+                "desc": "A voltage imbalance exists between the stacks in the module."
+              },
+              {
+                "name": "RESERVED_1",
+                "value": 18,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "RESERVED_2",
+                "value": 19
+              },
+              {
+                "name": "CONTACTOR_ERROR",
+                "value": 20,
+                "label": "Contactor Error",
+                "desc": "A contactor failed to open or close as requested."
+              },
+              {
+                "name": "FAN_ERROR",
+                "value": 21,
+                "label": "Fan Error",
+                "desc": "One or more module fans has failed."
+              },
+              {
+                "name": "GROUND_FAULT",
+                "value": 22,
+                "label": "Ground Fault Error",
+                "desc": "Ground fault detected."
+              },
+              {
+                "name": "OPEN_DOOR_ERROR",
+                "value": 23,
+                "label": "Open Door Error",
+                "desc": "One or more doors are open."
+              },
+              {
+                "name": "RESERVED_3",
+                "value": 24,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "RESERVED_4",
+                "value": 25,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "RESERVED_5",
+                "value": 26,
+                "label": "Reserved",
+                "desc": "Reserved bit."
+              },
+              {
+                "name": "FIRE_ALARM",
+                "value": 27,
+                "label": "Fire Alarm",
+                "desc": "A fire has been detected."
+              },
+              {
+                "name": "MODULE_CONFIGURATION_ALARM",
+                "value": 28,
+                "label": "Configuration Alarm",
+                "desc": "The battery module has been configured incorrectly and will not operate."
+              },
+              {
+                "name": "MODULE_CONFIGURATION_WARNING",
+                "value": 29,
+                "label": "Configuration Warning",
+                "desc": "The battery module has been configured incorrectly and may not operate as expected."
+              }
+            ]
+          },
+          {
+            "name": "ModEvt2",
+            "type": "bitfield32",
+            "size": 2,
+            "mandatory": "M",
+            "label": "Module Event 2",
+            "desc": "Alarms, warnings and status values.  Bit flags.",
+            "symbols": [
+              {
+                "name": "LEAK_ALARM",
+                "value": 0,
+                "label": "Leak Alarm",
+                "desc": "A leak has been detected."
+              },
+              {
+                "name": "PUMP_ALARM",
+                "value": 1,
+                "label": "Pump Alarm",
+                "desc": "A pump has experienced an alarm condition or some other error."
+              },
+              {
+                "name": "HIGH_PRESSURE_ALARM",
+                "value": 2,
+                "label": "High Pressure Alarm",
+                "desc": "Pressure exceeds maximum value."
+              },
+              {
+                "name": "HIGH_PRESSURE_WARNING",
+                "value": 3,
+                "label": "High Pressure Warning",
+                "desc": "Pressure approaching maximum value."
+              },
+              {
+                "name": "LOW_FLOW_ALARM",
+                "value": 4,
+                "label": "Low Flow Alarm",
+                "desc": "Flow exceeds minimum value."
+              },
+              {
+                "name": "LOW_FLOW_WARNING",
+                "value": 5,
+                "label": "Low Flow Warning",
+                "desc": "Flow approaching minimum value."
+              }
+            ]
+          },
+          {
+            "name": "ModConFail",
+            "type": "enum16",
+            "size": 1,
+            "label": "Connection Failure Reason",
+            "symbols": [
+              {
+                "name": "NO_FAILURE",
+                "value": 0,
+                "label": "No Failure",
+                "desc": "Connect did not fail."
+              },
+              {
+                "name": "BUTTON_PUSHED",
+                "value": 1,
+                "label": "Button Pushed",
+                "desc": "A button was pushed which prevented connection."
+              },
+              {
+                "name": "MODULE_GROUND_FAULT",
+                "value": 2,
+                "label": "Ground Fault",
+                "desc": "Ground fault during auto-connect."
+              },
+              {
+                "name": "OUTSIDE_VOLTAGE_RANGE",
+                "value": 3,
+                "label": "Outside Voltage Range",
+                "desc": "Outside voltage target window during auto-connect."
+              },
+              {
+                "name": "MODULE_NOT_ENABLED",
+                "value": 4,
+                "label": "Module  Not Enabled",
+                "desc": "The module is not enabled."
+              },
+              {
+                "name": "FUSE_OPEN",
+                "value": 5,
+                "label": "Fuse Open",
+                "desc": "A fuse is open which prevents connection."
+              },
+              {
+                "name": "CONTACTOR_FAILURE",
+                "value": 6,
+                "label": "Contactor Failure",
+                "desc": "A contactor failed to operate."
+              },
+              {
+                "name": "PRECHARGE_FAILURE",
+                "value": 7,
+                "label": "Precharge Failure",
+                "desc": "A failure during precharge occurred."
+              },
+              {
+                "name": "MODULE_FAULT",
+                "value": 8,
+                "label": "Module Fault",
+                "desc": "A module fault has occurred."
+              }
+            ]
+          },
+          {
+            "name": "ModSetEna",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Enable/Disable Module",
+            "desc": "Enables and disables the module.",
+            "symbols": [
+              {
+                "name": "ENABLE_MODULE",
+                "value": 1,
+                "label": "Enable Module",
+                "desc": "Enable the module."
+              },
+              {
+                "name": "DISABLE_MODULE",
+                "value": 2,
+                "label": "Disable Module",
+                "desc": "Disable the module."
+              }
+            ]
+          },
+          {
+            "name": "ModSetCon",
+            "type": "enum16",
+            "size": 1,
+            "access": "RW",
+            "label": "Connect/Disconnect Module ",
+            "desc": "Connects and disconnects the module.",
+            "symbols": [
+              {
+                "name": "CONNECT_MODULE",
+                "value": 1,
+                "label": "Connect Module",
+                "desc": "Connect the module."
+              },
+              {
+                "name": "DISCONNECT_MODULE",
+                "value": 2,
+                "label": "Disconnect Module",
+                "desc": "Disconnect the module."
+              }
+            ]
+          },
+          {
+            "name": "ModDisRsn",
+            "type": "enum16",
+            "size": 1,
+            "label": "Disabled Reason",
+            "desc": "Reason why the module is currently disabled.",
+            "symbols": [
+              {
+                "name": "NONE",
+                "value": 0,
+                "label": "No Reason",
+                "desc": "No reason provided."
+              },
+              {
+                "name": "FAULT",
+                "value": 1,
+                "label": "Fault",
+                "desc": "A fault has occurred which caused the module to be disabled."
+              },
+              {
+                "name": "MAINTENANCE",
+                "value": 2,
+                "label": "Maintenance",
+                "desc": "The module has been disabled for maintenance reasons."
+              },
+              {
+                "name": "EXTERNAL",
+                "value": 3,
+                "label": "External",
+                "desc": "The module has been disabled by an external user or controller."
+              },
+              {
+                "name": "OTHER",
+                "value": 4,
+                "label": "Other",
+                "desc": "The module has been disabled for some other reason."
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "id": 807
+}

--- a/models/model_808.json
+++ b/models/model_808.json
@@ -1,0 +1,52 @@
+{
+  "group": {
+    "name": "flow_battery_module",
+    "type": "group",
+    "label": "Flow Battery Module Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 808
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "ModuleTBD",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Module Points To Be Determined"
+      }
+    ],
+    "groups": [
+      {
+        "name": "stack",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "StackTBD",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Stack Points To Be Determined"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 808
+}

--- a/models/model_809.json
+++ b/models/model_809.json
@@ -1,0 +1,52 @@
+{
+  "group": {
+    "name": "flow_battery_stack",
+    "type": "group",
+    "label": "Flow Battery Stack Model",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 809
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "StackTBD",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "label": "Stack Points To Be Determined"
+      }
+    ],
+    "groups": [
+      {
+        "name": "cell",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "CellTBD",
+            "type": "uint16",
+            "size": 1,
+            "mandatory": "M",
+            "label": "Cell Points To Be Determined"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 809
+}

--- a/models/model_9.json
+++ b/models/model_9.json
@@ -1,0 +1,772 @@
+{
+  "group": {
+    "name": "model_9",
+    "type": "group",
+    "label": "Set Operator Security Certificate",
+    "desc": "Security model for PKI",
+    "points": [
+      {
+        "name": "ID",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model ID",
+        "desc": "Model identifier",
+        "value": 9
+      },
+      {
+        "name": "L",
+        "type": "uint16",
+        "size": 1,
+        "mandatory": "M",
+        "static": "S",
+        "label": "Model Length",
+        "desc": "Model length"
+      },
+      {
+        "name": "CertUID",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Cert_UID",
+        "desc": "User ID for this certificate"
+      },
+      {
+        "name": "CertRole",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Cert_Role",
+        "desc": "Role for this certificate"
+      },
+      {
+        "name": "Fmt",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Format",
+        "desc": "Format of this certificate",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE"
+          },
+          {
+            "name": "X509_PEM",
+            "value": 1,
+            "label": "PEM"
+          },
+          {
+            "name": "X509_DER",
+            "value": 2,
+            "label": "DER"
+          }
+        ]
+      },
+      {
+        "name": "Typ",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Type",
+        "desc": "Type of this certificate",
+        "symbols": [
+          {
+            "name": "DEV_KEY_PAIR",
+            "value": 0
+          },
+          {
+            "name": "DEV_SHARED_KEY",
+            "value": 1
+          },
+          {
+            "name": "OPERATOR_PUB",
+            "value": 2
+          },
+          {
+            "name": "OPERATOR_SHARED",
+            "value": 3
+          },
+          {
+            "name": "CA_PUB",
+            "value": 4
+          }
+        ]
+      },
+      {
+        "name": "TotLn",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Total Length",
+        "desc": "Total Length of the Certificate"
+      },
+      {
+        "name": "FrgLn",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Fragment length",
+        "desc": "Length of this fragment"
+      },
+      {
+        "name": "Frg1",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Frag1",
+        "desc": "First word of this fragment"
+      },
+      {
+        "name": "Frg2",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg3",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg4",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg5",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg6",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg7",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg8",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg9",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg10",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg11",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg12",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg13",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg14",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg15",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg16",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg17",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg18",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg19",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg20",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg21",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg22",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg23",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg24",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg25",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg26",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg27",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg28",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg29",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg30",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg31",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg32",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg33",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg34",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg35",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg36",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg37",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg38",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg39",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg40",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg41",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg42",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg43",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg44",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg45",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg46",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg47",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg48",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg49",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg50",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg51",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg52",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg53",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg54",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg55",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg56",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg57",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg58",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg59",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg60",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg61",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg62",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg63",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg64",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg65",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg66",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg67",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg68",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg69",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg70",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg71",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg72",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg73",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg74",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg75",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg78",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg79",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M"
+      },
+      {
+        "name": "Frg80",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Frag80",
+        "desc": "Last word of this fragment"
+      },
+      {
+        "name": "Ts",
+        "type": "uint32",
+        "size": 2,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Timestamp",
+        "desc": "Timestamp value is the number of seconds since January 1, 2000"
+      },
+      {
+        "name": "Ms",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Milliseconds",
+        "desc": "Millisecond counter 0-999"
+      },
+      {
+        "name": "Seq",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Sequence",
+        "desc": "Sequence number of request"
+      },
+      {
+        "name": "UID",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "UID",
+        "desc": "User ID for the request signature"
+      },
+      {
+        "name": "Role",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Role",
+        "desc": "Signing key used 0-5"
+      },
+      {
+        "name": "Alg",
+        "type": "enum16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "Algorithm",
+        "desc": "Algorithm used to compute the digital signature",
+        "symbols": [
+          {
+            "name": "NONE",
+            "value": 0,
+            "label": "NONE",
+            "desc": "No digital signature"
+          },
+          {
+            "name": "AES-GMAC-64",
+            "value": 1,
+            "label": "AES-GMAC-64",
+            "desc": "64 bit AES signature algorithm is used"
+          },
+          {
+            "name": "ECC-256",
+            "value": 2,
+            "label": "ECC-256",
+            "desc": "256 bit ECC signature algorithm is used"
+          }
+        ]
+      },
+      {
+        "name": "N",
+        "type": "uint16",
+        "size": 1,
+        "access": "RW",
+        "mandatory": "M",
+        "label": "N",
+        "desc": "Number of registers to follow for the certificate"
+      }
+    ],
+    "groups": [
+      {
+        "name": "repeating",
+        "type": "group",
+        "count": 0,
+        "points": [
+          {
+            "name": "Cert",
+            "type": "uint16",
+            "size": 1,
+            "access": "RW",
+            "mandatory": "M"
+          }
+        ]
+      }
+    ]
+  },
+  "id": 9
+}

--- a/models/schema.json
+++ b/models/schema.json
@@ -1,0 +1,239 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "group": {
+            "properties": {
+                "comments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "count": {
+                    "default": 1,
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "groups": {
+                    "items": {
+                        "$ref": "#/definitions/group"
+                    },
+                    "type": "array"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "points": {
+                    "items": {
+                        "$ref": "#/definitions/point"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "enum": [
+                        "group",
+                        "sync"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "type"
+            ],
+            "type": "object"
+        },
+        "point": {
+            "properties": {
+                "access": {
+                    "default": "R",
+                    "enum": [
+                        "R",
+                        "RW"
+                    ],
+                    "type": "string"
+                },
+                "comments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "count": {
+                    "type": "integer"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "mandatory": {
+                    "default": "O",
+                    "enum": [
+                        "M",
+                        "O"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "sf": {
+                    "maximum": 10,
+                    "minimum": -10,
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "static": {
+                    "default": "D",
+                    "enum": [
+                        "D",
+                        "S"
+                    ],
+                    "type": "string"
+                },
+                "symbols": {
+                    "items": {
+                        "$ref": "#/definitions/symbol"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "enum": [
+                        "int16",
+                        "int32",
+                        "int64",
+                        "raw16",
+                        "uint16",
+                        "uint32",
+                        "uint64",
+                        "acc16",
+                        "acc32",
+                        "acc64",
+                        "bitfield16",
+                        "bitfield32",
+                        "bitfield64",
+                        "enum16",
+                        "enum32",
+                        "float32",
+                        "float64",
+                        "string",
+                        "sf",
+                        "pad",
+                        "ipaddr",
+                        "ipv6addr",
+                        "eui48",
+                        "sunssf",
+                        "count"
+                    ],
+                    "type": "string"
+                },
+                "units": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "type",
+                "size"
+            ],
+            "type": "object"
+        },
+        "symbol": {
+            "properties": {
+                "comments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "value": {}
+            },
+            "required": [
+                "name",
+                "value"
+            ],
+            "type": "object"
+        }
+    },
+    "description": "JSON Schema for SunSpec information model definition",
+    "properties": {
+        "comments": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "desc": {
+            "type": "string"
+        },
+        "detail": {
+            "type": "string"
+        },
+        "group": {
+            "$ref": "#/definitions/group"
+        },
+        "id": {
+            "maximum": 65535,
+            "minimum": 1,
+            "type": "integer"
+        },
+        "label": {
+            "type": "string"
+        },
+        "notes": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "id",
+        "group"
+    ],
+    "type": "object"
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,8 +25,8 @@ pub async fn main() {
         .with_line_number(true)
         .init();
 
-    let socket_addr = "127.0.0.1:5083".parse().unwrap();
-    let mut ss = match SunSpecConnection::new(socket_addr, Some(3), false).await {
+    let socket_addr = "10.174.2.83:502".parse().unwrap();
+    let mut ss = match SunSpecConnection::new(socket_addr, Some(4), false).await {
         Ok(mb) => mb,
         Err(e) => {
             error!("Can't create modbus connection: {e}");
@@ -63,26 +63,18 @@ pub async fn main() {
         }
     } else {
         // read fields
-        let _model: u16 = 64208_u16;
+        let _model: u16 = 804_u16;
         let md = ss.models.get(&_model).unwrap().clone();
         // let testing: Vec<Word> = ss.get_raw(md.address, 64).await.unwrap();
         // info!("{:#?}", testing);
         let _fields: Vec<&str> = vec![
-            "SysMd",
-            "CTPow",
-            "WhIn",
-            "WhOut",
-            "ErrorWord",
-            "EnableBits",
-            "RelayStatus",
-            "StatusWord",
-            "LineStatus",
-            "Pad0",
+            "ModSoC",
+            "ModSoH"
         ];
         for f in _fields {
             match ss.clone().get_point(md.clone(), f, None).await {
                 Ok(pt) => {
-                    println!("64208/{f} = {:#?}", pt.value);
+                    println!("{_model}/{f} = {:#?}", pt.value);
                 }
                 Err(e) => {
                     error!("Error received: {e}");

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,9 +7,10 @@ mod cli_args;
 use clap::Parser;
 use cli_args::CliArgs;
 use std::process;
-use sunspec_rs::sunspec_connection::SunSpecConnection;
+use sunspec_rs::sunspec_connection::{SunSpecConnection, Word};
 use sunspec_rs::sunspec_data::SunSpecData;
 use sunspec_rs::sunspec_models::ValueType;
+use tokio_modbus::Address;
 use tracing_log::AsTrace;
 use tracing_subscriber;
 
@@ -20,6 +21,8 @@ pub async fn main() {
     // setup log level
     tracing_subscriber::fmt()
         .with_max_level(cli.verbose.log_level_filter().as_trace())
+        .with_file(true)
+        .with_line_number(true)
         .init();
 
     let socket_addr = "127.0.0.1:5083".parse().unwrap();
@@ -60,15 +63,26 @@ pub async fn main() {
         }
     } else {
         // read fields
-        let _model: u16 = 64206_u16;
-        let _fields: Vec<&str> = vec!["XFRV", "XFRTms"];
+        let _model: u16 = 64208_u16;
         let md = ss.models.get(&_model).unwrap().clone();
-        let block_count = md.clone().get_block_count().unwrap();
-        info!("{:#?}", block_count);
+        // let testing: Vec<Word> = ss.get_raw(md.address, 64).await.unwrap();
+        // info!("{:#?}", testing);
+        let _fields: Vec<&str> = vec![
+            "SysMd",
+            "CTPow",
+            "WhIn",
+            "WhOut",
+            "ErrorWord",
+            "EnableBits",
+            "RelayStatus",
+            "StatusWord",
+            "LineStatus",
+            "Pad0",
+        ];
         for f in _fields {
             match ss.clone().get_point(md.clone(), f, None).await {
                 Ok(pt) => {
-                    debug!("{:#?}", pt.value);
+                    println!("64208/{f} = {:#?}", pt.value);
                 }
                 Err(e) => {
                     error!("Error received: {e}");

--- a/src/bin/tools/scan_slaves/main.rs
+++ b/src/bin/tools/scan_slaves/main.rs
@@ -50,7 +50,7 @@ pub async fn main() {
                             warn!("Slave id {i} is a clone signal.");
                             continue;
                         }
-                        info!("Slave {i} has {} models.", ss.models.len());
+                        println!("Slave {i} {s} has {} models.", ss.models.len());
                         devices.push(s)
                     }
                 }

--- a/src/lib/json/group.rs
+++ b/src/lib/json/group.rs
@@ -1,0 +1,158 @@
+use crate::json::defaults;
+use crate::json::point::Point;
+use serde::{Deserialize, Serialize};
+
+impl From<&Group> for Group {
+    fn from(value: &Group) -> Self {
+        value.clone()
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub enum GroupType {
+    #[default]
+    #[serde(rename = "group")]
+    Group,
+    #[serde(rename = "sync")]
+    Sync,
+}
+
+impl From<&GroupType> for GroupType {
+    fn from(value: &GroupType) -> Self {
+        value.clone()
+    }
+}
+
+impl ToString for GroupType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Group => "group".to_string(),
+            Self::Sync => "sync".to_string(),
+        }
+    }
+}
+
+impl std::str::FromStr for GroupType {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        match value {
+            "group" => Ok(Self::Group),
+            "sync" => Ok(Self::Sync),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for GroupType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for GroupType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for GroupType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub(crate) struct Group {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
+    #[serde(default = "defaults::group_count")]
+    pub count: GroupCount,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub groups: Vec<Group>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub points: Vec<Point>,
+    #[serde(rename = "type")]
+    pub type_: GroupType,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GroupCount {
+    String(String),
+    Integer(i64),
+}
+
+impl From<&GroupCount> for GroupCount {
+    fn from(value: &GroupCount) -> Self {
+        value.clone()
+    }
+}
+
+impl Default for GroupCount {
+    fn default() -> Self {
+        GroupCount::Integer(1_i64)
+    }
+}
+
+impl std::str::FromStr for GroupCount {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::String(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Integer(v))
+        } else {
+            Err("string conversion failed for all variants".into())
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for GroupCount {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for GroupCount {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for GroupCount {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl ToString for GroupCount {
+    fn to_string(&self) -> String {
+        match self {
+            Self::String(x) => x.to_string(),
+            Self::Integer(x) => x.to_string(),
+        }
+    }
+}
+
+impl From<i64> for GroupCount {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}

--- a/src/lib/json/misc.rs
+++ b/src/lib/json/misc.rs
@@ -1,0 +1,9 @@
+use crate::json::group::Group;
+use crate::sunspec_models::Block;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct JSONModel {
+    pub id: u16,
+    pub group: Group,
+}

--- a/src/lib/json/mod.rs
+++ b/src/lib/json/mod.rs
@@ -1,0 +1,85 @@
+#![allow(clippy::redundant_closure_call)]
+#![allow(clippy::needless_lifetimes)]
+#![allow(clippy::match_single_binding)]
+#![allow(clippy::clone_on_copy)]
+
+pub mod group;
+pub mod misc;
+pub mod point;
+
+use crate::json::group::GroupCount;
+use serde::{Deserialize, Serialize};
+use serde_json::*;
+
+pub mod error {
+    #[doc = r" Error from a TryFrom or FromStr implementation."]
+    pub struct ConversionError(std::borrow::Cow<'static, str>);
+
+    impl std::error::Error for ConversionError {}
+
+    impl std::fmt::Display for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+
+    impl std::fmt::Debug for ConversionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl From<&'static str> for ConversionError {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+
+    impl From<String> for ConversionError {
+        fn from(value: String) -> Self {
+            Self(value.into())
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Symbol {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    pub value: serde_json::Value,
+}
+
+impl From<&Symbol> for Symbol {
+    fn from(value: &Symbol) -> Self {
+        value.clone()
+    }
+}
+
+pub mod defaults {
+    use crate::json::point::{PointAccess, PointMandatory, PointStatic};
+
+    pub(crate) fn group_count() -> super::GroupCount {
+        super::GroupCount::Integer(1_i64)
+    }
+
+    pub(crate) fn point_access() -> PointAccess {
+        PointAccess::R
+    }
+
+    pub(crate) fn point_mandatory() -> PointMandatory {
+        PointMandatory::O
+    }
+
+    pub(crate) fn point_static() -> PointStatic {
+        PointStatic::D
+    }
+}

--- a/src/lib/json/point.rs
+++ b/src/lib/json/point.rs
@@ -1,0 +1,491 @@
+use crate::json::defaults;
+use crate::json::Symbol;
+use serde::{Deserialize, Serialize};
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Point {
+    #[serde(default = "defaults::point_access")]
+    pub access: PointAccess,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub count: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default = "defaults::point_mandatory")]
+    pub mandatory: PointMandatory,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sf: Option<PointSf>,
+    pub size: i64,
+    #[serde(rename = "static", default = "defaults::point_static")]
+    pub static_: PointStatic,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub symbols: Vec<Symbol>,
+    #[serde(rename = "type")]
+    pub type_: PointType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub units: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<PointValue>,
+}
+
+impl From<&Point> for Point {
+    fn from(value: &Point) -> Self {
+        value.clone()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PointAccess {
+    R,
+    #[serde(rename = "RW")]
+    Rw,
+}
+
+impl From<&PointAccess> for PointAccess {
+    fn from(value: &PointAccess) -> Self {
+        value.clone()
+    }
+}
+
+impl ToString for PointAccess {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::R => "R".to_string(),
+            Self::Rw => "RW".to_string(),
+        }
+    }
+}
+
+impl std::str::FromStr for PointAccess {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        match value {
+            "R" => Ok(Self::R),
+            "RW" => Ok(Self::Rw),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointAccess {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointAccess {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointAccess {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl Default for PointAccess {
+    fn default() -> Self {
+        PointAccess::R
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PointMandatory {
+    M,
+    O,
+}
+
+impl From<&PointMandatory> for PointMandatory {
+    fn from(value: &PointMandatory) -> Self {
+        value.clone()
+    }
+}
+
+impl ToString for PointMandatory {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::M => "M".to_string(),
+            Self::O => "O".to_string(),
+        }
+    }
+}
+
+impl std::str::FromStr for PointMandatory {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        match value {
+            "M" => Ok(Self::M),
+            "O" => Ok(Self::O),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointMandatory {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointMandatory {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointMandatory {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl Default for PointMandatory {
+    fn default() -> Self {
+        PointMandatory::O
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PointSf {
+    String(String),
+    Integer(i64),
+}
+
+impl From<&PointSf> for PointSf {
+    fn from(value: &PointSf) -> Self {
+        value.clone()
+    }
+}
+
+impl std::str::FromStr for PointSf {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::String(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Integer(v))
+        } else {
+            Err("string conversion failed for all variants".into())
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointSf {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointSf {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointSf {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl ToString for PointSf {
+    fn to_string(&self) -> String {
+        match self {
+            Self::String(x) => x.to_string(),
+            Self::Integer(x) => x.to_string(),
+        }
+    }
+}
+
+impl From<i64> for PointSf {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PointStatic {
+    D,
+    S,
+}
+
+impl From<&PointStatic> for PointStatic {
+    fn from(value: &PointStatic) -> Self {
+        value.clone()
+    }
+}
+
+impl ToString for PointStatic {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::D => "D".to_string(),
+            Self::S => "S".to_string(),
+        }
+    }
+}
+
+impl std::str::FromStr for PointStatic {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        match value {
+            "D" => Ok(Self::D),
+            "S" => Ok(Self::S),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointStatic {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointStatic {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointStatic {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl Default for PointStatic {
+    fn default() -> Self {
+        PointStatic::D
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum PointType {
+    #[serde(rename = "int16")]
+    Int16,
+    #[serde(rename = "int32")]
+    Int32,
+    #[serde(rename = "int64")]
+    Int64,
+    #[serde(rename = "raw16")]
+    Raw16,
+    #[serde(rename = "uint16")]
+    Uint16,
+    #[serde(rename = "uint32")]
+    Uint32,
+    #[serde(rename = "uint64")]
+    Uint64,
+    #[serde(rename = "acc16")]
+    Acc16,
+    #[serde(rename = "acc32")]
+    Acc32,
+    #[serde(rename = "acc64")]
+    Acc64,
+    #[serde(rename = "bitfield16")]
+    Bitfield16,
+    #[serde(rename = "bitfield32")]
+    Bitfield32,
+    #[serde(rename = "bitfield64")]
+    Bitfield64,
+    #[serde(rename = "enum16")]
+    Enum16,
+    #[serde(rename = "enum32")]
+    Enum32,
+    #[serde(rename = "float32")]
+    Float32,
+    #[serde(rename = "float64")]
+    Float64,
+    #[serde(rename = "string")]
+    String,
+    #[serde(rename = "sf")]
+    Sf,
+    #[serde(rename = "pad")]
+    Pad,
+    #[serde(rename = "ipaddr")]
+    Ipaddr,
+    #[serde(rename = "ipv6addr")]
+    Ipv6addr,
+    #[serde(rename = "eui48")]
+    Eui48,
+    #[serde(rename = "sunssf")]
+    Sunssf,
+    #[serde(rename = "count")]
+    Count,
+}
+
+impl From<&PointType> for PointType {
+    fn from(value: &PointType) -> Self {
+        value.clone()
+    }
+}
+
+impl ToString for PointType {
+    fn to_string(&self) -> String {
+        match *self {
+            Self::Int16 => "int16".to_string(),
+            Self::Int32 => "int32".to_string(),
+            Self::Int64 => "int64".to_string(),
+            Self::Raw16 => "raw16".to_string(),
+            Self::Uint16 => "uint16".to_string(),
+            Self::Uint32 => "uint32".to_string(),
+            Self::Uint64 => "uint64".to_string(),
+            Self::Acc16 => "acc16".to_string(),
+            Self::Acc32 => "acc32".to_string(),
+            Self::Acc64 => "acc64".to_string(),
+            Self::Bitfield16 => "bitfield16".to_string(),
+            Self::Bitfield32 => "bitfield32".to_string(),
+            Self::Bitfield64 => "bitfield64".to_string(),
+            Self::Enum16 => "enum16".to_string(),
+            Self::Enum32 => "enum32".to_string(),
+            Self::Float32 => "float32".to_string(),
+            Self::Float64 => "float64".to_string(),
+            Self::String => "string".to_string(),
+            Self::Sf => "sf".to_string(),
+            Self::Pad => "pad".to_string(),
+            Self::Ipaddr => "ipaddr".to_string(),
+            Self::Ipv6addr => "ipv6addr".to_string(),
+            Self::Eui48 => "eui48".to_string(),
+            Self::Sunssf => "sunssf".to_string(),
+            Self::Count => "count".to_string(),
+        }
+    }
+}
+
+impl std::str::FromStr for PointType {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        match value {
+            "int16" => Ok(Self::Int16),
+            "int32" => Ok(Self::Int32),
+            "int64" => Ok(Self::Int64),
+            "raw16" => Ok(Self::Raw16),
+            "uint16" => Ok(Self::Uint16),
+            "uint32" => Ok(Self::Uint32),
+            "uint64" => Ok(Self::Uint64),
+            "acc16" => Ok(Self::Acc16),
+            "acc32" => Ok(Self::Acc32),
+            "acc64" => Ok(Self::Acc64),
+            "bitfield16" => Ok(Self::Bitfield16),
+            "bitfield32" => Ok(Self::Bitfield32),
+            "bitfield64" => Ok(Self::Bitfield64),
+            "enum16" => Ok(Self::Enum16),
+            "enum32" => Ok(Self::Enum32),
+            "float32" => Ok(Self::Float32),
+            "float64" => Ok(Self::Float64),
+            "string" => Ok(Self::String),
+            "sf" => Ok(Self::Sf),
+            "pad" => Ok(Self::Pad),
+            "ipaddr" => Ok(Self::Ipaddr),
+            "ipv6addr" => Ok(Self::Ipv6addr),
+            "eui48" => Ok(Self::Eui48),
+            "sunssf" => Ok(Self::Sunssf),
+            "count" => Ok(Self::Count),
+            _ => Err("invalid value".into()),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointType {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PointValue {
+    String(String),
+    Integer(i64),
+}
+
+impl From<&PointValue> for PointValue {
+    fn from(value: &PointValue) -> Self {
+        value.clone()
+    }
+}
+
+impl std::str::FromStr for PointValue {
+    type Err = crate::json::error::ConversionError;
+    fn from_str(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        if let Ok(v) = value.parse() {
+            Ok(Self::String(v))
+        } else if let Ok(v) = value.parse() {
+            Ok(Self::Integer(v))
+        } else {
+            Err("string conversion failed for all variants".into())
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for PointValue {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &str) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<&String> for PointValue {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: &String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl std::convert::TryFrom<String> for PointValue {
+    type Error = crate::json::error::ConversionError;
+    fn try_from(value: String) -> Result<Self, crate::json::error::ConversionError> {
+        value.parse()
+    }
+}
+
+impl ToString for PointValue {
+    fn to_string(&self) -> String {
+        match self {
+            Self::String(x) => x.to_string(),
+            Self::Integer(x) => x.to_string(),
+        }
+    }
+}
+
+impl From<i64> for PointValue {
+    fn from(value: i64) -> Self {
+        Self::Integer(value)
+    }
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate tracing;
 extern crate thiserror;
+mod json;
 pub mod metrics;
 pub mod modbus_test_harness;
 pub mod model_data;

--- a/src/lib/sunspec_models.rs
+++ b/src/lib/sunspec_models.rs
@@ -153,111 +153,206 @@ impl From<&JSONModel> for SunSpecModels {
 
         let mut blocks: Vec<Block> = vec![];
 
-        if json.group.groups.is_empty() {
-            let mut block_len: u16 = 0;
-            block_len = model_len;
-            let mut points: Vec<Point> = vec![];
+        let mut block_len: u16 = 0;
+        block_len = model_len;
+        let mut points: Vec<Point> = vec![];
 
-            let mut offset: u16 = 0;
-            // in the json model, ID and L are always zero and 1 in the array.  In the xml/smdx,
-            // ID and L aren't specified because they're implied.  Because of this, we skip processing
-            // the first two points so that the offset address lines up.
-            for point in json.group.points.iter().skip(2) {
-                info!("{}: offset value for {} is {offset}", point.name, json.id);
+        let mut offset: u16 = 0;
+        // in the json model, ID and L are always zero and 1 in the array.  In the xml/smdx,
+        // ID and L aren't specified because they're implied.  Because of this, we skip processing
+        // the first two points so that the offset address lines up.
+        for point in json.group.points.iter().skip(2) {
+            info!("{}: offset value for {} is {offset}", point.name, json.id);
 
-                let sf_string: Option<String>;
-                if point.sf.is_some() {
-                    match point.clone().sf.unwrap() {
-                        PointSf::String(s) => sf_string = Some(s),
-                        PointSf::Integer(i) => sf_string = Some(format!("{}", i)),
-                    }
-                } else {
-                    sf_string = None;
+            let sf_string: Option<String>;
+            if point.sf.is_some() {
+                match point.clone().sf.unwrap() {
+                    PointSf::String(s) => sf_string = Some(s),
+                    PointSf::Integer(i) => sf_string = Some(format!("{}", i)),
                 }
-
-                let foo = Point {
-                    id: point.name.clone(),
-                    offset,
-                    r#type: match point.type_ {
-                        jpt::Int16 => "int16".to_string(),
-                        jpt::Int32 => "int32".to_string(),
-                        jpt::Int64 => "int64".to_string(),
-                        jpt::Raw16 => "raw16".to_string(),
-                        jpt::Uint16 => "uint16".to_string(),
-                        jpt::Uint32 => "uint32".to_string(),
-                        jpt::Uint64 => "uint64".to_string(),
-                        jpt::Acc16 => "acc16".to_string(),
-                        jpt::Acc32 => "acc32".to_string(),
-                        jpt::Acc64 => "acc64".to_string(),
-                        jpt::Bitfield16 => "bitfield16".to_string(),
-                        jpt::Bitfield32 => "bitfield32".to_string(),
-                        jpt::Bitfield64 => "bitfield64".to_string(),
-                        jpt::Enum16 => "enum16".to_string(),
-                        jpt::Enum32 => "enum32".to_string(),
-                        jpt::Float32 => "float32".to_string(),
-                        jpt::Float64 => "float64".to_string(),
-                        jpt::String => "string".to_string(),
-                        jpt::Sf => "sf".to_string(),
-                        jpt::Pad => "pad".to_string(),
-                        jpt::Ipaddr => "ipaddr".to_string(),
-                        jpt::Ipv6addr => "ipv6addr".to_string(),
-                        jpt::Eui48 => "eui48".to_string(),
-                        jpt::Sunssf => "sunssf".to_string(),
-                        jpt::Count => "count".to_string(),
-                    },
-                    len: Some(point.size as u16),
-                    mandatory: if point.mandatory == PointMandatory::M {
-                        Some(true)
-                    } else {
-                        Some(false)
-                    },
-                    access: if point.access == PointAccess::Rw {
-                        Some(Access::ReadWrite)
-                    } else {
-                        Some(Access::ReadOnly)
-                    },
-                    symbol: Some(
-                        point
-                            .symbols
-                            .iter()
-                            .map(|s| Symbol {
-                                symbol: s.clone().value.to_string(),
-                                id: s.clone().name,
-                            })
-                            .collect(),
-                    ),
-                    units: point.units.clone(),
-                    scale_factor: sf_string,
-                    value: if point.static_ == PointStatic::S {
-                        match point.value.clone() {
-                            Some(PointValue::String(s)) => Some(ValueType::String(s)),
-                            Some(PointValue::Integer(i)) => Some(ValueType::Integer(i as i32)),
-                            None => {
-                                warn!(
-                                    "Point is specified as static, but no value provided: {:#?}",
-                                    serde_json::to_string(point)
-                                );
-                                None
-                            }
-                        }
-                    } else {
-                        None
-                    },
-                    literal: None,
-                    block_id: None,
-                };
-                points.push(foo);
-                offset = offset.saturating_add(point.size as u16);
+            } else {
+                sf_string = None;
             }
 
-            blocks.push(Block {
-                len: block_len,
-                r#type: None,
-                name: None,
-                point: points,
-            })
-        } else {
-            info!("there be groups here in {}", json.group.clone().name);
+            let foo = Point {
+                id: point.name.clone(),
+                offset,
+                r#type: match point.type_ {
+                    jpt::Int16 => "int16".to_string(),
+                    jpt::Int32 => "int32".to_string(),
+                    jpt::Int64 => "int64".to_string(),
+                    jpt::Raw16 => "raw16".to_string(),
+                    jpt::Uint16 => "uint16".to_string(),
+                    jpt::Uint32 => "uint32".to_string(),
+                    jpt::Uint64 => "uint64".to_string(),
+                    jpt::Acc16 => "acc16".to_string(),
+                    jpt::Acc32 => "acc32".to_string(),
+                    jpt::Acc64 => "acc64".to_string(),
+                    jpt::Bitfield16 => "bitfield16".to_string(),
+                    jpt::Bitfield32 => "bitfield32".to_string(),
+                    jpt::Bitfield64 => "bitfield64".to_string(),
+                    jpt::Enum16 => "enum16".to_string(),
+                    jpt::Enum32 => "enum32".to_string(),
+                    jpt::Float32 => "float32".to_string(),
+                    jpt::Float64 => "float64".to_string(),
+                    jpt::String => "string".to_string(),
+                    jpt::Sf => "sf".to_string(),
+                    jpt::Pad => "pad".to_string(),
+                    jpt::Ipaddr => "ipaddr".to_string(),
+                    jpt::Ipv6addr => "ipv6addr".to_string(),
+                    jpt::Eui48 => "eui48".to_string(),
+                    jpt::Sunssf => "sunssf".to_string(),
+                    jpt::Count => "count".to_string(),
+                },
+                len: Some(point.size as u16),
+                mandatory: if point.mandatory == PointMandatory::M {
+                    Some(true)
+                } else {
+                    Some(false)
+                },
+                access: if point.access == PointAccess::Rw {
+                    Some(Access::ReadWrite)
+                } else {
+                    Some(Access::ReadOnly)
+                },
+                symbol: Some(
+                    point
+                        .symbols
+                        .iter()
+                        .map(|s| Symbol {
+                            symbol: s.clone().value.to_string(),
+                            id: s.clone().name,
+                        })
+                        .collect(),
+                ),
+                units: point.units.clone(),
+                scale_factor: sf_string,
+                value: if point.static_ == PointStatic::S {
+                    match point.value.clone() {
+                        Some(PointValue::String(s)) => Some(ValueType::String(s)),
+                        Some(PointValue::Integer(i)) => Some(ValueType::Integer(i as i32)),
+                        None => {
+                            warn!(
+                                "Point is specified as static, but no value provided: {:#?}",
+                                serde_json::to_string(point)
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                },
+                literal: None,
+                block_id: None,
+            };
+            points.push(foo);
+            offset = offset.saturating_add(point.size as u16);
+        }
+
+        blocks.push(Block {
+            len: block_len,
+            r#type: None,
+            name: None,
+            point: points,
+        });
+
+        if !json.group.groups.is_empty() {
+            // we need to generate a new block per group
+            for g in json.group.groups.iter() {
+                // reinitialize an empty points vec per grouping
+                let mut points: Vec<Point> = vec![];
+                let mut block = Block::default();
+                block.name = Some(g.clone().name);
+                for point in g.points.iter() {
+                    info!("{}: offset value for {} is {offset}", point.name, json.id);
+
+                    let sf_string: Option<String>;
+                    if point.sf.is_some() {
+                        match point.clone().sf.unwrap() {
+                            PointSf::String(s) => sf_string = Some(s),
+                            PointSf::Integer(i) => sf_string = Some(format!("{}", i)),
+                        }
+                    } else {
+                        sf_string = None;
+                    }
+
+                    let foo = Point {
+                        id: point.name.clone(),
+                        offset,
+                        r#type: match point.type_ {
+                            jpt::Int16 => "int16".to_string(),
+                            jpt::Int32 => "int32".to_string(),
+                            jpt::Int64 => "int64".to_string(),
+                            jpt::Raw16 => "raw16".to_string(),
+                            jpt::Uint16 => "uint16".to_string(),
+                            jpt::Uint32 => "uint32".to_string(),
+                            jpt::Uint64 => "uint64".to_string(),
+                            jpt::Acc16 => "acc16".to_string(),
+                            jpt::Acc32 => "acc32".to_string(),
+                            jpt::Acc64 => "acc64".to_string(),
+                            jpt::Bitfield16 => "bitfield16".to_string(),
+                            jpt::Bitfield32 => "bitfield32".to_string(),
+                            jpt::Bitfield64 => "bitfield64".to_string(),
+                            jpt::Enum16 => "enum16".to_string(),
+                            jpt::Enum32 => "enum32".to_string(),
+                            jpt::Float32 => "float32".to_string(),
+                            jpt::Float64 => "float64".to_string(),
+                            jpt::String => "string".to_string(),
+                            jpt::Sf => "sf".to_string(),
+                            jpt::Pad => "pad".to_string(),
+                            jpt::Ipaddr => "ipaddr".to_string(),
+                            jpt::Ipv6addr => "ipv6addr".to_string(),
+                            jpt::Eui48 => "eui48".to_string(),
+                            jpt::Sunssf => "sunssf".to_string(),
+                            jpt::Count => "count".to_string(),
+                        },
+                        len: Some(point.size as u16),
+                        mandatory: if point.mandatory == PointMandatory::M {
+                            Some(true)
+                        } else {
+                            Some(false)
+                        },
+                        access: if point.access == PointAccess::Rw {
+                            Some(Access::ReadWrite)
+                        } else {
+                            Some(Access::ReadOnly)
+                        },
+                        symbol: Some(
+                            point
+                                .symbols
+                                .iter()
+                                .map(|s| Symbol {
+                                    symbol: s.clone().value.to_string(),
+                                    id: s.clone().name,
+                                })
+                                .collect(),
+                        ),
+                        units: point.units.clone(),
+                        scale_factor: sf_string,
+                        value: if point.static_ == PointStatic::S {
+                            match point.value.clone() {
+                                Some(PointValue::String(s)) => Some(ValueType::String(s)),
+                                Some(PointValue::Integer(i)) => Some(ValueType::Integer(i as i32)),
+                                None => {
+                                    warn!(
+                                "Point is specified as static, but no value provided: {:#?}",
+                                serde_json::to_string(point)
+                            );
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        },
+                        literal: None,
+                        block_id: None,
+                    };
+                    points.push(foo);
+                    offset = offset.saturating_add(point.size as u16);
+                }
+                block.point = points;
+                blocks.push(block);
+            }
         }
 
         assert!(model_len > 0);

--- a/src/lib/sunspec_models.rs
+++ b/src/lib/sunspec_models.rs
@@ -1,3 +1,11 @@
+use crate::json::defaults::point_access;
+use crate::json::group::GroupType;
+use crate::json::misc::JSONModel;
+use crate::json::point::{
+    Point as JSONPoint, PointAccess, PointMandatory, PointSf, PointStatic, PointType as jpt,
+    PointValue,
+};
+use crate::sunspec_connection::ADDR_OFFSET;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -134,4 +142,135 @@ pub enum LiteralType {
 pub struct SunSpecModels {
     pub model: Model,
     pub strings: Vec<Strings>,
+}
+
+impl From<&JSONModel> for SunSpecModels {
+    fn from(json: &JSONModel) -> Self {
+        let mut model_len: u16 = 0;
+        for p in json.group.points.iter() {
+            model_len = model_len.saturating_add(p.size as u16);
+        }
+
+        let mut blocks: Vec<Block> = vec![];
+
+        if json.group.groups.is_empty() {
+            let mut block_len: u16 = 0;
+            block_len = model_len;
+            let mut points: Vec<Point> = vec![];
+
+            let mut offset: u16 = 0;
+            // in the json model, ID and L are always zero and 1 in the array.  In the xml/smdx,
+            // ID and L aren't specified because they're implied.  Because of this, we skip processing
+            // the first two points so that the offset address lines up.
+            for point in json.group.points.iter().skip(2) {
+                info!("{}: offset value for {} is {offset}", point.name, json.id);
+
+                let sf_string: Option<String>;
+                if point.sf.is_some() {
+                    match point.clone().sf.unwrap() {
+                        PointSf::String(s) => sf_string = Some(s),
+                        PointSf::Integer(i) => sf_string = Some(format!("{}", i)),
+                    }
+                } else {
+                    sf_string = None;
+                }
+
+                let foo = Point {
+                    id: point.name.clone(),
+                    offset,
+                    r#type: match point.type_ {
+                        jpt::Int16 => "int16".to_string(),
+                        jpt::Int32 => "int32".to_string(),
+                        jpt::Int64 => "int64".to_string(),
+                        jpt::Raw16 => "raw16".to_string(),
+                        jpt::Uint16 => "uint16".to_string(),
+                        jpt::Uint32 => "uint32".to_string(),
+                        jpt::Uint64 => "uint64".to_string(),
+                        jpt::Acc16 => "acc16".to_string(),
+                        jpt::Acc32 => "acc32".to_string(),
+                        jpt::Acc64 => "acc64".to_string(),
+                        jpt::Bitfield16 => "bitfield16".to_string(),
+                        jpt::Bitfield32 => "bitfield32".to_string(),
+                        jpt::Bitfield64 => "bitfield64".to_string(),
+                        jpt::Enum16 => "enum16".to_string(),
+                        jpt::Enum32 => "enum32".to_string(),
+                        jpt::Float32 => "float32".to_string(),
+                        jpt::Float64 => "float64".to_string(),
+                        jpt::String => "string".to_string(),
+                        jpt::Sf => "sf".to_string(),
+                        jpt::Pad => "pad".to_string(),
+                        jpt::Ipaddr => "ipaddr".to_string(),
+                        jpt::Ipv6addr => "ipv6addr".to_string(),
+                        jpt::Eui48 => "eui48".to_string(),
+                        jpt::Sunssf => "sunssf".to_string(),
+                        jpt::Count => "count".to_string(),
+                    },
+                    len: Some(point.size as u16),
+                    mandatory: if point.mandatory == PointMandatory::M {
+                        Some(true)
+                    } else {
+                        Some(false)
+                    },
+                    access: if point.access == PointAccess::Rw {
+                        Some(Access::ReadWrite)
+                    } else {
+                        Some(Access::ReadOnly)
+                    },
+                    symbol: Some(
+                        point
+                            .symbols
+                            .iter()
+                            .map(|s| Symbol {
+                                symbol: s.clone().value.to_string(),
+                                id: s.clone().name,
+                            })
+                            .collect(),
+                    ),
+                    units: point.units.clone(),
+                    scale_factor: sf_string,
+                    value: if point.static_ == PointStatic::S {
+                        match point.value.clone() {
+                            Some(PointValue::String(s)) => Some(ValueType::String(s)),
+                            Some(PointValue::Integer(i)) => Some(ValueType::Integer(i as i32)),
+                            None => {
+                                warn!(
+                                    "Point is specified as static, but no value provided: {:#?}",
+                                    serde_json::to_string(point)
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    },
+                    literal: None,
+                    block_id: None,
+                };
+                points.push(foo);
+                offset = offset.saturating_add(point.size as u16);
+            }
+
+            blocks.push(Block {
+                len: block_len,
+                r#type: None,
+                name: None,
+                point: points,
+            })
+        } else {
+            info!("there be groups here in {}", json.group.clone().name);
+        }
+
+        assert!(model_len > 0);
+        let model = Model {
+            id: json.id,
+            len: model_len,
+            name: json.group.clone().name,
+            block: blocks,
+        };
+
+        SunSpecModels {
+            model,
+            strings: vec![],
+        }
+    }
 }


### PR DESCRIPTION
This PR enables reading the json payload from the models list instead of the SMDX format file.  My contact at sunspec alliance said they're only going to be publishing new models in json going forward, so this support was necessary.